### PR TITLE
[Fix] Add missing `compilerOpts` to`cinterop` 

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -75,6 +75,7 @@ kotlin {
                 val cInteropTask = tasks[interopProcessingTaskName]
                 cInteropTask.dependsOn(buildCInteropDef)
                 defFile = buildCInteropDef.get().outputs.files.singleFile
+                compilerOpts.addAll(listOf("-DHAVE_GETHOSTUUID=0"))
             }
             cinterops.create("powersync-sqlite-core")
         }


### PR DESCRIPTION
Fix: Add `HAVE_GETHOSTUUID=0` to `compilerOpts` resolving compiler error when compiling sqliteArm64Simulator

Error:
```
Exception in thread "main" java.lang.Error ...  'gethostuuid' is unavailable: not available on iOS
```