### PR TITLE
fix: required powersync sqlite core version not set

### DIFF
--- a/demos/supabase-todolist/shared/build.gradle.kts
+++ b/demos/supabase-todolist/shared/build.gradle.kts
@@ -26,6 +26,7 @@ kotlin {
         ios.deploymentTarget = "14.1"
         podfile = project.file("../iosApp/Podfile")
         pod("powersync-sqlite-core") {
+            version = "0.2.1"
             linkOnly = true
         }
 


### PR DESCRIPTION
## Description
If a user has an old `Podfile.lock` with a `powersync-sqlite-core` version that is less than 0.2.0 they will see an error as we now require them to use a version of `powersync-sqlite-core` > 0.2.0.

## Work Done
* Added a version in cocoapods section of build.gradle.kts pod so that users will be required to upgrade their `powersync-sqlite-core` pod. The downside of this is that we can only set exact values. Therefore we will need to update this value in future. However, we could remove it once we are sure all users are using a version greater than 0.2.0 as it will then download the latest version.

## Screenshot
<img width="459" alt="image" src="https://github.com/user-attachments/assets/64725b4d-ae76-4d1e-802b-935d0d3da463">
