### PR TITLE
[Fix] JSON serialization in sync streaming and `OplogEntry` `data` field type

### DIFF
--- a/core/src/commonMain/kotlin/com/powersync/bucket/OplogEntry.kt
+++ b/core/src/commonMain/kotlin/com/powersync/bucket/OplogEntry.kt
@@ -4,16 +4,16 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class OplogEntry (
+data class OplogEntry(
     val checksum: Long,
     @SerialName("op_id") val opId: String,
     @SerialName("object_id") val rowId: String? = null,
-    @SerialName("object_type") val rowType: String?= null,
+    @SerialName("object_type") val rowType: String? = null,
     val op: OpType? = null,
     /**
      * Together with rowType and rowId, this uniquely identifies a source entry per bucket in the oplog.
      * There may be multiple source entries for a single "rowType + rowId" combination.
      */
     val subkey: String? = null,
-    val data: Map<String, String>? = null
+    val data: String? = null
 )

--- a/core/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
@@ -19,6 +19,7 @@ import com.powersync.db.internal.PsInternalTable
 import com.powersync.db.schema.Schema
 import com.powersync.sync.SyncStatus
 import com.powersync.sync.SyncStream
+import com.powersync.utils.JsonUtil
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
@@ -64,8 +65,7 @@ internal class PowerSyncDatabaseImpl(
     }
 
     private suspend fun applySchema() {
-        val json = Json { encodeDefaults = true }
-        val schemaJson = json.encodeToString(schema)
+        val schemaJson = JsonUtil.json.encodeToString(schema)
 
         this.writeTransaction {
             internalDb.queries.replaceSchema(schemaJson).awaitAsOne()

--- a/core/src/commonMain/kotlin/com/powersync/db/crud/CrudEntry.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/crud/CrudEntry.kt
@@ -1,8 +1,6 @@
 package com.powersync.db.crud
 
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonElement
+import com.powersync.utils.JsonUtil
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 
@@ -57,7 +55,7 @@ data class CrudEntry(
 ) {
     companion object {
         fun fromRow(row: CrudRow): CrudEntry {
-            val data = Json.parseToJsonElement(row.data).jsonObject
+            val data = JsonUtil.json.parseToJsonElement(row.data).jsonObject
             return CrudEntry(
                 id = data["id"]!!.jsonPrimitive.content,
                 clientId = row.id.toInt(),

--- a/core/src/commonMain/kotlin/com/powersync/db/internal/PsInternalDatabase.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/internal/PsInternalDatabase.kt
@@ -14,13 +14,13 @@ import com.powersync.PsSqlDriver
 import com.powersync.db.PsDatabase
 import com.powersync.db.ReadQueries
 import com.powersync.db.WriteQueries
+import com.powersync.utils.JsonUtil
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.launch
 import kotlinx.serialization.encodeToString
-import kotlinx.serialization.json.Json
 
 
 @OptIn(FlowPreview::class)
@@ -210,7 +210,7 @@ class PsInternalDatabase(val driver: PsSqlDriver, private val scope: CoroutineSc
                 rootPages.add(row.p2)
             }
         }
-        val params = listOf(Json.encodeToString(rootPages))
+        val params = listOf(JsonUtil.json.encodeToString(rootPages))
         val tableRows = createQuery(
             "SELECT tbl_name FROM sqlite_master WHERE rootpage IN (SELECT json_each.value FROM json_each(?))",
             parameters = params.size,

--- a/core/src/commonMain/kotlin/com/powersync/utils/Json.kt
+++ b/core/src/commonMain/kotlin/com/powersync/utils/Json.kt
@@ -1,0 +1,15 @@
+package com.powersync.utils
+
+import kotlinx.serialization.json.Json
+
+/**
+ * A global instance of a JSON serializer.
+ */
+object JsonUtil {
+    val json = Json {
+        encodeDefaults = true
+        isLenient = true
+        ignoreUnknownKeys = true
+    }
+}
+

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ development=true
 RELEASE_SIGNING_ENABLED=true
 # Library config
 GROUP=com.powersync
-LIBRARY_VERSION=0.0.1-ALPHA2
+LIBRARY_VERSION=0.0.1-ALPHA3
 GITHUB_REPO=https://github.com/powersync-ja/powersync-kotlin.git
 # POM
 POM_URL=https://github.com/powersync-ja/powersync-kotlin/


### PR DESCRIPTION
 Changes:

- Fix: `OplogEntry.data` incorrectly typed 
- Add: `JsonUtil.json` to make JSON encoding/decoding config consistent everywhere. 
- Updated JSON config:
  * `encodeDefaults` -> Default values will now be encoded
  * `isLenient` -> Less-strict parsing, in particular unquoted keys and string literals will not throw an error
  * `ignoreUnknownKeys` -> Unknown keys encountered during deserialization will not throw an error