### PR TITLE
chore: improve logging

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -102,8 +102,8 @@ kotlin {
             implementation(libs.kotlinx.datetime)
             implementation(libs.stately.concurrency)
             implementation(libs.bundles.sqldelight)
-            implementation(libs.canard)
             implementation(libs.configuration.annotations)
+            implementation(libs.kermit)
         }
 
         androidMain.dependencies {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -103,7 +103,7 @@ kotlin {
             implementation(libs.stately.concurrency)
             implementation(libs.bundles.sqldelight)
             implementation(libs.configuration.annotations)
-            implementation(libs.kermit)
+            api(libs.kermit)
         }
 
         androidMain.dependencies {
@@ -127,6 +127,20 @@ kotlin {
 android {
     kotlin {
         jvmToolchain(17)
+    }
+
+
+    buildFeatures {
+        buildConfig = true
+    }
+
+    buildTypes {
+        release {
+            buildConfigField("boolean", "DEBUG", "false")
+        }
+        debug {
+            buildConfigField("boolean", "DEBUG", "true")
+        }
     }
 
     namespace = "com.powersync"

--- a/core/src/androidMain/kotlin/BuildConfig.kt
+++ b/core/src/androidMain/kotlin/BuildConfig.kt
@@ -1,0 +1,4 @@
+public actual object BuildConfig {
+    public actual val isDebug: Boolean
+        get() = com.powersync.BuildConfig.DEBUG
+}

--- a/core/src/commonMain/kotlin/BuildConfig.kt
+++ b/core/src/commonMain/kotlin/BuildConfig.kt
@@ -1,0 +1,3 @@
+public expect object BuildConfig {
+    public val isDebug: Boolean
+}

--- a/core/src/commonMain/kotlin/com/powersync/PowerSyncDatabaseFactory.kt
+++ b/core/src/commonMain/kotlin/com/powersync/PowerSyncDatabaseFactory.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import co.touchlab.skie.configuration.annotations.DefaultArgumentInterop
+import co.touchlab.kermit.Logger
 
 public const val DEFAULT_DB_FILENAME: String = "powersync.db"
 
@@ -18,12 +19,14 @@ public fun PowerSyncDatabase(
     factory: DatabaseDriverFactory,
     schema: Schema,
     dbFilename: String = DEFAULT_DB_FILENAME,
-    scope: CoroutineScope = GlobalScope
+    scope: CoroutineScope = GlobalScope,
+    logger: Logger = Logger
 ): PowerSyncDatabase {
     return PowerSyncDatabaseImpl(
         schema = schema,
         factory = factory,
         dbFilename = dbFilename,
-        scope = scope
+        scope = scope,
+        logger = logger
     )
 }

--- a/core/src/commonMain/kotlin/com/powersync/PowerSyncDatabaseFactory.kt
+++ b/core/src/commonMain/kotlin/com/powersync/PowerSyncDatabaseFactory.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import co.touchlab.skie.configuration.annotations.DefaultArgumentInterop
 import co.touchlab.kermit.Logger
+import com.powersync.utils.generateLogger
 
 public const val DEFAULT_DB_FILENAME: String = "powersync.db"
 
@@ -20,13 +21,15 @@ public fun PowerSyncDatabase(
     schema: Schema,
     dbFilename: String = DEFAULT_DB_FILENAME,
     scope: CoroutineScope = GlobalScope,
-    logger: Logger = Logger
+    logger: Logger? = null
 ): PowerSyncDatabase {
+    val generatedLogger: Logger = generateLogger(logger)
+
     return PowerSyncDatabaseImpl(
         schema = schema,
         factory = factory,
         dbFilename = dbFilename,
         scope = scope,
-        logger = logger
+        logger = generatedLogger
     )
 }

--- a/core/src/commonMain/kotlin/com/powersync/sync/SyncStatus.kt
+++ b/core/src/commonMain/kotlin/com/powersync/sync/SyncStatus.kt
@@ -3,6 +3,7 @@ package com.powersync.sync
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import com.powersync.connectors.PowerSyncBackendConnector
 import kotlinx.datetime.Instant
 
 public interface SyncStatusData {
@@ -111,7 +112,7 @@ public data class SyncStatus internal constructor(
      */
     internal fun update(builder: SyncStatusDataContainer.Builder.() -> Unit) {
         data = SyncStatusDataContainer.Builder(data).apply(builder).build()
-        stateFlow.value = data;
+        stateFlow.value = data
     }
 
     /**

--- a/core/src/commonMain/kotlin/com/powersync/utils/Log.kt
+++ b/core/src/commonMain/kotlin/com/powersync/utils/Log.kt
@@ -1,2 +1,24 @@
 package com.powersync.utils
 
+import co.touchlab.kermit.Logger
+import co.touchlab.kermit.Severity
+
+/*
+ * Generates a logger with the appropriate severity level based on the build type
+ * if no Logger is provided.
+*/
+public fun generateLogger(logger: Logger?): Logger {
+    if(logger != null) {
+        return logger
+    }
+
+    val defaultLogger: Logger = Logger
+
+    if(BuildConfig.isDebug) {
+        Logger.setMinSeverity(Severity.Verbose)
+    } else {
+        Logger.setMinSeverity(Severity.Warn)
+    }
+
+    return defaultLogger
+}

--- a/core/src/commonMain/kotlin/com/powersync/utils/Log.kt
+++ b/core/src/commonMain/kotlin/com/powersync/utils/Log.kt
@@ -1,0 +1,2 @@
+package com.powersync.utils
+

--- a/core/src/iosMain/kotlin/BuildConfig.kt
+++ b/core/src/iosMain/kotlin/BuildConfig.kt
@@ -1,0 +1,7 @@
+import kotlin.experimental.ExperimentalNativeApi
+import kotlin.native.Platform
+
+public actual object BuildConfig {
+    @OptIn(ExperimentalNativeApi::class)
+    public actual val isDebug: Boolean = Platform.isDebugBinary
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,15 +8,15 @@ java = "17"
 idea = "222.4459.24" # Flamingo | 2022.2.1 (see https://plugins.jetbrains.com/docs/intellij/android-studio-releases-list.html)
 
 # Dependencies
+kermit = "2.0.4"
 kotlin = "1.9.22"
 coroutines = "1.7.3"
 kotlinx-datetime = "0.5.0"
 kotlinx-io = "0.3.0"
-ktor = "2.3.7"
+ktor = "2.3.10"
 uuid = "0.8.2"
 powersync-core = "0.1.6"
 sqlite-android = "3.45.0"
-canard = "1.1.2"
 
 sqlDelight = "2.0.1"
 stately = "2.0.6"
@@ -24,8 +24,8 @@ supabase = "2.3.1"
 junit = "4.13.2"
 
 compose = "1.5.12"
-compose-preview = "1.6.0"
-compose-compiler = "1.5.8"
+compose-preview = "1.6.8"
+compose-compiler = "1.5.14"
 
 # plugins
 android-gradle-plugin = "8.2.2"
@@ -49,6 +49,7 @@ org-jetbrains-kotlin-jvm = "1.9.22"
 [libraries]
 compose-compiler = { module = "androidx.compose.compiler:compiler", version.ref = "compose-compiler" }
 configuration-annotations = { module = "co.touchlab.skie:configuration-annotations", version.ref = "configurationAnnotations" }
+kermit = { module = "co.touchlab:kermit", version.ref = "kermit" }
 powersync-sqlite-core = { module = "co.powersync:powersync-sqlite-core", version.ref = "powersync-core" }
 mavenPublishPlugin = { module = "com.vanniktech:gradle-maven-publish-plugin", version.ref = "maven-publish" }
 
@@ -63,7 +64,6 @@ kotlin-stdlib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", versio
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }
 
 uuid = { module = "com.benasher44:uuid", version.ref = "uuid" }
-canard = { module = "org.kodein.log:canard", version.ref = "canard" }
 
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-ios = { module = "io.ktor:ktor-client-darwin", version.ref = "ktor" }


### PR DESCRIPTION
## Description
Improve the logging experience for users. 

Currently, all the logs are exposed which may result in sensitive information being logged resulting in a security vulnerability. To improve this I have changed the current logger Canard to use touchlab's [Kermit](https://kermit.touchlab.co/docs/) logger and if a user does not provide a logger I have set some sensible log levels to be displayed when it is `debug` or `release` build. The reason for this is 

1. It allows the user to set the global logger settings
2. It is more popular which increases the likelihood of users already using it
3. The experience is now more aligned with the other SDK's
4. It is extendable by the user but has sensible defaults set if they opt not to

## Work Done
* Added a build config flag which is used to determine if it is a debug build or not
* Swapped out current logger for new Kermit logger
* Set sensible log defaults if user does not provide a logger

## Testing
I have tested this on both iOS and Android in `debug` and `release` builds and it works as expected i.e. all logs are shown in `degub` and only warnings and above are shown in `release`