### PR TITLE
fix: credentials not invalidating on disconnect

### DIFF
--- a/core/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
@@ -256,13 +256,20 @@ internal class PowerSyncDatabaseImpl(
     }
 
     override suspend fun disconnect() {
-        if (syncJob != null && uploadJob != null && syncJob!!.isActive && uploadJob!!.isActive) {
-            //Wait for jobs to finish and then cancel with a CancellationException
+        if (syncJob != null && syncJob!!.isActive) {
             syncJob?.cancelAndJoin()
-            uploadJob?.cancelAndJoin()
-            syncStream = null
-            currentStatus.update(connected = false, connecting = false)
         }
+
+        if (uploadJob != null && uploadJob!!.isActive) {
+            uploadJob?.cancelAndJoin()
+        }
+
+        if(syncStream != null) {
+            syncStream?.invalidateCredentials()
+            syncStream = null
+        }
+
+        currentStatus.update(connected = false, connecting = false)
     }
 
     override suspend fun disconnectAndClear(clearLocal: Boolean) {

--- a/core/src/commonMain/kotlin/com/powersync/sync/SyncStream.kt
+++ b/core/src/commonMain/kotlin/com/powersync/sync/SyncStream.kt
@@ -77,6 +77,10 @@ internal class SyncStream(
         }
     }
 
+    fun invalidateCredentials() {
+        connector.invalidateCredentials()
+    }
+
 
     suspend fun streamingSync() {
         var invalidCredentials = false


### PR DESCRIPTION
## Description
Stale credentials are being kept on disconnect.

## Work Done
Add `invalidateCredentials` to the `disconnect` function so that stale credentials are cleared when `disconnect` is called which should happen during `signOut`. 

## Video
https://github.com/user-attachments/assets/69d0d748-54f5-4d3d-ab84-31c0bc31f75c

