### PR TITLE
fix: 422 publishing error

### DIFF
--- a/PowerSync/gradle.properties
+++ b/PowerSync/gradle.properties
@@ -1,2 +1,3 @@
-POM_ARTIFACT_ID=PowerSync
+# This needs to be lowercase otherwise there will be a 422 when publishing
+POM_ARTIFACT_ID=powersync
 POM_NAME=PowerSync Swift Framework


### PR DESCRIPTION
## Description 
There is an error `Received status code 422 from server: Unprocessable Entity` when publishing as shown in this action https://github.com/powersync-ja/powersync-kotlin/actions/runs/9598875826/job/26471307117. Based on this stackoverflow https://stackoverflow.com/questions/64322121/publishing-github-packages-returns-422-error entry it appears that the artifact id must be lowercase to publish. This PR changes the artifact id to lowercase.