### PR TITLE
fix: handle null values in opData

### DIFF
--- a/core/src/commonMain/kotlin/com/powersync/db/crud/CrudEntry.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/crud/CrudEntry.kt
@@ -1,6 +1,7 @@
 package com.powersync.db.crud
 
 import com.powersync.utils.JsonUtil
+import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 
@@ -51,7 +52,7 @@ public data class CrudEntry(
      *
      * For DELETE, this is null.
      */
-    val opData: Map<String, String>?
+    val opData: Map<String, String?>?
 ) {
     public companion object {
         public fun fromRow(row: CrudRow): CrudEntry {
@@ -60,7 +61,12 @@ public data class CrudEntry(
                 id = data["id"]!!.jsonPrimitive.content,
                 clientId = row.id.toInt(),
                 op = UpdateType.fromJsonChecked(data["op"]!!.jsonPrimitive.content),
-                opData = data["data"]?.jsonObject?.mapValues { it.value.jsonPrimitive.content },
+                opData = data["data"]?.jsonObject?.mapValues { (_, value) ->
+                    when {
+                        value.jsonPrimitive.contentOrNull != null -> value.jsonPrimitive.content
+                        else -> null
+                    }
+                },
                 table = data["type"]!!.jsonPrimitive.content,
                 transactionId = row.txId,
             )

--- a/core/src/commonMain/kotlin/com/powersync/db/crud/CrudEntry.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/crud/CrudEntry.kt
@@ -62,10 +62,7 @@ public data class CrudEntry(
                 clientId = row.id.toInt(),
                 op = UpdateType.fromJsonChecked(data["op"]!!.jsonPrimitive.content),
                 opData = data["data"]?.jsonObject?.mapValues { (_, value) ->
-                    when {
-                        value.jsonPrimitive.contentOrNull != null -> value.jsonPrimitive.content
-                        else -> null
-                    }
+                    value.jsonPrimitive.contentOrNull
                 },
                 table = data["type"]!!.jsonPrimitive.content,
                 transactionId = row.txId,


### PR DESCRIPTION
## Description
An issue arose when we wanted to change a value from a non-null type to null in `uploadData` function. This was a result of opData always returning strings and therefore returning `"null"` and not `null`. The `uploadData` function tried to upload data to the postgres db which would result in for example:

```bash
Data upload error - retrying last entry: CrudEntry<3/3 PATCH todos/d6b6d112-e779-4389-a7b4-34c45808ecdc {completed=0, completed_at=null, completed_by=null}>, io.github.jan.supabase.exceptions.BadRequestRestException: invalid input syntax for type timestamp with time zone: "null"
```

## Work Done
Added a case to handle `null` values in `opData`.

## Video
Video shows values returning true when not null and false when null in the console. Also no errors are shown where previously the error above would be shown.

https://github.com/user-attachments/assets/a408b203-df52-4c55-a20b-e0320d5d95ba

