### PR TITLE
chore: use callback in transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,8 +238,8 @@ The `execute` method executes a write query (INSERT, UPDATE, DELETE) and returns
 
 ```kotlin
 suspend fun insertCustomer(name: String, email: String) {
-    database.writeTransaction {
-        database.execute(
+    database.writeTransaction { tx ->
+        tx.execute(
             sql = "INSERT INTO customers (id, name, email) VALUES (uuid(), ?, ?)",
             parameters = listOf(name, email)
         )
@@ -263,8 +263,8 @@ suspend fun deleteCustomer(id: String? = null) {
             }
         ) ?: return
 
-    database.writeTransaction {
-        database.execute(
+    database.writeTransaction { tx ->
+        tx.execute(
             sql = "DELETE FROM customers WHERE id = ?",
             parameters = listOf(targetId)
         )

--- a/core/src/commonMain/kotlin/com/powersync/db/Queries.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/Queries.kt
@@ -2,6 +2,7 @@ package com.powersync.db
 
 import app.cash.sqldelight.SuspendingTransactionWithReturn
 import app.cash.sqldelight.db.SqlCursor
+import com.powersync.db.internal.PowerSyncTransaction
 import kotlinx.coroutines.flow.Flow
 
 public interface Queries {
@@ -49,7 +50,7 @@ public interface Queries {
         mapper: (SqlCursor) -> RowType
     ): Flow<List<RowType>>
 
-    public suspend fun <R> writeTransaction(body: suspend SuspendingTransactionWithReturn<R>.() -> R): R
+    public suspend fun <R> writeTransaction(callback: suspend (PowerSyncTransaction) -> R): R
 
-    public suspend fun <R> readTransaction(body: suspend SuspendingTransactionWithReturn<R>.() -> R): R
+    public suspend fun <R> readTransaction(callback: suspend (PowerSyncTransaction) -> R): R
 }

--- a/core/src/commonMain/kotlin/com/powersync/db/internal/InternalDatabase.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/internal/InternalDatabase.kt
@@ -10,6 +10,7 @@ import app.cash.sqldelight.coroutines.mapToList
 import app.cash.sqldelight.db.QueryResult
 import app.cash.sqldelight.db.SqlCursor
 import app.cash.sqldelight.db.SqlPreparedStatement
+import com.powersync.PowerSyncDatabase
 import com.powersync.PsSqlDriver
 import com.powersync.db.Queries
 import com.powersync.persistence.PsDatabase
@@ -27,7 +28,7 @@ import kotlinx.serialization.encodeToString
 internal class PsInternalDatabase(val driver: PsSqlDriver, private val scope: CoroutineScope) :
     Queries {
 
-    private val transactor: PsDatabase = PsDatabase(driver)
+    val transactor: PsDatabase = PsDatabase(driver)
     val queries = transactor.powersyncQueries
 
     companion object {
@@ -158,12 +159,18 @@ internal class PsInternalDatabase(val driver: PsSqlDriver, private val scope: Co
         }
     }
 
-    override suspend fun <R> readTransaction(body: suspend SuspendingTransactionWithReturn<R>.() -> R): R {
-        return transactor.transactionWithResult(noEnclosing = true, body)
+    override suspend fun <R> readTransaction(callback: suspend (PowerSyncTransaction) -> R): R {
+        return transactor.transactionWithResult(noEnclosing = true) {
+            val transaction = generateTransaction()
+            callback(transaction)
+        }
     }
 
-    override suspend fun <R> writeTransaction(body: suspend SuspendingTransactionWithReturn<R>.() -> R): R {
-        return transactor.transactionWithResult(noEnclosing = true, body)
+    override suspend fun <R> writeTransaction(callback: suspend (PowerSyncTransaction) -> R): R {
+        return transactor.transactionWithResult(noEnclosing = true) {
+            val transaction = generateTransaction()
+            callback(transaction)
+        }
     }
 
     // Register callback for table updates
@@ -219,6 +226,41 @@ internal class PsInternalDatabase(val driver: PsSqlDriver, private val scope: Co
         ).executeAsList()
 
         return tableRows.toSet()
+    }
+
+    private fun generateTransaction(): PowerSyncTransaction {
+        val transaction = object : PowerSyncTransaction {
+            override suspend fun execute(sql: String, parameters: List<Any?>?): Long {
+                return this@PsInternalDatabase.execute(sql, parameters ?: emptyList())
+            }
+
+            override suspend fun <RowType : Any> get(
+                sql: String,
+                parameters: List<Any?>?,
+                mapper: (SqlCursor) -> RowType
+            ): RowType {
+                return this@PsInternalDatabase.get(sql, parameters ?: emptyList(), mapper)
+            }
+
+            override suspend fun <RowType : Any> getAll(
+                sql: String,
+                parameters: List<Any?>?,
+                mapper: (SqlCursor) -> RowType
+            ): List<RowType> {
+                return this@PsInternalDatabase.getAll(sql, parameters ?: emptyList(), mapper)
+            }
+
+            override suspend fun <RowType : Any> getOptional(
+                sql: String,
+                parameters: List<Any?>?,
+                mapper: (SqlCursor) -> RowType
+            ): RowType? {
+                return this@PsInternalDatabase.getOptional(sql, parameters ?: emptyList(), mapper)
+            }
+
+        }
+
+        return transaction
     }
 
     fun getExistingTableNames(tableGlob: String): List<String> {

--- a/core/src/commonMain/kotlin/com/powersync/db/internal/PowerSyncTransaction.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/internal/PowerSyncTransaction.kt
@@ -1,0 +1,25 @@
+package com.powersync.db.internal
+
+import app.cash.sqldelight.db.SqlCursor
+
+public interface PowerSyncTransaction {
+    public suspend fun execute(sql: String, parameters: List<Any?>? = listOf()): Long
+
+    public suspend fun <RowType : Any> getOptional(
+        sql: String,
+        parameters: List<Any?>? = listOf(),
+        mapper: (SqlCursor) -> RowType
+    ): RowType?
+
+    public suspend fun <RowType : Any> getAll(
+        sql: String,
+        parameters: List<Any?>? = listOf(),
+        mapper: (SqlCursor) -> RowType
+    ): List<RowType>
+
+    public suspend fun <RowType : Any> get(
+        sql: String,
+        parameters: List<Any?>? = listOf(),
+        mapper: (SqlCursor) -> RowType
+    ): RowType
+}

--- a/core/src/commonMain/kotlin/com/powersync/db/internal/PowerSyncTransactionFactory.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/internal/PowerSyncTransactionFactory.kt
@@ -1,0 +1,41 @@
+package com.powersync
+
+import app.cash.sqldelight.db.SqlCursor
+import com.powersync.db.internal.PowerSyncTransaction
+import com.powersync.db.internal.PsInternalDatabase
+
+internal fun PowerSyncTransaction(
+    internalDatabase: PsInternalDatabase,
+): PowerSyncTransaction {
+    val transaction = object : PowerSyncTransaction {
+
+        override suspend fun execute(sql: String, parameters: List<Any?>?): Long {
+            return internalDatabase.execute(sql, parameters ?: emptyList())
+        }
+
+        override suspend fun <RowType : Any> get(
+            sql: String,
+            parameters: List<Any?>?,
+            mapper: (SqlCursor) -> RowType
+        ): RowType {
+            return internalDatabase.get(sql, parameters ?: emptyList(), mapper)
+        }
+
+        override suspend fun <RowType : Any> getAll(
+            sql: String,
+            parameters: List<Any?>?,
+            mapper: (SqlCursor) -> RowType
+        ): List<RowType> {
+            return internalDatabase.getAll(sql, parameters ?: emptyList(), mapper)
+        }
+         override suspend fun <RowType : Any> getOptional(
+             sql: String,
+             parameters: List<Any?>?,
+             mapper: (SqlCursor) -> RowType
+         ): RowType? {
+             return internalDatabase.getOptional(sql, parameters ?: emptyList(), mapper)
+         }
+    }
+
+    return transaction
+}

--- a/demos/hello-powersync/composeApp/src/commonMain/kotlin/com/powersync/demos/PowerSync.kt
+++ b/demos/hello-powersync/composeApp/src/commonMain/kotlin/com/powersync/demos/PowerSync.kt
@@ -46,8 +46,8 @@ class PowerSync(
     }
 
     suspend fun createUser(name: String, email: String) {
-        database.writeTransaction {
-            database.execute(
+        database.writeTransaction { tx ->
+            tx.execute(
                 "INSERT INTO customers (id, name, email) VALUES (uuid(), ?, ?)",
                 listOf(name, email)
             )
@@ -61,8 +61,8 @@ class PowerSync(
             })
             ?: return
 
-        database.writeTransaction {
-            database.execute("DELETE FROM customers WHERE id = ?", listOf(targetId))
+        database.writeTransaction { tx ->
+            tx.execute("DELETE FROM customers WHERE id = ?", listOf(targetId))
         }
     }
 }

--- a/demos/supabase-todolist/shared/src/commonMain/kotlin/com/powersync/demos/powersync/List.kt
+++ b/demos/supabase-todolist/shared/src/commonMain/kotlin/com/powersync/demos/powersync/List.kt
@@ -38,9 +38,9 @@ internal class ListContent(
 
     fun onItemDeleteClicked(item: ListItem) {
         runBlocking {
-            db.writeTransaction {
-                db.execute("DELETE FROM $LISTS_TABLE WHERE id = ?", listOf(item.id))
-                db.execute("DELETE FROM $TODOS_TABLE WHERE list_id = ?", listOf(item.id))
+            db.writeTransaction { tx ->
+                tx.execute("DELETE FROM $LISTS_TABLE WHERE id = ?", listOf(item.id))
+                tx.execute("DELETE FROM $TODOS_TABLE WHERE list_id = ?", listOf(item.id))
             }
         }
     }
@@ -49,8 +49,8 @@ internal class ListContent(
         if (_inputText.value.isBlank()) return
 
         runBlocking {
-            db.writeTransaction {
-                db.execute(
+            db.writeTransaction { tx ->
+                tx.execute(
                     "INSERT INTO $LISTS_TABLE (id, created_at, name, owner_id) VALUES (uuid(), datetime(), ?, ?)",
                     listOf(_inputText.value, userId)
                 )

--- a/demos/supabase-todolist/shared/src/commonMain/kotlin/com/powersync/demos/powersync/Todo.kt
+++ b/demos/supabase-todolist/shared/src/commonMain/kotlin/com/powersync/demos/powersync/Todo.kt
@@ -60,8 +60,8 @@ internal class Todo(
 
     fun onItemDeleteClicked(item: TodoItem) {
         viewModelScope.launch {
-            db.writeTransaction {
-                db.execute("DELETE FROM $TODOS_TABLE WHERE id = ?", listOf(item.id))
+            db.writeTransaction { tx ->
+                tx.execute("DELETE FROM $TODOS_TABLE WHERE id = ?", listOf(item.id))
             }
         }
     }
@@ -74,8 +74,8 @@ internal class Todo(
         }
 
         viewModelScope.launch {
-            db.writeTransaction {
-                db.execute(
+            db.writeTransaction { tx ->
+                tx.execute(
                     "INSERT INTO $TODOS_TABLE (id, created_at, created_by, description, list_id) VALUES (uuid(), datetime(), ?, ?, ?)",
                     listOf(userId, _inputText.value, listId)
                 )
@@ -117,8 +117,8 @@ internal class Todo(
         viewModelScope.launch {
             val updatedItem = transformer(item)
             Logger.i("Updating item: $updatedItem")
-            db.writeTransaction {
-                db.execute(
+            db.writeTransaction { tx ->
+                tx.execute(
                     "UPDATE $TODOS_TABLE SET description = ?, completed = ?, completed_by = ?, completed_at = ? WHERE id = ?",
                     listOf(updatedItem.description, updatedItem.completed, updatedItem.completedBy, updatedItem.completedAt, item.id)
                 )


### PR DESCRIPTION
## Description
Adopt callback pattern for `readTransaction` and `writeTransaction`. 

## Work Done
Changed `readTransaction` and `writeTransaction` functionality to use a callback such that users can now use for example
db.writeTransaction { tx ->
  tx.execute()
  tx.get()
  ...
}

## Video
https://github.com/user-attachments/assets/75720202-95f3-45eb-b939-cce6bde63cff

