### PR TITLE
chore: turn SKIE off for suspend functions

### DIFF
--- a/PowerSync/build.gradle.kts
+++ b/PowerSync/build.gradle.kts
@@ -1,4 +1,5 @@
 import co.touchlab.faktory.versionmanager.TimestampVersionManager
+import co.touchlab.skie.configuration.SuspendInterop
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 
 plugins {
@@ -31,6 +32,14 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             api(project(":core"))
+        }
+    }
+}
+
+skie {
+    features {
+        group {
+            SuspendInterop.Enabled(false) // or false
         }
     }
 }

--- a/PowerSync/build.gradle.kts
+++ b/PowerSync/build.gradle.kts
@@ -39,7 +39,9 @@ kotlin {
 skie {
     features {
         group {
-            SuspendInterop.Enabled(false) // or false
+            // We turn this off as the suspend interop feature results in
+            // threading issues when implementing SDK in Swift
+            SuspendInterop.Enabled(false)
         }
     }
 }

--- a/core/src/commonMain/kotlin/com/powersync/connectors/PowerSyncBackendConnector.kt
+++ b/core/src/commonMain/kotlin/com/powersync/connectors/PowerSyncBackendConnector.kt
@@ -5,7 +5,6 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
-import co.touchlab.skie.configuration.annotations.SuspendInterop
 
 /**
  * Implement this to connect an app backend.
@@ -70,7 +69,6 @@ public abstract class PowerSyncBackendConnector {
      *
      * This token is kept for the duration of a sync connection.
      */
-    @SuspendInterop.Disabled
     public abstract suspend fun fetchCredentials(): PowerSyncCredentials?
 
     /**
@@ -80,6 +78,5 @@ public abstract class PowerSyncBackendConnector {
      *
      * Any thrown errors will result in a retry after the configured wait period (default: 5 seconds).
      */
-    @SuspendInterop.Disabled
     public abstract suspend fun uploadData(database: PowerSyncDatabase)
 }


### PR DESCRIPTION
## Description
When SKIE bridges the code from Kotlin to Swift it makes a few changes to suspend functions that have resulted in quite a few issues. 

The crux of the issue is that `async` functions in Swift are running on the main thread while `suspend` functions that are transformed using SKIE to Swift are run on a background thread. This results in transactions starting on the main thread while the database execute functions in the transaction are run on a background thread leading to deadlocks and changes being rejected as indicated by the audit report. Further this seems to have also had implications on token refreshes and once removed has fixed those issues.

This PR turns of SKIE changes to Kotlin `suspend` functions. From some manual testing on the demo app there does not appear to be any issue or slowness as a result of this change. This will require a change PR in the Swift demo once this is merged an released as async functions won't need a `__` anymore. 