### PR TITLE
WIP: JVM support

### DIFF
--- a/compose/build.gradle.kts
+++ b/compose/build.gradle.kts
@@ -12,6 +12,7 @@ kotlin {
         publishLibraryVariants("release", "debug")
     }
 
+    jvm()
     iosX64()
     iosArm64()
     iosSimulatorArm64()

--- a/compose/src/jvmMain/kotlin/com/powersync/compose/DatabaseDriverFactory.compose.jvm.kt
+++ b/compose/src/jvmMain/kotlin/com/powersync/compose/DatabaseDriverFactory.compose.jvm.kt
@@ -1,0 +1,12 @@
+package com.powersync.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import com.powersync.DatabaseDriverFactory
+
+@Composable
+public actual fun rememberDatabaseDriverFactory(): DatabaseDriverFactory {
+    return remember {
+        DatabaseDriverFactory()
+    }
+}

--- a/connectors/supabase/build.gradle.kts
+++ b/connectors/supabase/build.gradle.kts
@@ -19,6 +19,7 @@ kotlin {
         }
     }
 
+    jvm()
     iosX64()
     iosArm64()
     iosSimulatorArm64()

--- a/core/src/jvmMain/cpp/CMakeLists.txt
+++ b/core/src/jvmMain/cpp/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.18.1)
+
+project(powersync-sqlite)
+
+set(PACKAGE_NAME "powersync-sqlite")
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/../output)
+
+find_package(JNI REQUIRED)
+
+include_directories(${JNI_INCLUDE_DIRS})
+include_directories(${SQLITE3_INTEROP_DIR})
+
+add_library(sqlite3_static STATIC
+        "${SQLITE3_INTEROP_DIR}/sqlite3.c"
+)
+
+add_library(
+        ${PACKAGE_NAME}
+        SHARED
+        sqlite_bindings.cpp
+)
+
+target_link_libraries(
+        ${PACKAGE_NAME}
+        PRIVATE
+        sqlite3_static
+)

--- a/core/src/jvmMain/cpp/build.sh
+++ b/core/src/jvmMain/cpp/build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+[[ -z "$TARGET" ]] && echo "Please set the PLATFORM variable" && exit 1
+[[ -z "$SOURCE_PATH" ]] && echo "Please set the SOURCE_PATH variable" && exit 1
+[[ -z "$INTEROP_PATH" ]] && echo "Please set the INTEROP_PATH variable" && exit 1
+
+mkdir -p "$TARGET"
+cd "$TARGET"
+
+cmake -DSQLITE3_INTEROP_DIR="$INTEROP_PATH" "$SOURCE_PATH"
+cmake --build .

--- a/core/src/jvmMain/cpp/sqlite_bindings.cpp
+++ b/core/src/jvmMain/cpp/sqlite_bindings.cpp
@@ -1,0 +1,91 @@
+#include <jni.h>
+#include <inttypes.h>
+#include <sqlite3.h>
+#include <string>
+
+typedef struct context {
+  JavaVM *javaVM;
+  jobject bindingsObj;
+  jclass bindingsClz;
+} Context;
+Context g_ctx;
+
+extern "C" {
+
+JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved) {
+  JNIEnv *env;
+  memset(&g_ctx, 0, sizeof(g_ctx));
+  g_ctx.javaVM = vm;
+
+  if (vm->GetEnv((void **) &env, JNI_VERSION_1_6) != JNI_OK) {
+    return JNI_ERR;  // JNI version not supported.
+  }
+
+  return JNI_VERSION_1_6;
+}
+
+static void
+update_hook_callback(void *pData, int opCode, char const *pDbName, char const *pTableName,
+                     sqlite3_int64 iRow) {
+  // Get JNIEnv for the current thread
+  JNIEnv *env;
+  JavaVM *javaVM = g_ctx.javaVM;
+  javaVM->GetEnv((void **) &env, JNI_VERSION_1_6);
+
+  if (g_ctx.bindingsClz) {
+    jmethodID updateId = env->GetMethodID(
+        g_ctx.bindingsClz, "onTableUpdate", "(Ljava/lang/String;)V");
+
+    jstring tableString = env->NewStringUTF(std::string(pTableName).c_str());
+    env->CallVoidMethod(g_ctx.bindingsObj, updateId, tableString);
+  }
+}
+
+static jint
+commit_hook(void *pool) {
+  // Get JNIEnv for the current thread
+  JNIEnv *env;
+  JavaVM *javaVM = g_ctx.javaVM;
+  javaVM->GetEnv((void **) &env, JNI_VERSION_1_6);
+
+  if (g_ctx.bindingsClz) {
+    jmethodID methodId = env->GetMethodID(
+        g_ctx.bindingsClz, "onTransactionCommit", "(Z)V");
+
+    env->CallVoidMethod(g_ctx.bindingsObj, methodId, JNI_TRUE);
+  }
+
+  return 0;
+}
+
+static void rollback_hook(void *pool) {
+  // Get JNIEnv for the current thread
+  JNIEnv *env;
+  JavaVM *javaVM = g_ctx.javaVM;
+  javaVM->GetEnv((void **) &env, JNI_VERSION_1_6);
+
+  if (g_ctx.bindingsClz) {
+    jmethodID methodId = env->GetMethodID(
+        g_ctx.bindingsClz, "onTransactionCommit", "(Z)V");
+
+    env->CallVoidMethod(g_ctx.bindingsObj, methodId, JNI_FALSE);
+  }
+}
+
+jint powersync_init(sqlite3 *db, char **pzErrMsg,
+                    const sqlite3_api_routines *pApi) {
+
+  sqlite3_update_hook(db, update_hook_callback, NULL);
+  sqlite3_commit_hook(db, commit_hook, NULL);
+  sqlite3_rollback_hook(db, rollback_hook, NULL);
+
+  return SQLITE_OK;
+}
+
+JNIEXPORT void JNICALL
+Java_com_powersync_DatabaseDriverFactory_setupSqliteBinding(JNIEnv *env, jobject thiz) {
+  jclass clz = env->GetObjectClass(thiz);
+  g_ctx.bindingsClz = (jclass) env->NewGlobalRef(clz);
+  g_ctx.bindingsObj = env->NewGlobalRef(thiz);
+}
+}

--- a/core/src/jvmMain/kotlin/BuidConfig.kt
+++ b/core/src/jvmMain/kotlin/BuidConfig.kt
@@ -1,0 +1,6 @@
+public actual object BuildConfig {
+    public actual val isDebug: Boolean
+        // TODO: need to determine a good way to set this on JVM presuming we don't want to bundle BuildKonfig in the
+        //  library.
+        get() = true
+}

--- a/core/src/jvmMain/kotlin/com/powersync/DatabaseDriverFactory.jvm.kt
+++ b/core/src/jvmMain/kotlin/com/powersync/DatabaseDriverFactory.jvm.kt
@@ -1,0 +1,50 @@
+package com.powersync
+
+import app.cash.sqldelight.async.coroutines.synchronous
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import com.powersync.db.internal.InternalSchema
+import java.util.Properties
+import kotlinx.coroutines.CoroutineScope
+
+@Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+public actual class DatabaseDriverFactory {
+    private var driver: PsSqlDriver? = null
+    private external fun setupSqliteBinding()
+
+    @Suppress("unused")
+    private fun onTableUpdate(tableName: String) {
+        driver?.updateTable(tableName)
+    }
+
+    @Suppress("unused")
+    private fun onTransactionCommit(success: Boolean) {
+        driver?.also { driver ->
+            if (success) {
+                driver.fireTableUpdates()
+            } else {
+                driver.clearTableUpdates()
+            }
+        }
+    }
+
+    public actual fun createDriver(
+        scope: CoroutineScope,
+        dbFilename: String
+    ): PsSqlDriver {
+        val schema = InternalSchema.synchronous()
+        this.driver = PsSqlDriver(
+            scope = scope,
+            driver = JdbcSqliteDriver("jdbc:sqlite:$dbFilename", Properties(), schema)
+        )
+        setupSqliteBinding()
+        return this.driver as PsSqlDriver
+    }
+
+    public companion object {
+        init {
+            // There is presumably a better way to load the library from the jar.
+            @Suppress("UnsafeDynamicallyLoadedCode")
+            System.load(OSXLibraryLoader().loadLibraryFromResources())
+        }
+    }
+}

--- a/core/src/jvmMain/kotlin/com/powersync/LibraryLoader.kt
+++ b/core/src/jvmMain/kotlin/com/powersync/LibraryLoader.kt
@@ -1,0 +1,38 @@
+package com.powersync
+
+import com.powersync.LibraryLoader.Companion.SQLITE_BINARY_FILENAME
+import java.io.File
+import java.io.InputStream
+
+private interface LibraryLoader {
+    companion object {
+        const val SQLITE_BINARY_FILENAME: String = "libpowersync-sqlite"
+    }
+
+    fun loadLibraryFromResources(): String
+
+    fun createTempFile(prefix: String, suffix: String): File {
+        val dir = System.getProperty("java.io.tmpdir")
+        return File.createTempFile(prefix, suffix, File(dir))
+    }
+}
+
+// TODO: Need to create and test implementations of this for windows/linux, or even better implement a cleaner
+//  of extracting the shared library.
+public class OSXLibraryLoader : LibraryLoader {
+    override fun loadLibraryFromResources(): String {
+        val path = "/$SQLITE_BINARY_FILENAME.dylib"
+        val tempFile = createTempFile(SQLITE_BINARY_FILENAME, ".dylib")
+        tempFile.deleteOnExit()
+
+        val inputStream: InputStream = LibraryLoader::class.java.getResourceAsStream(path)
+            ?: throw IllegalArgumentException("File $path not found in resources")
+        inputStream.use { input ->
+            tempFile.outputStream().use { output ->
+                input.copyTo(output)
+            }
+        }
+
+        return tempFile.absolutePath
+    }
+}

--- a/demos/hello-powersync/composeApp/build.gradle.kts
+++ b/demos/hello-powersync/composeApp/build.gradle.kts
@@ -14,6 +14,8 @@ plugins {
 kotlin {
     androidTarget()
 
+    jvm()
+
 //    iosX64() // uncomment to enable iOS x64
     iosArm64()
     iosSimulatorArm64()

--- a/demos/hello-powersync/desktop/build.gradle.kts
+++ b/demos/hello-powersync/desktop/build.gradle.kts
@@ -1,0 +1,28 @@
+import org.jetbrains.compose.desktop.application.dsl.TargetFormat
+
+plugins {
+    // Gradle complains when I attempt to re-use the plugin definition from the project toml. Something to do
+    // with the way the sonatype module is set up I presume. Need to figure this out before merge
+    id("org.jetbrains.kotlin.jvm")
+    alias(projectLibs.plugins.jetbrainsCompose)
+}
+
+dependencies {
+    implementation(project(":composeApp"))
+    implementation(compose.desktop.currentOs)
+}
+
+group = "com.powersync"
+version = "1.0.0"
+
+compose.desktop {
+    application {
+        mainClass = "com.powersync.demos.MainKt"
+
+        nativeDistributions {
+            targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
+            packageName = "PowerSync Demo"
+            packageVersion = project.version as String
+        }
+    }
+}

--- a/demos/hello-powersync/desktop/src/main/kotlin/com/powersync/demos/Main.kt
+++ b/demos/hello-powersync/desktop/src/main/kotlin/com/powersync/demos/Main.kt
@@ -1,0 +1,15 @@
+package com.powersync.demos
+
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Window
+import androidx.compose.ui.window.application
+import androidx.compose.ui.window.rememberWindowState
+
+fun main() = application {
+    val windowState = rememberWindowState(size = DpSize(1200.dp, 900.dp))
+
+    Window(state = windowState, onCloseRequest = ::exitApplication, title = "PowerSync Demo") {
+        App()
+    }
+}

--- a/demos/hello-powersync/settings.gradle.kts
+++ b/demos/hello-powersync/settings.gradle.kts
@@ -28,6 +28,7 @@ dependencyResolutionManagement {
 rootProject.name = "hello-powersync"
 
 include(":composeApp")
+include(":desktop")
 
 includeBuild("../..") {
     dependencySubstitution {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -72,6 +72,7 @@ ktor-client-contentnegotiation = { module = "io.ktor:ktor-client-content-negotia
 ktor-serialization-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 
+sqldelight-driver-desktop = { module = "app.cash.sqldelight:sqlite-driver", version.ref ="sqlDelight" }
 sqldelight-driver-ios = { module = "app.cash.sqldelight:native-driver", version.ref = "sqlDelight" }
 sqldelight-driver-android = { module = "app.cash.sqldelight:android-driver", version.ref = "sqlDelight" }
 requery-sqlite-android = { module = "com.github.requery:sqlite-android", version.ref = "sqlite-android" }

--- a/persistence/build.gradle.kts
+++ b/persistence/build.gradle.kts
@@ -12,6 +12,7 @@ kotlin {
     iosX64()
     iosArm64()
     iosSimulatorArm64()
+    jvm()
 
     explicitApi()
 
@@ -29,6 +30,10 @@ kotlin {
 
         iosMain.dependencies {
             api(libs.sqldelight.driver.ios)
+        }
+
+        jvmMain.dependencies {
+            implementation(libs.sqldelight.driver.desktop)
         }
     }
 }


### PR DESCRIPTION
Currently non-functional and only tested on OSX. I've not much experience bundling native libs so probably there is convention errors and hackiness that needs to be cleaned up with the build/make/gradle configs and the library loader.

Notes:
 - Currently crashes on start up with `[SQLITE_ERROR] SQL error or missing database (no such function: powersync_rs_version)`, guessing this is because we need a way to support extensions for the JVM driver. Is this handled by requery on Android?
 - Library loader is (hackily?) just pulling the shared library out to a temporary file, worth exploring other options.
  
 TODOs:
-  [ ] Didn't implement a way to determine if debug/release build yet
 - [ ] `sqlight_bindings.cpp` is copy/pasta from Android, would be good to pull it up so it can be shared 
 - [ ] No logic for storing the database in a shared user folder yet, when run from Android Studio the database is just dumped in the build folder

Usage:
 - Noted above, Windows/Linux will require at least implementing a library loader with the appropriate shared library extension.
 - Gradle Sync 
 - Install locally:
   - Disable release signing (`RELEASE_SIGNING_ENABLED=false`)
   - Run `publishToMavenLocal` task 
 - Open `powersync-hello` and create a Gradle run configuration
    - Select the `hello-powersync:desktop` module 
    - Set the Run field to `run -DmainClass=com.powersync.demo.MainKt`
 - Run the new config

Expect the app to crash with the missing `powersync_rs_version` function error