### PR TITLE
chore: remove expiresAt field

### DIFF
--- a/connectors/supabase/src/commonMain/kotlin/com/powersync/connector/supabase/SupabaseConnector.kt
+++ b/connectors/supabase/src/commonMain/kotlin/com/powersync/connector/supabase/SupabaseConnector.kt
@@ -57,17 +57,16 @@ public class SupabaseConnector(
         check(supabaseClient.auth.sessionStatus.value is SessionStatus.Authenticated) { "Supabase client is not authenticated" }
 
         // Use Supabase token for PowerSync
-        val session = supabaseClient.auth.currentSessionOrNull() ?: error("Could not fetch Supabase credentials");
+        val session = supabaseClient.auth.currentSessionOrNull() ?: error("Could not fetch Supabase credentials")
 
         check(session.user != null) { "No user data" }
 
-        // userId and expiresAt are for debugging purposes only
+        // userId is for debugging purposes only
         return PowerSyncCredentials(
             endpoint = powerSyncEndpoint,
             token = session.accessToken, // Use the access token to authenticate against PowerSync
-            expiresAt = session.expiresAt,
             userId = session.user!!.id
-        );
+        )
     }
 
     /**

--- a/core/src/commonMain/kotlin/com/powersync/connectors/PowerSyncCredentials.kt
+++ b/core/src/commonMain/kotlin/com/powersync/connectors/PowerSyncCredentials.kt
@@ -22,18 +22,10 @@ public data class PowerSyncCredentials(
     /**
      * User ID.
      */
-    @SerialName("user_id") val userId: String?,
-    /**
-     * When the token expires. Only use for debugging purposes.
-     */
-    val expiresAt: Instant?
+    @SerialName("user_id") val userId: String?
 ) {
     override fun toString(): String {
-        return "PowerSyncCredentials<endpoint: $endpoint userId: $userId expiresAt: ${
-            expiresAt?.toLocalDateTime(
-                TimeZone.UTC
-            )
-        }>"
+        return "PowerSyncCredentials<endpoint: $endpoint userId: $userId>"
     }
 
     public fun endpointUri(path: String): String {


### PR DESCRIPTION
## Description
`expiresAt` is an unused field and was only added for debugging purposes. As this is no longer necessary and converting Dates from Swift to Kotlin is a lot of a work it can be removed to avoid this. 

## Work Done
Removed all references to `expiresAt` field