### PR TITLE
chore: update delays

### DIFF
--- a/core/src/commonMain/kotlin/com/powersync/PowerSyncDatabase.kt
+++ b/core/src/commonMain/kotlin/com/powersync/PowerSyncDatabase.kt
@@ -27,14 +27,14 @@ public interface PowerSyncDatabase : Queries {
      *
      *  The connection is automatically re-opened if it fails for any reason.
      *
-     *  Use @param [crudThrottleMs] to specify the time between CRUD operations. Defaults to 100ms.
-     *  Use @param [retryDelayMs] to specify the delay between retries after failure. Defaults to 1000ms.
+     *  Use @param [crudThrottleMs] to specify the time between CRUD operations. Defaults to 1000ms.
+     *  Use @param [retryDelayMs] to specify the delay between retries after failure. Defaults to 5000ms.
      *
      *  TODO: Internal Team - Status changes are reported on [statusStream].
      */
 
-    public suspend fun connect(connector: PowerSyncBackendConnector, crudThrottleMs: Long = 100L,
-                               retryDelayMs: Long = 1000L)
+    public suspend fun connect(connector: PowerSyncBackendConnector, crudThrottleMs: Long = 1000L,
+                               retryDelayMs: Long = 5000L)
 
 
     /**

--- a/core/src/commonMain/kotlin/com/powersync/sync/SyncStream.kt
+++ b/core/src/commonMain/kotlin/com/powersync/sync/SyncStream.kt
@@ -40,7 +40,7 @@ internal class SyncStream(
     private val bucketStorage: BucketStorage,
     private val connector: PowerSyncBackendConnector,
     private val uploadCrud: suspend () -> Unit,
-    private val retryDelayMs: Long = 1000L,
+    private val retryDelayMs: Long = 5000L,
     private val logger: Logger
 ) {
     private var isUploadingCrud = AtomicBoolean(false)


### PR DESCRIPTION
## Description
Make delays conform to other SDK's

## Work Done
Changed `crudThrottleMs` and `retryDelayMs` to match SDKs, i.e. 1000ms and 5000ms respectively. 