### PR TITLE
fix: deletes not pulling through to sqlite and demo improvements

### DIFF
--- a/core/src/commonMain/kotlin/com/powersync/sync/SyncStream.kt
+++ b/core/src/commonMain/kotlin/com/powersync/sync/SyncStream.kt
@@ -271,7 +271,7 @@ internal class SyncStream(
             )
 
             isStreamingSyncData(obj) -> return handleStreamingSyncData(obj, state)
-            isStreamingKeepAlive(obj) -> return handleStreamingKeepalive(obj, state)
+            isStreamingKeepAlive(obj) -> return handleStreamingKeepAlive(obj, state)
             else -> {
                 logger.w { "Unhandled instruction $jsonString" }
                 return state
@@ -390,7 +390,7 @@ internal class SyncStream(
         return state
     }
 
-    private suspend fun handleStreamingKeepalive(
+    private suspend fun handleStreamingKeepAlive(
         jsonObj: JsonObject,
         state: SyncStreamState
     ): SyncStreamState {

--- a/demos/supabase-todolist/shared/src/commonMain/kotlin/com/powersync/demos/App.kt
+++ b/demos/supabase-todolist/shared/src/commonMain/kotlin/com/powersync/demos/App.kt
@@ -72,6 +72,10 @@ fun App(factory: DatabaseDriverFactory, modifier: Modifier = Modifier) {
 
     when (currentScreen) {
         is Screen.Home -> {
+            if(authState == AuthState.SignedOut) {
+                navController.navigate(Screen.SignIn)
+            }
+
             val handleOnItemClicked = { item: ListItem ->
                 lists.value.onItemClicked(item)
                 navController.navigate(Screen.Todos)

--- a/demos/supabase-todolist/shared/src/commonMain/kotlin/com/powersync/demos/Auth.kt
+++ b/demos/supabase-todolist/shared/src/commonMain/kotlin/com/powersync/demos/Auth.kt
@@ -28,13 +28,14 @@ internal class AuthViewModel(
     init {
         viewModelScope.launch {
             supabase.sessionStatus.collect() {
-                when(it) {
+                when (it) {
                     is SessionStatus.Authenticated -> {
                         _authState.value = AuthState.SignedIn
                         _userId.value = it.session.user?.id
                         db.connect(supabase)
                         navController.navigate(Screen.Home)
                     }
+
                     SessionStatus.LoadingFromStorage -> Logger.e("Loading from storage")
                     SessionStatus.NetworkError -> Logger.e("Network error")
                     is SessionStatus.NotAuthenticated -> {
@@ -47,23 +48,22 @@ internal class AuthViewModel(
         }
     }
 
-    fun signIn(email: String, password: String) {
-        viewModelScope.launch {
-            supabase.login(email, password)
-            _authState.value = AuthState.SignedIn
-        }
+    suspend fun signIn(email: String, password: String) {
+        supabase.login(email, password)
+        _authState.value = AuthState.SignedIn
     }
 
-    fun signUp(email: String, password: String) {
-        viewModelScope.launch {
-            supabase.signUp(email, password)
-            _authState.value = AuthState.SignedIn
-        }
+    suspend fun signUp(email: String, password: String) {
+        supabase.signUp(email, password)
+        _authState.value = AuthState.SignedIn
     }
 
-    fun signOut() {
-        viewModelScope.launch {
+    suspend fun signOut() {
+        try {
             supabase.signOut()
+        } catch (e: Exception) {
+            Logger.e("Error signing out: $e")
+        } finally {
             _authState.value = AuthState.SignedOut
         }
     }

--- a/demos/supabase-todolist/shared/src/commonMain/kotlin/com/powersync/demos/screens/SignInScreen.kt
+++ b/demos/supabase-todolist/shared/src/commonMain/kotlin/com/powersync/demos/screens/SignInScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.unit.dp
 import com.powersync.demos.AuthViewModel
 import com.powersync.demos.NavController
 import com.powersync.demos.Screen
+import io.github.jan.supabase.exceptions.BadRequestRestException
 import kotlinx.coroutines.launch
 
 @Composable
@@ -31,7 +32,11 @@ internal fun SignInScreen(
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        Text("Sign In", style = MaterialTheme.typography.h4, modifier = Modifier.padding(bottom = 32.dp))
+        Text(
+            "Sign In",
+            style = MaterialTheme.typography.h4,
+            modifier = Modifier.padding(bottom = 32.dp)
+        )
 
         TextField(
             value = email,
@@ -68,7 +73,11 @@ internal fun SignInScreen(
                     try {
                         authViewModel.signIn(email, password)
                     } catch (e: Exception) {
-                        errorMessage = e.message ?: "An error occurred during sign-in"
+                        if (e is BadRequestRestException) {
+                            errorMessage = "Invalid email or password"
+                        } else {
+                            errorMessage = e.message ?: "An error occurred during sign-in"
+                        }
                     } finally {
                         isLoading = false
                     }


### PR DESCRIPTION
## Description
Deletes from external DB (e.g. supabase) were not being propagated to the SQLite DB. Also made some improvements to the demo for sign-in and error handling.

## Work Done
* Updated `deleteBucket` method so that syncing deletes now works as expected
* Renamed `handleStreamingKeepalive` to `handleStreamingKeepAlive`
* Improved demo

## Video
https://github.com/user-attachments/assets/47f3fe7e-09ad-4c0f-abc4-4c4b5ff76afd


