### PR TITLE
Quality enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ class MyConnector : PowerSyncBackendConnector() {
 }
 ```
 
-#### 3. Initialize the PowerSync database an connect it to the connector, using `PowerSyncBuilder`:
+#### 3. Initialize the PowerSync database and connect it to the connector, using `PowerSyncBuilder`:
 
 You need to instantiate the PowerSync database — this is the core managed database.
 Its primary functions are to record all changes in the local database, whether online or offline. In addition, it automatically uploads changes to your app backend when connected.
@@ -183,7 +183,7 @@ Its primary functions are to record all changes in the local database, whether o
 a. Create platform specific `DatabaseDriverFactory` to be used by the `PowerSyncBuilder` to create the SQLite database driver.
 
   ```kotlin
-  // Android
+// Android
 val driverFactory = DatabaseDriverFactory(this)
 
 // iOS
@@ -193,16 +193,28 @@ val driverFactory = DatabaseDriverFactory()
 b. Build a `PowerSyncDatabase` instance using the `PowerSyncBuilder` and the `DatabaseDriverFactory`. The schema you created in a previous step is also used as a parameter:
 
   ```kotlin
-    // commonMain
+// commonMain
 val database = PowerSyncBuilder.from(driverFactory, schema).build()
   ```
 
 c. Connect the `PowerSyncDatabase` to the backend connector:
 
   ```kotlin
-    // commonMain
+// commonMain
 database.connect(MyConnector())
   ```
+
+**Special case: Compose Multiplatform**
+
+The artifact `com.powersync:powersync-compose` provides a simpler API:
+
+```kotlin
+// commonMain
+val database = rememberPowerSyncDatabase(schema)
+remember {
+    database.connect(MyConnector())
+}
+```
 
 #### 4. Subscribe to changes in data
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,12 +18,14 @@ allprojects {
     repositories {
         mavenCentral()
         google()
-        maven("https://jitpack.io")
         maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
         maven("https://www.jetbrains.com/intellij-repository/releases")
         maven("https://cache-redirector.jetbrains.com/intellij-dependencies")
         // Repo for the backported Android IntelliJ Plugin by Jetbrains used in Ultimate
         maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/kotlin-ide-plugin-dependencies/")
+        maven("https://jitpack.io") {
+            content { includeGroup("com.github.requery") }
+        }
     }
 
 

--- a/compose/build.gradle.kts
+++ b/compose/build.gradle.kts
@@ -1,0 +1,43 @@
+import com.powersync.plugins.sonatype.setupGithubRepository
+
+plugins {
+    alias(libs.plugins.kotlinMultiplatform)
+    alias(libs.plugins.androidLibrary)
+    alias(libs.plugins.jetbrainsCompose)
+    id("com.powersync.plugins.sonatype")
+}
+
+kotlin {
+    androidTarget {
+        publishLibraryVariants("release", "debug")
+    }
+
+    iosX64()
+    iosArm64()
+    iosSimulatorArm64()
+
+    explicitApi()
+
+    sourceSets {
+        commonMain.dependencies {
+            api(project(":core"))
+            implementation(compose.runtime)
+        }
+        androidMain.dependencies {
+            implementation(compose.foundation)
+        }
+    }
+}
+
+android {
+    namespace = "com.powersync.compose"
+    compileSdk = libs.versions.android.compileSdk.get().toInt()
+    defaultConfig {
+        minSdk = libs.versions.android.minSdk.get().toInt()
+    }
+    kotlin {
+        jvmToolchain(17)
+    }
+}
+
+setupGithubRepository()

--- a/compose/gradle.properties
+++ b/compose/gradle.properties
@@ -1,0 +1,2 @@
+POM_ARTIFACT_ID=powersync-compose
+POM_NAME=PowerSync Compose Multiplatform factory

--- a/compose/gradle.properties
+++ b/compose/gradle.properties
@@ -1,2 +1,2 @@
-POM_ARTIFACT_ID=powersync-compose
+POM_ARTIFACT_ID=compose
 POM_NAME=PowerSync Compose Multiplatform factory

--- a/compose/src/androidMain/kotlin/com/powersync/compose/DatabaseDriverFactory.compose.android.kt
+++ b/compose/src/androidMain/kotlin/com/powersync/compose/DatabaseDriverFactory.compose.android.kt
@@ -1,0 +1,16 @@
+package com.powersync.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+import com.powersync.DatabaseDriverFactory
+
+
+@Composable
+public actual fun rememberDatabaseDriverFactory(): DatabaseDriverFactory {
+    val context = LocalContext.current
+    return remember {
+        DatabaseDriverFactory(context)
+    }
+
+}

--- a/compose/src/commonMain/kotlin/com/powersync/compose/DatabaseDriverFactory.compose.kt
+++ b/compose/src/commonMain/kotlin/com/powersync/compose/DatabaseDriverFactory.compose.kt
@@ -1,0 +1,27 @@
+package com.powersync.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import com.powersync.DatabaseDriverFactory
+import com.powersync.PowerSyncBuilder
+import com.powersync.PowerSyncDatabase
+import com.powersync.db.schema.Schema
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.plus
+
+
+@Composable
+public expect fun rememberDatabaseDriverFactory(): DatabaseDriverFactory
+
+@Composable
+public fun rememberPowerSyncDatabase(schema: Schema): PowerSyncDatabase {
+    val driverFactory = rememberDatabaseDriverFactory()
+    val scope = rememberCoroutineScope()
+    return remember(schema) {
+        PowerSyncBuilder
+            .from(driverFactory, schema)
+            .scope(scope + Dispatchers.Default)
+            .build()
+    }
+}

--- a/compose/src/iosMain/kotlin/com/powersync/compose/DatabaseDriverFactory.compose.ios.kt
+++ b/compose/src/iosMain/kotlin/com/powersync/compose/DatabaseDriverFactory.compose.ios.kt
@@ -1,0 +1,14 @@
+package com.powersync.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import com.powersync.DatabaseDriverFactory
+
+
+@Composable
+public actual fun rememberDatabaseDriverFactory(): DatabaseDriverFactory {
+    return remember {
+        DatabaseDriverFactory()
+    }
+
+}

--- a/connectors/supabase/build.gradle.kts
+++ b/connectors/supabase/build.gradle.kts
@@ -16,6 +16,8 @@ kotlin {
     iosArm64()
     iosSimulatorArm64()
 
+    explicitApi()
+
     sourceSets {
         commonMain.dependencies {
             api(project(":core"))

--- a/connectors/supabase/src/commonMain/kotlin/com/powersync/connector/supabase/SupabaseConnector.kt
+++ b/connectors/supabase/src/commonMain/kotlin/com/powersync/connector/supabase/SupabaseConnector.kt
@@ -16,10 +16,10 @@ import io.github.jan.supabase.postgrest.from
 /**
  * Get a Supabase token to authenticate against the PowerSync instance.
  */
-class SupabaseConnector(
-    val supabaseUrl: String,
-    val supabaseKey: String,
-    val powerSyncEndpoint: String,
+public class SupabaseConnector(
+    public val supabaseUrl: String,
+    public val supabaseKey: String,
+    public val powerSyncEndpoint: String,
 ) : PowerSyncBackendConnector() {
 
     private var loggedIn: Boolean = false
@@ -37,7 +37,7 @@ class SupabaseConnector(
         return client
     }
 
-    suspend fun login(email: String, password: String) {
+    public suspend fun login(email: String, password: String) {
         supabaseClient.auth.signInWith(Email) {
             this.email = email
             this.password = password

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -81,6 +81,8 @@ kotlin {
         }
     }
 
+    explicitApi()
+
     sourceSets {
         all {
             languageSettings {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -100,6 +100,7 @@ kotlin {
             implementation(libs.kotlinx.datetime)
             implementation(libs.stately.concurrency)
             implementation(libs.bundles.sqldelight)
+            implementation(libs.canard)
         }
         androidMain.dependencies {
             implementation(libs.powersync.sqlite.core)

--- a/core/src/androidMain/kotlin/com/powersync/DatabaseDriverFactory.android.kt
+++ b/core/src/androidMain/kotlin/com/powersync/DatabaseDriverFactory.android.kt
@@ -10,7 +10,7 @@ import io.requery.android.database.sqlite.SQLiteCustomExtension
 import kotlinx.coroutines.CoroutineScope
 
 @Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
-actual class DatabaseDriverFactory(private val context: Context) {
+public actual class DatabaseDriverFactory(private val context: Context) {
     private var driver: PsSqlDriver? = null
     private external fun setupSqliteBinding()
 
@@ -30,7 +30,7 @@ actual class DatabaseDriverFactory(private val context: Context) {
         }
     }
 
-    actual fun createDriver(
+    public actual fun createDriver(
         scope: CoroutineScope,
         dbFilename: String,
     ): PsSqlDriver {
@@ -69,7 +69,7 @@ actual class DatabaseDriverFactory(private val context: Context) {
     }
 
 
-    companion object {
+    public companion object {
         init {
             System.loadLibrary("powersync-sqlite")
         }

--- a/core/src/commonMain/kotlin/com/powersync/DatabaseDriverFactory.kt
+++ b/core/src/commonMain/kotlin/com/powersync/DatabaseDriverFactory.kt
@@ -3,9 +3,9 @@ package com.powersync
 import kotlinx.coroutines.CoroutineScope
 
 @Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
-expect class DatabaseDriverFactory {
+public expect class DatabaseDriverFactory {
 
-    fun createDriver(
+    public fun createDriver(
         scope: CoroutineScope,
         dbFilename: String
     ): PsSqlDriver

--- a/core/src/commonMain/kotlin/com/powersync/PowerSyncBuilder.kt
+++ b/core/src/commonMain/kotlin/com/powersync/PowerSyncBuilder.kt
@@ -6,24 +6,24 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 
-interface PowerSyncBuilder {
+public interface PowerSyncBuilder {
 
-    fun build(): PowerSyncDatabase
+    public fun build(): PowerSyncDatabase
 
     /**
      * By default [PowerSyncDatabase] will open a global scope for management of shared processes, if instead you'd like to control
      * the scope that sharing/multicasting happens in you can pass a @param [scope]
      */
-    fun scope(scope: CoroutineScope): PowerSyncBuilder
+    public fun scope(scope: CoroutineScope): PowerSyncBuilder
 
-    companion object {
+    public companion object {
 
-        const val DEFAULT_DB_FILENAME = "powersync.db"
-        fun from(factory: DatabaseDriverFactory, schema: Schema): PowerSyncBuilder {
+        public const val DEFAULT_DB_FILENAME: String = "powersync.db"
+        public fun from(factory: DatabaseDriverFactory, schema: Schema): PowerSyncBuilder {
             return from(factory, schema, DEFAULT_DB_FILENAME)
         }
 
-        fun from(
+        public fun from(
             factory: DatabaseDriverFactory,
             schema: Schema,
             dbFilename: String

--- a/core/src/commonMain/kotlin/com/powersync/PowerSyncDatabase.kt
+++ b/core/src/commonMain/kotlin/com/powersync/PowerSyncDatabase.kt
@@ -18,14 +18,14 @@ import com.powersync.sync.SyncStream
  *
  * All changes to local tables are automatically recorded, whether connected or not. Once connected, the changes are uploaded.
  */
-interface PowerSyncDatabase : ReadQueries, WriteQueries {
+public interface PowerSyncDatabase : ReadQueries, WriteQueries {
 
     /**
      * The current sync status.
      */
-    val currentStatus: SyncStatus
+    public val currentStatus: SyncStatus
 
-    var syncStream: SyncStream?
+//    public var syncStream: SyncStream?
 
     /**
      *  Connect to the PowerSync service, and keep the databases in sync.
@@ -35,7 +35,7 @@ interface PowerSyncDatabase : ReadQueries, WriteQueries {
      *  TODO: Status changes are reported on [statusStream].
      */
 
-    suspend fun connect(connector: PowerSyncBackendConnector)
+    public suspend fun connect(connector: PowerSyncBackendConnector)
 
 
     /**
@@ -55,7 +55,7 @@ interface PowerSyncDatabase : ReadQueries, WriteQueries {
      * data by transaction. One batch may contain data from multiple transactions,
      * and a single transaction may be split over multiple batches.
      */
-    suspend fun getCrudBatch(limit: Int = 100): CrudBatch?
+    public suspend fun getCrudBatch(limit: Int = 100): CrudBatch?
 
 
     /**
@@ -72,10 +72,10 @@ interface PowerSyncDatabase : ReadQueries, WriteQueries {
      * All data for the transaction is loaded into memory.
      */
 
-    suspend fun getNextCrudTransaction(): CrudTransaction?
+    public suspend fun getNextCrudTransaction(): CrudTransaction?
 
     /**
      * Convenience method to get the current version of PowerSync.
      */
-    suspend fun getPowerSyncVersion(): String
+    public suspend fun getPowerSyncVersion(): String
 }

--- a/core/src/commonMain/kotlin/com/powersync/PowerSyncDatabase.kt
+++ b/core/src/commonMain/kotlin/com/powersync/PowerSyncDatabase.kt
@@ -25,8 +25,6 @@ public interface PowerSyncDatabase : ReadQueries, WriteQueries {
      */
     public val currentStatus: SyncStatus
 
-//    public var syncStream: SyncStream?
-
     /**
      *  Connect to the PowerSync service, and keep the databases in sync.
      *

--- a/core/src/commonMain/kotlin/com/powersync/PsSqlDriver.kt
+++ b/core/src/commonMain/kotlin/com/powersync/PsSqlDriver.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 
-class PsSqlDriver(private val driver: SqlDriver, private val scope: CoroutineScope) :
+public class PsSqlDriver(private val driver: SqlDriver, private val scope: CoroutineScope) :
     SqlDriver by driver {
     // MutableSharedFlow to emit batched table updates
     private val tableUpdatesFlow = MutableSharedFlow<List<String>>(replay = 0)
@@ -17,25 +17,25 @@ class PsSqlDriver(private val driver: SqlDriver, private val scope: CoroutineSco
     // In-memory buffer to store table names before flushing
     private val pendingUpdates = mutableSetOf<String>()
 
-    fun updateTable(tableName: String) {
+    public fun updateTable(tableName: String) {
         pendingUpdates.add(tableName)
     }
 
-    fun clearTableUpdates() {
+    public fun clearTableUpdates() {
         pendingUpdates.clear()
     }
 
     // Flows on table updates
-    fun tableUpdates(): Flow<List<String>> {
+    public fun tableUpdates(): Flow<List<String>> {
         return tableUpdatesFlow.asSharedFlow()
     }
 
     // Flows on table updates containing a specific table
-    fun updatesOnTable(tableName: String): Flow<Unit> {
+    public fun updatesOnTable(tableName: String): Flow<Unit> {
         return tableUpdates().filter { it.contains(tableName) }.map { }
     }
 
-    fun fireTableUpdates() {
+    public fun fireTableUpdates() {
         val updates = pendingUpdates.toList()
         if (updates.isEmpty()) {
             return;

--- a/core/src/commonMain/kotlin/com/powersync/bucket/BucketChecksum.kt
+++ b/core/src/commonMain/kotlin/com/powersync/bucket/BucketChecksum.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class BucketChecksum(
+internal data class BucketChecksum(
     val bucket: String,
     val checksum: Int,
     val count: Int? = null,

--- a/core/src/commonMain/kotlin/com/powersync/bucket/BucketRequest.kt
+++ b/core/src/commonMain/kotlin/com/powersync/bucket/BucketRequest.kt
@@ -3,4 +3,4 @@ package com.powersync.bucket
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class BucketRequest(val name: String, val after: String)
+internal data class BucketRequest(val name: String, val after: String)

--- a/core/src/commonMain/kotlin/com/powersync/bucket/BucketState.kt
+++ b/core/src/commonMain/kotlin/com/powersync/bucket/BucketState.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class BucketState(
+internal data class BucketState(
     val bucket: String,
     @SerialName("op_id") val opId: String
 ) {

--- a/core/src/commonMain/kotlin/com/powersync/bucket/BucketStorage.kt
+++ b/core/src/commonMain/kotlin/com/powersync/bucket/BucketStorage.kt
@@ -11,7 +11,7 @@ import com.powersync.db.internal.PsInternalTable
 import com.powersync.utils.JsonUtil
 import kotlinx.coroutines.runBlocking
 
-class BucketStorage(val db: PsInternalDatabase) {
+internal class BucketStorage(val db: PsInternalDatabase) {
 
     private val tableNames: MutableSet<String> = mutableSetOf()
     private var hasCompletedSync = AtomicBoolean(false)
@@ -201,7 +201,7 @@ class BucketStorage(val db: PsInternalDatabase) {
             }
         }
 
-        val valid = updateObjectsFromBuckets(targetCheckpoint);
+        val valid = updateObjectsFromBuckets()
 
         if (!valid) {
             return SyncLocalDatabaseResult(
@@ -234,11 +234,11 @@ class BucketStorage(val db: PsInternalDatabase) {
     }
 
     /**
-     * Atomically update the local state to the current checkpoint.
+     * Atomically update the local state.
      *
      * This includes creating new tables, dropping old tables, and copying data over from the oplog.
      */
-    private suspend fun updateObjectsFromBuckets(checkpoint: Checkpoint): Boolean {
+    private suspend fun updateObjectsFromBuckets(): Boolean {
         return db.writeTransaction {
             val res = db.execute(
                 "INSERT INTO powersync_operations(op, data) VALUES(?, ?)",

--- a/core/src/commonMain/kotlin/com/powersync/bucket/Checkpoint.kt
+++ b/core/src/commonMain/kotlin/com/powersync/bucket/Checkpoint.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class Checkpoint(
+internal data class Checkpoint(
     @SerialName("last_op_id") val lastOpId: String,
     @SerialName("buckets") val checksums: List<BucketChecksum>,
     @SerialName("write_checkpoint") val writeCheckpoint: String? = null

--- a/core/src/commonMain/kotlin/com/powersync/bucket/ChecksumCache.kt
+++ b/core/src/commonMain/kotlin/com/powersync/bucket/ChecksumCache.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class ChecksumCache(
+internal data class ChecksumCache(
     @SerialName("last_op_id") val lostOpId: String,
     val checksums: Map<String, BucketChecksum>
 )

--- a/core/src/commonMain/kotlin/com/powersync/bucket/OpType.kt
+++ b/core/src/commonMain/kotlin/com/powersync/bucket/OpType.kt
@@ -3,7 +3,7 @@ package com.powersync.bucket
 import kotlinx.serialization.Serializable
 
 @Serializable
-enum class OpType(private val value: Int) {
+internal enum class OpType(private val value: Int) {
     CLEAR(1),
     MOVE(2),
     PUT(3),

--- a/core/src/commonMain/kotlin/com/powersync/bucket/OplogEntry.kt
+++ b/core/src/commonMain/kotlin/com/powersync/bucket/OplogEntry.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class OplogEntry(
+internal data class OplogEntry(
     val checksum: Long,
     @SerialName("op_id") val opId: String,
     @SerialName("object_id") val rowId: String? = null,

--- a/core/src/commonMain/kotlin/com/powersync/bucket/SqliteOp.kt
+++ b/core/src/commonMain/kotlin/com/powersync/bucket/SqliteOp.kt
@@ -1,3 +1,3 @@
 package com.powersync.bucket
 
-data class SqliteOp(val sql: String, val args: List<Any>)
+internal data class SqliteOp(val sql: String, val args: List<Any>)

--- a/core/src/commonMain/kotlin/com/powersync/bucket/WriteCheckpointResult.kt
+++ b/core/src/commonMain/kotlin/com/powersync/bucket/WriteCheckpointResult.kt
@@ -4,11 +4,11 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class WriteCheckpointResponse(
+internal data class WriteCheckpointResponse(
     val data: WriteCheckpointData
 )
 
 @Serializable
-data class WriteCheckpointData(
+internal data class WriteCheckpointData(
     @SerialName("write_checkpoint") val writeCheckpoint: String
 )

--- a/core/src/commonMain/kotlin/com/powersync/connectors/PowerSyncBackendConnector.kt
+++ b/core/src/commonMain/kotlin/com/powersync/connectors/PowerSyncBackendConnector.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.GlobalScope
  * 2. Applying local changes against the backend application server.
  *
  */
-abstract class PowerSyncBackendConnector {
+public abstract class PowerSyncBackendConnector {
     private var cachedCredentials: PowerSyncCredentials? = null
     private var fetchRequest: Deferred<PowerSyncCredentials?>? = null
 
@@ -24,7 +24,7 @@ abstract class PowerSyncBackendConnector {
      *
      * These credentials may have expired already.
      */
-    suspend fun getCredentialsCached(): PowerSyncCredentials? {
+    public suspend fun getCredentialsCached(): PowerSyncCredentials? {
         cachedCredentials?.let { return it }
         return prefetchCredentials()
     }
@@ -34,7 +34,7 @@ abstract class PowerSyncBackendConnector {
      *
      * This may be called when the current credentials have expired.
      */
-    fun invalidateCredentials() {
+    public fun invalidateCredentials() {
         cachedCredentials = null
     }
 
@@ -47,7 +47,7 @@ abstract class PowerSyncBackendConnector {
      * This may be called before the current credentials have expired.
      */
     @OptIn(DelicateCoroutinesApi::class)
-    suspend fun prefetchCredentials(): PowerSyncCredentials? {
+    public suspend fun prefetchCredentials(): PowerSyncCredentials? {
         fetchRequest = fetchRequest ?: GlobalScope.async {
             fetchCredentials().also { value ->
                 cachedCredentials = value
@@ -69,7 +69,7 @@ abstract class PowerSyncBackendConnector {
      *
      * This token is kept for the duration of a sync connection.
      */
-    abstract suspend fun fetchCredentials(): PowerSyncCredentials?
+    public abstract suspend fun fetchCredentials(): PowerSyncCredentials?
 
     /**
      * Upload local changes to the app backend.
@@ -78,5 +78,5 @@ abstract class PowerSyncBackendConnector {
      *
      * Any thrown errors will result in a retry after the configured wait period (default: 5 seconds).
      */
-    abstract suspend fun uploadData(database: PowerSyncDatabase)
+    public abstract suspend fun uploadData(database: PowerSyncDatabase)
 }

--- a/core/src/commonMain/kotlin/com/powersync/connectors/PowerSyncCredentials.kt
+++ b/core/src/commonMain/kotlin/com/powersync/connectors/PowerSyncCredentials.kt
@@ -10,7 +10,7 @@ import kotlinx.serialization.SerialName
  * Temporary credentials to connect to the PowerSync service.
  */
 @Serializable
-data class PowerSyncCredentials(
+public data class PowerSyncCredentials(
     /**
      * PowerSync endpoint, e.g. "https://myinstance.powersync.co".
      */
@@ -36,7 +36,7 @@ data class PowerSyncCredentials(
         }>"
     }
 
-    fun endpointUri(path: String): String {
+    public fun endpointUri(path: String): String {
         return "$endpoint/$path"
     }
 }

--- a/core/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
@@ -53,7 +53,7 @@ internal class PowerSyncDatabaseImpl(
      */
     override val currentStatus: SyncStatus = SyncStatus()
 
-    override var syncStream: SyncStream? = null
+    private var syncStream: SyncStream? = null
 
     init {
         runBlocking {

--- a/core/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
@@ -27,7 +27,9 @@ import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.encodeToString
-import kotlinx.serialization.json.Json
+import org.kodein.log.LoggerFactory
+import org.kodein.log.frontend.defaultLogFrontend
+import org.kodein.log.newLogger
 
 /**
  * A PowerSync managed database.
@@ -45,8 +47,11 @@ internal class PowerSyncDatabaseImpl(
     private val dbFilename: String,
     driver: PsSqlDriver = factory.createDriver(scope, dbFilename),
 ) : PowerSyncDatabase {
+    private val loggerFactory = LoggerFactory(defaultLogFrontend)
+    private val logger = newLogger(loggerFactory)
+
     private val internalDb = PsInternalDatabase(driver, scope)
-    private val bucketStorage: BucketStorage = BucketStorage(internalDb)
+    private val bucketStorage: BucketStorage = BucketStorage(internalDb, loggerFactory)
 
     /**
      * The current sync status.
@@ -58,8 +63,8 @@ internal class PowerSyncDatabaseImpl(
     init {
         runBlocking {
             val sqliteVersion = internalDb.queries.sqliteVersion().awaitAsOne()
-            println("SQLiteVersion: $sqliteVersion")
-            println("PowerSyncVersion: ${getPowerSyncVersion()}")
+            logger.debug { "SQLiteVersion: $sqliteVersion" }
+            logger.debug { "PowerSyncVersion: ${getPowerSyncVersion()}" }
             applySchema();
         }
     }
@@ -78,7 +83,8 @@ internal class PowerSyncDatabaseImpl(
             SyncStream(
                 bucketStorage = bucketStorage,
                 connector = connector,
-                uploadCrud = suspend { connector.uploadData(this) }
+                uploadCrud = suspend { connector.uploadData(this) },
+                loggerFactory = loggerFactory
             )
 
         scope.launch {
@@ -153,7 +159,7 @@ internal class PowerSyncDatabaseImpl(
             return@readTransaction CrudTransaction(
                 crud = entries, transactionId = txId,
                 complete = { writeCheckpoint ->
-                    println("[CrudTransaction::complete] Completing transaction with checkpoint $writeCheckpoint")
+                    logger.info { "[CrudTransaction::complete] Completing transaction with checkpoint $writeCheckpoint" }
                     handleWriteCheckpoint(entries.last().clientId, writeCheckpoint)
                 }
             )

--- a/core/src/commonMain/kotlin/com/powersync/db/ReadQueries.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/ReadQueries.kt
@@ -4,12 +4,12 @@ import app.cash.sqldelight.SuspendingTransactionWithReturn
 import app.cash.sqldelight.db.SqlCursor
 import kotlinx.coroutines.flow.Flow
 
-interface ReadQueries {
+public interface ReadQueries {
 
     /**
      * Execute a read-only (SELECT) query and return a single result.
      */
-    suspend fun <RowType : Any> get(
+    public suspend fun <RowType : Any> get(
         sql: String,
         parameters: List<Any>? = listOf(),
         mapper: (SqlCursor) -> RowType
@@ -18,7 +18,7 @@ interface ReadQueries {
     /**
      * Execute a read-only (SELECT) query and return the results.
      */
-    suspend fun <RowType : Any> getAll(
+    public suspend fun <RowType : Any> getAll(
         sql: String,
         parameters: List<Any>? = listOf(),
         mapper: (SqlCursor) -> RowType
@@ -27,7 +27,7 @@ interface ReadQueries {
     /**
      * Execute a read-only (SELECT) query and return a single optional result.
      */
-    suspend fun <RowType : Any> getOptional(
+    public suspend fun <RowType : Any> getOptional(
         sql: String,
         parameters: List<Any>? = listOf(),
         mapper: (SqlCursor) -> RowType
@@ -36,14 +36,14 @@ interface ReadQueries {
     /**
      * Execute a read-only (SELECT) query every time the source tables are modified and return the results as a List in [Flow].
      */
-    fun <RowType : Any> watch(
+    public fun <RowType : Any> watch(
         sql: String,
         parameters: List<Any>? = listOf(),
         mapper: (SqlCursor) -> RowType
     ): Flow<List<RowType>>
 
 
-    suspend fun <R> readTransaction(body: suspend SuspendingTransactionWithReturn<R>.() -> R): R
+    public suspend fun <R> readTransaction(body: suspend SuspendingTransactionWithReturn<R>.() -> R): R
 
 }
 

--- a/core/src/commonMain/kotlin/com/powersync/db/WriteQueries.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/WriteQueries.kt
@@ -2,13 +2,13 @@ package com.powersync.db
 
 import app.cash.sqldelight.SuspendingTransactionWithReturn
 
-interface WriteQueries {
+public interface WriteQueries {
 
     /**
      * Execute a write query (INSERT, UPDATE, DELETE) and return the number of rows updated for an INSERT/DELETE/UPDATE.
      */
-    suspend fun execute(sql: String, parameters: List<Any>? = listOf()): Long
+    public suspend fun execute(sql: String, parameters: List<Any>? = listOf()): Long
 
-    suspend fun <R> writeTransaction(body: suspend SuspendingTransactionWithReturn<R>.() -> R): R
+    public suspend fun <R> writeTransaction(body: suspend SuspendingTransactionWithReturn<R>.() -> R): R
 
 }

--- a/core/src/commonMain/kotlin/com/powersync/db/crud/CrudBatch.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/crud/CrudBatch.kt
@@ -3,7 +3,7 @@ package com.powersync.db.crud
 /**
  * A batch of client-side changes.
  */
-data class CrudBatch(
+public data class CrudBatch(
     /**
      * List of client-side changes.
      */

--- a/core/src/commonMain/kotlin/com/powersync/db/crud/CrudEntry.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/crud/CrudEntry.kt
@@ -7,7 +7,7 @@ import kotlinx.serialization.json.jsonPrimitive
 /**
  * A single client-side change.
  */
-data class CrudEntry(
+public data class CrudEntry(
 
     /**
      * ID of the changed row.
@@ -53,8 +53,8 @@ data class CrudEntry(
      */
     val opData: Map<String, String>?
 ) {
-    companion object {
-        fun fromRow(row: CrudRow): CrudEntry {
+    public companion object {
+        public fun fromRow(row: CrudRow): CrudEntry {
             val data = JsonUtil.json.parseToJsonElement(row.data).jsonObject
             return CrudEntry(
                 id = data["id"]!!.jsonPrimitive.content,

--- a/core/src/commonMain/kotlin/com/powersync/db/crud/CrudRow.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/crud/CrudRow.kt
@@ -3,4 +3,4 @@ package com.powersync.db.crud
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class CrudRow(val id: String, val data: String, val txId: Int?)
+public data class CrudRow(val id: String, val data: String, val txId: Int?)

--- a/core/src/commonMain/kotlin/com/powersync/db/crud/CrudTransaction.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/crud/CrudTransaction.kt
@@ -3,7 +3,7 @@ package com.powersync.db.crud
 /**
  * A transaction of client-side changes.
  */
-data class CrudTransaction(
+public data class CrudTransaction(
     /**
      * Unique transaction id.
      *
@@ -23,5 +23,5 @@ data class CrudTransaction(
      */
     val complete: suspend (writeCheckpoint: String?) -> Unit
 ) {
-    override fun toString() = "CrudTransaction<$transactionId, $crud>"
+    override fun toString(): String = "CrudTransaction<$transactionId, $crud>"
 }

--- a/core/src/commonMain/kotlin/com/powersync/db/crud/UpdateType.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/crud/UpdateType.kt
@@ -3,7 +3,7 @@ package com.powersync.db.crud
 /**
  * Type of local change.
  */
-enum class UpdateType(val json: String) {
+public enum class UpdateType(private val json: String) {
     /**
      * Insert or replace a row. All non-null columns are included in the data.
      */
@@ -19,16 +19,16 @@ enum class UpdateType(val json: String) {
      */
     DELETE("DELETE");
 
-    fun toJson(): String {
+    public fun toJson(): String {
         return json
     }
 
-    companion object {
-        fun fromJson(json: String): UpdateType? {
+    public companion object {
+        public fun fromJson(json: String): UpdateType? {
             return entries.find { it.json == json }
         }
 
-        fun fromJsonChecked(json: String): UpdateType {
+        public fun fromJsonChecked(json: String): UpdateType {
             val v = fromJson(json)
             requireNotNull(v) { "Unexpected updateType: $json" }
             return v

--- a/core/src/commonMain/kotlin/com/powersync/db/crud/UploadQueueStats.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/crud/UploadQueueStats.kt
@@ -3,7 +3,7 @@ package com.powersync.db.crud
 /**
  * Stats of the local upload queue.
  */
-data class UploadQueueStats(
+public data class UploadQueueStats(
     /**
      * Number of records in the upload queue.
      */

--- a/core/src/commonMain/kotlin/com/powersync/db/internal/PsInternalDatabase.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/internal/PsInternalDatabase.kt
@@ -25,7 +25,7 @@ import kotlinx.serialization.encodeToString
 
 
 @OptIn(FlowPreview::class)
-class PsInternalDatabase(val driver: PsSqlDriver, private val scope: CoroutineScope) :
+internal class PsInternalDatabase(val driver: PsSqlDriver, private val scope: CoroutineScope) :
     ReadQueries,
     WriteQueries {
 
@@ -130,6 +130,7 @@ class PsInternalDatabase(val driver: PsSqlDriver, private val scope: CoroutineSc
     ): ExecutableQuery<Long> {
         return object : ExecutableQuery<Long>(mapper = { cursor -> cursor.getLong(0)!! }) {
             override fun <R> execute(mapper: (SqlCursor) -> QueryResult<R>): QueryResult<R> {
+                @Suppress("UNCHECKED_CAST")
                 return driver.execute(
                     identifier = null,
                     sql = query,
@@ -248,7 +249,7 @@ class PsInternalDatabase(val driver: PsSqlDriver, private val scope: CoroutineSc
     )
 }
 
-fun getBindersFromParams(parameters: List<Any>?): (SqlPreparedStatement.() -> Unit)? {
+internal fun getBindersFromParams(parameters: List<Any>?): (SqlPreparedStatement.() -> Unit)? {
     if (parameters.isNullOrEmpty()) {
         return null
     }

--- a/core/src/commonMain/kotlin/com/powersync/db/internal/PsInternalSchema.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/internal/PsInternalSchema.kt
@@ -5,7 +5,7 @@ import app.cash.sqldelight.db.QueryResult
 import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.db.SqlSchema
 
-public object PsInternalSchema : SqlSchema<QueryResult.AsyncValue<Unit>> {
+internal object PsInternalSchema : SqlSchema<QueryResult.AsyncValue<Unit>> {
     override val version: Long
         get() = 1
 

--- a/core/src/commonMain/kotlin/com/powersync/db/internal/PsInternalTable.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/internal/PsInternalTable.kt
@@ -1,6 +1,6 @@
 package com.powersync.db.internal
 
-enum class PsInternalTable(private val tableName: String) {
+internal enum class PsInternalTable(private val tableName: String) {
     DATA("ps_data"),
     CRUD("ps_crud"),
     BUCKETS("ps_buckets"),

--- a/core/src/commonMain/kotlin/com/powersync/db/schema/Column.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/schema/Column.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.Serializable
 
 /** A single column in a table schema. */
 @Serializable
-data class Column(
+public data class Column(
     /** Name of the column. */
     val name: String,
 
@@ -18,14 +18,14 @@ data class Column(
      */
     val type: ColumnType
 ) {
-    companion object {
+    public companion object {
         /** Create a TEXT column. */
-        fun text(name: String) = Column(name, ColumnType.TEXT)
+        public fun text(name: String): Column = Column(name, ColumnType.TEXT)
 
         /** Create an INTEGER column. */
-        fun integer(name: String) = Column(name, ColumnType.INTEGER)
+        public fun integer(name: String): Column = Column(name, ColumnType.INTEGER)
 
         /** Create a REAL column. */
-        fun real(name: String) = Column(name, ColumnType.REAL)
+        public fun real(name: String): Column = Column(name, ColumnType.REAL)
     }
 }

--- a/core/src/commonMain/kotlin/com/powersync/db/schema/ColumnType.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/schema/ColumnType.kt
@@ -1,6 +1,6 @@
 package com.powersync.db.schema
 
-enum class ColumnType {
+public enum class ColumnType {
     INTEGER,
     TEXT,
     REAL,

--- a/core/src/commonMain/kotlin/com/powersync/db/schema/Index.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/schema/Index.kt
@@ -16,6 +16,12 @@ public data class Index(
 ) {
 
     /**
+     * @param name Descriptive name of the index.
+     * @param columns List of columns used for the index.
+     */
+    public constructor(name: String, vararg columns: IndexedColumn) : this(name, columns.asList())
+
+    /**
      * Construct a new index with the specified column names.
      */
     public companion object {

--- a/core/src/commonMain/kotlin/com/powersync/db/schema/Index.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/schema/Index.kt
@@ -3,7 +3,7 @@ package com.powersync.db.schema
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class Index(
+public data class Index(
     /**
      * Descriptive name of the index.
      */
@@ -18,8 +18,8 @@ data class Index(
     /**
      * Construct a new index with the specified column names.
      */
-    companion object {
-        fun ascending(name: String, columns: List<String>): Index {
+    public companion object {
+        public fun ascending(name: String, columns: List<String>): Index {
             return Index(name, columns.map { IndexedColumn.ascending(it) })
         }
     }
@@ -28,7 +28,7 @@ data class Index(
      * Internal use only.
      * Specifies the full name of this index on a table.
      */
-    fun fullName(table: Table): String {
+    internal fun fullName(table: Table): String {
         return "${table.internalName}__$name"
     }
 
@@ -36,7 +36,7 @@ data class Index(
      * Internal use only.
      * Returns a SQL statement that creates this index.
      */
-    fun toSqlDefinition(table: Table): String {
+    internal fun toSqlDefinition(table: Table): String {
         val fields = columns.joinToString(", ") { it.toSql(table) }
         return """CREATE INDEX "${fullName(table)}" ON "${table.internalName}"($fields)"""
     }

--- a/core/src/commonMain/kotlin/com/powersync/db/schema/IndexedColumn.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/schema/IndexedColumn.kt
@@ -35,7 +35,7 @@ public data class IndexedColumn(
      * Sets the parent column definition. The column definition's type
      * is required for the serialized JSON payload of powersync_replace_schema
      */
-    public fun setColumnDefinition(column: Column) {
+    internal fun setColumnDefinition(column: Column) {
         this.type = column.type;
         this.columnDefinition = column;
     }

--- a/core/src/commonMain/kotlin/com/powersync/db/schema/IndexedColumn.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/schema/IndexedColumn.kt
@@ -7,7 +7,7 @@ import kotlinx.serialization.Serializable
  * Describes an indexed column.
  */
 @Serializable
-data class IndexedColumn(
+public data class IndexedColumn(
     /**
      * Name of the column to index.
      */
@@ -26,21 +26,21 @@ data class IndexedColumn(
      */
     var type: ColumnType? = null
 ) {
-    companion object {
-        fun ascending(column: String) = IndexedColumn(column, true)
-        fun descending(column: String) = IndexedColumn(column, false)
+    public companion object {
+        public fun ascending(column: String): IndexedColumn = IndexedColumn(column, true)
+        public fun descending(column: String): IndexedColumn = IndexedColumn(column, false)
     }
 
     /**
      * Sets the parent column definition. The column definition's type
      * is required for the serialized JSON payload of powersync_replace_schema
      */
-    fun setColumnDefinition(column: Column) {
+    public fun setColumnDefinition(column: Column) {
         this.type = column.type;
         this.columnDefinition = column;
     }
 
-    fun toSql(table: Table): String {
+    internal fun toSql(table: Table): String {
         val fullColumn = table[column] // errors if not found
         return fullColumn.let {
             if (ascending) mapColumn(it) else "${mapColumn(it)} DESC"
@@ -48,6 +48,6 @@ data class IndexedColumn(
     }
 }
 
-fun mapColumn(column: Column): String {
+internal fun mapColumn(column: Column): String {
     return "CAST(json_extract(data, ${column.name}) as ${column.type})"
 }

--- a/core/src/commonMain/kotlin/com/powersync/db/schema/Schema.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/schema/Schema.kt
@@ -3,4 +3,6 @@ package com.powersync.db.schema
 import kotlinx.serialization.Serializable
 
 @Serializable
-public data class Schema(val tables: List<Table>)
+public data class Schema(val tables: List<Table>) {
+    public constructor(vararg tables: Table) : this(tables.asList())
+}

--- a/core/src/commonMain/kotlin/com/powersync/db/schema/Schema.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/schema/Schema.kt
@@ -3,4 +3,4 @@ package com.powersync.db.schema
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class Schema(val tables: List<Table>)
+public data class Schema(val tables: List<Table>)

--- a/core/src/commonMain/kotlin/com/powersync/db/schema/Table.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/schema/Table.kt
@@ -1,15 +1,13 @@
 package com.powersync.db.schema
 
-import com.powersync.invalidSqliteCharacters
 import kotlinx.serialization.Serializable
-import kotlin.math.log
 
 /**
  * A single table in the schema.
  */
 @Serializable
 
-data class Table constructor(
+public data class Table constructor(
     /**
      * The synced table name, matching sync rules.
      */
@@ -50,13 +48,13 @@ data class Table constructor(
         }
     }
 
-    companion object {
+    public companion object {
         /**
          * Create a table that only exists locally.
          *
          * This table does not record changes, and is not synchronized from the service.
          */
-        fun localOnly(
+        public fun localOnly(
             name: String,
             columns: List<Column>,
             indexes: List<Index> = listOf(),
@@ -79,7 +77,7 @@ data class Table constructor(
          *
          * SELECT queries on the table will always return 0 rows.
          */
-        fun insertOnly(name: String, columns: List<Column>, viewName: String? = null): Table {
+        public fun insertOnly(name: String, columns: List<Column>, viewName: String? = null): Table {
             return Table(
                 name,
                 columns,
@@ -96,10 +94,10 @@ data class Table constructor(
      *
      * Name of the table that stores the underlying data.
      */
-    val internalName: String
+    internal val internalName: String
         get() = if (localOnly) "ps_data_local__$name" else "ps_data__$name"
 
-    operator fun get(columnName: String): Column {
+    public operator fun get(columnName: String): Column {
         return columns.first { it.name == columnName }
     }
 
@@ -116,7 +114,7 @@ data class Table constructor(
     /**
      * Check that there are no issues in the table definition.
      */
-    fun validate() {
+    public fun validate() {
         if (invalidSqliteCharacters.containsMatchIn(name)) {
             throw AssertionError("Invalid characters in table name: $name")
         } else if (_viewNameOverride != null && invalidSqliteCharacters.containsMatchIn(
@@ -172,6 +170,6 @@ data class Table constructor(
      * Name for the view, used for queries.
      * Defaults to the synced table name.
      */
-    val viewName: String
+    public val viewName: String
         get() = _viewNameOverride ?: name
 }

--- a/core/src/commonMain/kotlin/com/powersync/db/schema/validation.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/schema/validation.kt
@@ -1,3 +1,3 @@
-package com.powersync
+package com.powersync.db.schema
 
-val invalidSqliteCharacters = Regex("""["'%,.#\\s\\[\\]]""")
+internal val invalidSqliteCharacters = Regex("""["'%,.#\\s\\[\\]]""")

--- a/core/src/commonMain/kotlin/com/powersync/sync/StreamingSyncCheckpointDiff.kt
+++ b/core/src/commonMain/kotlin/com/powersync/sync/StreamingSyncCheckpointDiff.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class StreamingSyncCheckpointDiff(
+internal data class StreamingSyncCheckpointDiff(
     @SerialName("last_op_id") val lastOpId: String,
     @SerialName("updated_buckets") val updatedBuckets: List<BucketChecksum>,
     @SerialName("removed_buckets") val removedBuckets: List<String>,

--- a/core/src/commonMain/kotlin/com/powersync/sync/StreamingSyncRequest.kt
+++ b/core/src/commonMain/kotlin/com/powersync/sync/StreamingSyncRequest.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class StreamingSyncRequest(
+internal data class StreamingSyncRequest(
     val buckets: List<BucketRequest>,
     @SerialName("include_checksum") val includeChecksum: Boolean = true,
 ) {

--- a/core/src/commonMain/kotlin/com/powersync/sync/SyncDataBatch.kt
+++ b/core/src/commonMain/kotlin/com/powersync/sync/SyncDataBatch.kt
@@ -3,4 +3,4 @@ package com.powersync.sync
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class SyncDataBatch(val buckets: List<SyncDataBucket>)
+internal data class SyncDataBatch(val buckets: List<SyncDataBucket>)

--- a/core/src/commonMain/kotlin/com/powersync/sync/SyncDataBucket.kt
+++ b/core/src/commonMain/kotlin/com/powersync/sync/SyncDataBucket.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class SyncDataBucket (
+internal data class SyncDataBucket (
     val bucket: String,
     val data: List<OplogEntry>,
     @SerialName("has_more") val hasMore: Boolean = false,

--- a/core/src/commonMain/kotlin/com/powersync/sync/SyncLocalDatabaseResult.kt
+++ b/core/src/commonMain/kotlin/com/powersync/sync/SyncLocalDatabaseResult.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class SyncLocalDatabaseResult(
+internal data class SyncLocalDatabaseResult(
     var ready: Boolean = true,
     @SerialName("valid") val checkpointValid: Boolean = true,
     @SerialName("failed_buckets") val checkpointFailures: List<String>? = null

--- a/core/src/commonMain/kotlin/com/powersync/sync/SyncStatus.kt
+++ b/core/src/commonMain/kotlin/com/powersync/sync/SyncStatus.kt
@@ -167,4 +167,8 @@ public data class SyncStatus internal constructor(
     override fun toString(): String {
         return "SyncStatus(connected=$connected, connecting=$connecting, downloading=$downloading, uploading=$uploading, lastSyncedAt=$lastSyncedAt, error=$anyError)"
     }
+
+    public companion object {
+        public fun empty(): SyncStatus = SyncStatus()
+    }
 }

--- a/core/src/commonMain/kotlin/com/powersync/sync/SyncStatus.kt
+++ b/core/src/commonMain/kotlin/com/powersync/sync/SyncStatus.kt
@@ -2,7 +2,7 @@ package com.powersync.sync
 
 import kotlinx.datetime.Instant
 
-data class SyncStatus(
+public data class SyncStatus(
     /**
      * true if currently connected.
      *

--- a/core/src/commonMain/kotlin/com/powersync/sync/SyncStream.kt
+++ b/core/src/commonMain/kotlin/com/powersync/sync/SyncStream.kt
@@ -36,7 +36,7 @@ import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.decodeFromJsonElement
 
-class SyncStream(
+internal class SyncStream(
     private val bucketStorage: BucketStorage,
     private val connector: PowerSyncBackendConnector,
     private val uploadCrud: suspend () -> Unit,
@@ -418,7 +418,7 @@ class SyncStream(
 
 }
 
-data class SyncStreamState(
+internal data class SyncStreamState(
     var targetCheckpoint: Checkpoint?,
     var validatedCheckpoint: Checkpoint?,
     var appliedCheckpoint: Checkpoint?,

--- a/core/src/commonMain/kotlin/com/powersync/utils/Json.kt
+++ b/core/src/commonMain/kotlin/com/powersync/utils/Json.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.json.Json
 /**
  * A global instance of a JSON serializer.
  */
-object JsonUtil {
+internal object JsonUtil {
     val json = Json {
         encodeDefaults = true
         ignoreUnknownKeys = true

--- a/core/src/iosMain/kotlin/com/powersync/DatabaseDriverFactory.ios.kt
+++ b/core/src/iosMain/kotlin/com/powersync/DatabaseDriverFactory.ios.kt
@@ -20,14 +20,14 @@ import kotlinx.coroutines.CoroutineScope
 
 @Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
 @OptIn(ExperimentalForeignApi::class)
-actual class DatabaseDriverFactory {
+public actual class DatabaseDriverFactory {
     private var driver: PsSqlDriver? = null
 
     init {
         init_powersync_sqlite_extension()
     }
 
-    @Suppress("unused")
+    @Suppress("unused", "UNUSED_PARAMETER")
     private fun updateTableHook(opType: Int, databaseName: String, tableName: String, rowId: Long) {
         driver?.updateTable(tableName)
     }
@@ -42,7 +42,7 @@ actual class DatabaseDriverFactory {
         }
     }
 
-    actual fun createDriver(
+    public actual fun createDriver(
         scope: CoroutineScope,
         dbFilename: String,
     ): PsSqlDriver {
@@ -104,7 +104,6 @@ actual class DatabaseDriverFactory {
             staticCFunction { usrPtr ->
                 val callback = usrPtr!!.asStableRef<(Boolean) -> Unit>().get()
                 callback(false)
-                0
             },
             StableRef.create(::onTransactionCommit).asCPointer()
         )

--- a/demos/hello-powersync/composeApp/build.gradle.kts
+++ b/demos/hello-powersync/composeApp/build.gradle.kts
@@ -39,6 +39,7 @@ kotlin {
         commonMain.dependencies {
             api("com.powersync:core")
             api("com.powersync:connector-supabase")
+            api("com.powersync:compose")
             implementation(projectLibs.bundles.sqldelight)
             implementation(projectLibs.kotlinx.datetime)
             implementation(compose.runtime)

--- a/demos/hello-powersync/composeApp/src/androidMain/kotlin/com/powersync/demos/MainActivity.kt
+++ b/demos/hello-powersync/composeApp/src/androidMain/kotlin/com/powersync/demos/MainActivity.kt
@@ -13,7 +13,7 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
 
         setContent {
-            App(PowerSync(DatabaseDriverFactory(this)))
+            App()
         }
     }
 }
@@ -22,7 +22,7 @@ class MainActivity : ComponentActivity() {
 @Preview
 @Composable
 fun ViewContentPreview() {
-    ViewContent("Preview", listOf(User("1", "John Doe", "john@example.com")), {}, {}, SyncStatus())
+    ViewContent("Preview", listOf(User("1", "John Doe", "john@example.com")), {}, {}, SyncStatus.empty())
 }
 
 @Preview

--- a/demos/hello-powersync/composeApp/src/commonMain/kotlin/com/powersync/demos/App.kt
+++ b/demos/hello-powersync/composeApp/src/commonMain/kotlin/com/powersync/demos/App.kt
@@ -2,28 +2,10 @@ package com.powersync.demos
 
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.calculateEndPadding
-import androidx.compose.foundation.layout.calculateStartPadding
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Surface
-import androidx.compose.material.Text
-import androidx.compose.material.Divider
-import androidx.compose.material.LocalTextStyle
-import androidx.compose.material.Scaffold
-import androidx.compose.material.TopAppBar
-import androidx.compose.material.primarySurface
+import androidx.compose.material.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -33,11 +15,15 @@ import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.powersync.compose.rememberDatabaseDriverFactory
 import com.powersync.sync.SyncStatusData
 import kotlinx.coroutines.launch
 
 @Composable
-fun App(powerSync: PowerSync) {
+fun App() {
+    val driverFactory = rememberDatabaseDriverFactory()
+    val powerSync: PowerSync = remember { PowerSync(driverFactory) }
+
     var version by remember { mutableStateOf("Loading") }
     val scope = rememberCoroutineScope()
     val customers by powerSync.watchUsers().collectAsState(emptyList())

--- a/demos/hello-powersync/composeApp/src/iosMain/kotlin/com/powersync/demos/MainViewController.kt
+++ b/demos/hello-powersync/composeApp/src/iosMain/kotlin/com/powersync/demos/MainViewController.kt
@@ -3,4 +3,4 @@ package com.powersync.demos
 import androidx.compose.ui.window.ComposeUIViewController
 import com.powersync.DatabaseDriverFactory
 
-fun MainViewController() = ComposeUIViewController { App(PowerSync(DatabaseDriverFactory())) }
+fun MainViewController() = ComposeUIViewController { App() }

--- a/demos/hello-powersync/settings.gradle.kts
+++ b/demos/hello-powersync/settings.gradle.kts
@@ -36,5 +36,7 @@ includeBuild("../..") {
         substitute(module("com.powersync:connector-supabase"))
             .using(project(":connectors:supabase"))
             .because("we want to auto-wire up sample dependency")
+        substitute(module("com.powersync:compose"))
+            .using(project(":compose")).because("we want to auto-wire up sample dependency")
     }
 }

--- a/demos/hello-powersync/settings.gradle.kts
+++ b/demos/hello-powersync/settings.gradle.kts
@@ -14,7 +14,9 @@ dependencyResolutionManagement {
         google()
         mavenCentral()
         maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
-        maven("https://jitpack.io")
+        maven("https://jitpack.io") {
+            content { includeGroup("com.github.requery") }
+        }
     }
     versionCatalogs {
         create("projectLibs") {

--- a/demos/supabase-todolist/settings.gradle.kts
+++ b/demos/supabase-todolist/settings.gradle.kts
@@ -22,7 +22,9 @@ dependencyResolutionManagement {
         google()
         mavenCentral()
         maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
-        maven("https://jitpack.io")
+        maven("https://jitpack.io") {
+            content { includeGroup("com.github.requery") }
+        }
         maven {
             url = uri("https://maven.pkg.github.com/powersync-ja/powersync-kotlin")
             credentials {

--- a/dialect/build.gradle
+++ b/dialect/build.gradle
@@ -16,4 +16,5 @@ dependencies {
 
 kotlin {
     jvmToolchain(17)
+    explicitApi()
 }

--- a/dialect/src/main/kotlin/com/powersync/sqlite/PowerSyncDialect.kt
+++ b/dialect/src/main/kotlin/com/powersync/sqlite/PowerSyncDialect.kt
@@ -8,11 +8,11 @@ import app.cash.sqldelight.dialects.sqlite_3_35.SqliteTypeResolver
 import app.cash.sqldelight.dialects.sqlite_3_38.SqliteDialect as Sqlite338Dialect
 import com.alecstrong.sql.psi.core.psi.SqlFunctionExpr
 
-class PowerSyncDialect : SqlDelightDialect by Sqlite338Dialect() {
-    override fun typeResolver(parentResolver: TypeResolver) = PowerSyncTypeResolver(parentResolver)
+public class PowerSyncDialect : SqlDelightDialect by Sqlite338Dialect() {
+    override fun typeResolver(parentResolver: TypeResolver): PowerSyncTypeResolver = PowerSyncTypeResolver(parentResolver)
 }
 
-class PowerSyncTypeResolver(private val parentResolver: TypeResolver) :
+public class PowerSyncTypeResolver(private val parentResolver: TypeResolver) :
     TypeResolver by SqliteTypeResolver(parentResolver) {
     override fun functionType(functionExpr: SqlFunctionExpr): IntermediateType? {
         when (functionExpr.functionName.text) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,7 +19,7 @@ canard = "1.1.2"
 
 sqlDelight = "2.0.1"
 stately = "2.0.6"
-supabase = "2.0.4"
+supabase = "2.3.1"
 junit = "4.13.2"
 
 compose = "1.5.12"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ ktor = "2.3.7"
 uuid = "0.8.2"
 powersync-core = "0.1.6"
 sqlite-android = "3.45.0"
+canard = "1.1.2"
 
 sqlDelight = "2.0.1"
 stately = "2.0.6"
@@ -60,6 +61,8 @@ kotlin-stdlib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", versio
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }
 
 uuid = { module = "com.benasher44:uuid", version.ref = "uuid" }
+canard = { module = "org.kodein.log:canard", version.ref = "canard" }
+
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-ios = { module = "io.ktor:ktor-client-darwin", version.ref = "ktor" }
 ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }

--- a/plugins/sonatype/build.gradle.kts
+++ b/plugins/sonatype/build.gradle.kts
@@ -11,6 +11,9 @@ gradlePlugin {
     }
 }
 
+kotlin {
+    explicitApi()
+}
 
 dependencies {
     implementation(libs.mavenPublishPlugin)

--- a/plugins/sonatype/src/main/kotlin/com/powersync/plugins/sonatype/ProjectExtensions.kt
+++ b/plugins/sonatype/src/main/kotlin/com/powersync/plugins/sonatype/ProjectExtensions.kt
@@ -4,10 +4,10 @@ import org.gradle.api.Project
 import org.gradle.api.publish.PublishingExtension
 import java.net.URI
 
-inline val Project.gradlePublishing: PublishingExtension
+internal inline val Project.gradlePublishing: PublishingExtension
     get() = extensions.getByType(PublishingExtension::class.java)
 
-fun Project.findOptionalProperty(propertyName: String) = findProperty(propertyName)?.toString()
+internal fun Project.findOptionalProperty(propertyName: String) = findProperty(propertyName)?.toString()
 
 
 /** Sets up repository for publishing to Github Packages to GITHUB_REPO property
@@ -15,7 +15,7 @@ fun Project.findOptionalProperty(propertyName: String) = findProperty(propertyNa
  * `GITHUB_PUBLISH_USER` and `GITHUB_PUBLISH_TOKEN` gradle properties
  */
 @Suppress("unused")
-fun Project.setupGithubRepository() {
+public fun Project.setupGithubRepository() {
     gradlePublishing.apply {
         val githubRepo = githubRepoOrNull ?: return
 

--- a/plugins/sonatype/src/main/kotlin/com/powersync/plugins/sonatype/PublishToCentralPortalTask.kt
+++ b/plugins/sonatype/src/main/kotlin/com/powersync/plugins/sonatype/PublishToCentralPortalTask.kt
@@ -16,7 +16,7 @@ import java.net.URISyntaxException
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 import java.util.Base64
-abstract class PublishToCentralPortalTask : DefaultTask() {
+internal abstract class PublishToCentralPortalTask : DefaultTask() {
     @get:Input
     @get:Optional
     abstract val username: Property<String?>

--- a/plugins/sonatype/src/main/kotlin/com/powersync/plugins/sonatype/SonatypeCentralExtension.kt
+++ b/plugins/sonatype/src/main/kotlin/com/powersync/plugins/sonatype/SonatypeCentralExtension.kt
@@ -8,27 +8,27 @@ import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.bundling.Zip
 
-abstract class SonatypeCentralExtension(
+public abstract class SonatypeCentralExtension(
     private val project: Project
 ) {
     @get:Optional
-    val username: Property<String?> = project.objects.property(String::class.java)
+    public val username: Property<String?> = project.objects.property(String::class.java)
 
     @get:Optional
-    val password: Property<String?> = project.objects.property(String::class.java)
+    public val password: Property<String?> = project.objects.property(String::class.java)
 
-    companion object {
-        const val NAME = "sonatypePublishing"
-        const val GROUP = "publishing"
-        const val REPO_DIR = "sonatypeLocal"
-        const val BUNDLE_DIR = "sonatypeBundles"
+    public companion object {
+        public const val NAME: String = "sonatypePublishing"
+        public const val GROUP: String = "publishing"
+        public const val REPO_DIR: String = "sonatypeLocal"
+        public const val BUNDLE_DIR: String = "sonatypeBundles"
 
-        const val PUBLISH_TASK_NAME = "publishAllPublicationsToSonatypeRepository"
-        const val PUBLISH_LOCAL_TASK_NAME = "publishAllPublicationsToSonatypeLocalRepository"
-        const val COMPONENT_BUNDLE_TASK_NAME = "generateSonatypeComponentBundle"
+        public const val PUBLISH_TASK_NAME: String = "publishAllPublicationsToSonatypeRepository"
+        public const val PUBLISH_LOCAL_TASK_NAME: String = "publishAllPublicationsToSonatypeLocalRepository"
+        public const val COMPONENT_BUNDLE_TASK_NAME: String = "generateSonatypeComponentBundle"
 
-        const val SONATYPE_USERNAME_KEY = "centralPortal.username"
-        const val SONATYPE_PASSWORD_KEY = "centralPortal.password"
+        public const val SONATYPE_USERNAME_KEY: String = "centralPortal.username"
+        public const val SONATYPE_PASSWORD_KEY: String = "centralPortal.password"
     }
 
     internal fun apply() {

--- a/plugins/sonatype/src/main/kotlin/com/powersync/plugins/sonatype/SonatypeCentralUploadPlugin.kt
+++ b/plugins/sonatype/src/main/kotlin/com/powersync/plugins/sonatype/SonatypeCentralUploadPlugin.kt
@@ -4,7 +4,7 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import com.vanniktech.maven.publish.MavenPublishPlugin
 
-class SonatypeCentralUploadPlugin : Plugin<Project> {
+internal class SonatypeCentralUploadPlugin : Plugin<Project> {
     override fun apply(project: Project) {
         project.logger.info("Applying the `gradle-maven-publish` plugin")
         project.plugins.apply(MavenPublishPlugin::class.java)

--- a/powersyncswift/build.gradle.kts
+++ b/powersyncswift/build.gradle.kts
@@ -19,6 +19,8 @@ kotlin {
         }
     }
 
+    explicitApi()
+
     sourceSets {
         commonMain.dependencies {
             api(project(":core"))

--- a/powersyncswift/src/iosMain/kotlin/com/powersync/SDK.kt
+++ b/powersyncswift/src/iosMain/kotlin/com/powersync/SDK.kt
@@ -1,3 +1,3 @@
 package com.powersync
 
-fun sayHello() = "Hello from Kotlin!"
+public fun sayHello(): String = "Hello from Kotlin!"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,7 +12,9 @@ dependencyResolutionManagement {
         google()
         mavenCentral()
         maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
-        maven("https://jitpack.io")
+        maven("https://jitpack.io") {
+            content { includeGroup("com.github.requery") }
+        }
     }
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -24,4 +24,6 @@ include(":connectors:supabase")
 include(":dialect")
 include(":powersyncswift")
 
+include(":compose")
+
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")


### PR DESCRIPTION
This PR adds various quality enhancements:

- Constraints JitPack to only serving requery artifacts. This is a temporary measure. Jitpack needs to be removed from the requirements. Nikhil Purushe (Requery Sqlite-Android maintainer) has said on April 18th that he will look into publishing the lib to Maven Central "in the next couple of weeks". If that does not come through, Sqlite-Android will need to be forked.
- Enables [Explicit API mode](https://kotlinlang.org/docs/jvm-api-guidelines-backward-compatibility.html#explicit-api-mode).
- Enhances the SupabaseConnector to allow it to receive a SupabaseClient if the user already maintains one.
- Fixes some glitches in the documentation.
- Updates logging in order to use Android & iOS specific logging capabilities (through the Canard lib).
- Adds secondary vararg constructors to Index and Schema (to ease the schema DSL).
- Provide the `compose` artifact that offers `rememberDatabaseFactory` for Compose users.
