### PR TITLE
fix: make field truly optional

### DIFF
--- a/core/src/commonMain/kotlin/com/powersync/sync/StreamingSyncCheckpointDiff.kt
+++ b/core/src/commonMain/kotlin/com/powersync/sync/StreamingSyncCheckpointDiff.kt
@@ -9,5 +9,5 @@ data class StreamingSyncCheckpointDiff(
     @SerialName("last_op_id") val lastOpId: String,
     @SerialName("updated_buckets") val updatedBuckets: List<BucketChecksum>,
     @SerialName("removed_buckets") val removedBuckets: List<String>,
-    @SerialName("write_checkpoint") val writeCheckpoint: String?
+    @SerialName("write_checkpoint") val writeCheckpoint: String? = null
 )


### PR DESCRIPTION
## Description
I saw this issue appear now that we fixed allowing `write_checkpoint` to be nullable.
```
SyncStream::streamingSync Error: kotlinx.serialization.MissingFieldException: Field 'write_checkpoint' is required for type with serial name 'com.powersync.sync.StreamingSyncCheckpointDiff', but it was missing
```

## Work Done
* Made `write_checkpoint` = null so that it is truly optional as explained in https://stackoverflow.com/questions/64796913/kotlinx-serialization-missingfieldexception. 

Note we could also implement this system wide to avoid similar issues in future https://github.com/Kotlin/kotlinx.serialization/blob/v1.3.0-RC/docs/json.md#explicit-nulls