### PR TITLE
feat: add user agent

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,6 +1,7 @@
 import de.undercouch.gradle.tasks.download.Download
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 import com.powersync.plugins.sonatype.setupGithubRepository
+import com.codingfeline.buildkonfig.compiler.FieldSpec.Type.STRING
 
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
@@ -8,6 +9,7 @@ plugins {
     alias(libs.plugins.androidLibrary)
     alias(libs.plugins.mavenPublishPlugin)
     alias(libs.plugins.downloadPlugin)
+    alias(libs.plugins.buildKonfig)
     id("com.powersync.plugins.sonatype")
 }
 
@@ -161,6 +163,21 @@ android {
     }
 }
 
+buildkonfig {
+    packageName = "com.powersync.core"
+    defaultConfigs {
+        buildConfigField(STRING, "LIBRARY_VERSION", version.toString())
+        buildConfigField(STRING, "LIBRARY_NAME", "powersync-kotlin")
+    }
+    // This will be used to differentiate between the Swift and Kotlin SDKs
+    // TODO: Need to update publish plugin to publish individual modules
+    // then update build script to add -Pbuildkonfig.flavor=swift-sdk as a flag
+    // and implement that as its own github workflow
+    defaultConfigs("swift-sdk") {
+        buildConfigField(STRING, "LIBRARY_NAME", "powersync-swift")
+    }
+}
+
 
 afterEvaluate {
     val buildTasks = tasks.matching {
@@ -180,4 +197,3 @@ afterEvaluate {
 }
 
 setupGithubRepository()
-

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -171,8 +171,8 @@ buildkonfig {
     }
     // This will be used to differentiate between the Swift and Kotlin SDKs
     // TODO: Need to update publish plugin to publish individual modules
-    // then update build script to add -Pbuildkonfig.flavor=swift-sdk as a flag
-    // and implement that as its own github workflow
+    //       then update build script to add -Pbuildkonfig.flavor=swift-sdk as a flag
+    //       and implement that as its own github workflow
     defaultConfigs("swift-sdk") {
         buildConfigField(STRING, "LIBRARY_NAME", "powersync-swift")
     }

--- a/core/src/commonMain/kotlin/com/powersync/sync/SyncStream.kt
+++ b/core/src/commonMain/kotlin/com/powersync/sync/SyncStream.kt
@@ -8,6 +8,8 @@ import com.powersync.bucket.Checkpoint
 import com.powersync.bucket.WriteCheckpointResponse
 import co.touchlab.stately.concurrency.AtomicBoolean
 import com.powersync.connectors.PowerSyncBackendConnector
+import com.powersync.core.BuildKonfig.LIBRARY_VERSION
+import com.powersync.core.BuildKonfig.LIBRARY_NAME
 import com.powersync.utils.JsonUtil
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
@@ -164,6 +166,10 @@ internal class SyncStream(
         }
     }
 
+    private fun powerSyncUserAgent(): String {
+        return "$LIBRARY_NAME/$LIBRARY_VERSION"
+    }
+
     private suspend fun getWriteCheckpoint(): String {
         val credentials = connector.getCredentialsCached()
         require(credentials != null) { "Not logged in" }
@@ -174,6 +180,7 @@ internal class SyncStream(
             headers {
                 append(HttpHeaders.Authorization, "Token ${credentials.token}")
                 append("User-Id", credentials.userId ?: "")
+                append("User-Agent", powerSyncUserAgent())
             }
         }
         if (response.status.value == 401) {
@@ -200,6 +207,7 @@ internal class SyncStream(
             headers {
                 append(HttpHeaders.Authorization, "Token ${credentials.token}")
                 append("User-Id", credentials.userId ?: "")
+                append("User-Agent", powerSyncUserAgent())
             }
             timeout { socketTimeoutMillis = Long.MAX_VALUE }
             setBody(bodyJson)

--- a/core/src/commonMain/kotlin/com/powersync/sync/SyncStream.kt
+++ b/core/src/commonMain/kotlin/com/powersync/sync/SyncStream.kt
@@ -179,7 +179,6 @@ internal class SyncStream(
             contentType(ContentType.Application.Json)
             headers {
                 append(HttpHeaders.Authorization, "Token ${credentials.token}")
-                append("User-Id", credentials.userId ?: "")
                 append("User-Agent", powerSyncUserAgent())
             }
         }
@@ -206,7 +205,6 @@ internal class SyncStream(
             contentType(ContentType.Application.Json)
             headers {
                 append(HttpHeaders.Authorization, "Token ${credentials.token}")
-                append("User-Id", credentials.userId ?: "")
                 append("User-Agent", powerSyncUserAgent())
             }
             timeout { socketTimeoutMillis = Long.MAX_VALUE }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ kotlinx-datetime = "0.5.0"
 kotlinx-io = "0.3.0"
 ktor = "2.3.10"
 uuid = "0.8.2"
+buildKonfig = "0.15.1"
 powersync-core = "0.2.1"
 sqlite-android = "3.45.0"
 
@@ -107,6 +108,7 @@ sqldelight = { id = "app.cash.sqldelight", version.ref = "sqlDelight" }
 grammarKitComposer = { id = "com.alecstrong.grammar.kit.composer", version.ref = "grammerKit" }
 mavenPublishPlugin = { id = "com.vanniktech.maven.publish", version.ref = "maven-publish" }
 downloadPlugin = { id = "de.undercouch.download", version.ref = "download-plugin" }
+buildKonfig = { id = "com.codingfeline.buildkonfig", version.ref = "buildKonfig" }
 
 [bundles]
 sqldelight = [


### PR DESCRIPTION
## Description
Add `User-Agent` header to requests to identify the sdk being used. 

**Note:** Currently this will not differentiate based on the Kotlin or Swift SDK and will only show Kotlin SDK in the user agent. This is because we need to:
1. Update publish plugin to publish individual modules 
2. Create a separate build and publish github workflow for the Swift SDK  and add `-Pbuildkonfig.flavor=swift-sdk` as a flag.
3. This flag will then change the Library to reflect `powersync-swift` instead of `powersync-kotlin`

## Work Done
* Added the `User-Agent` header to requests
* Added BuildKonfig module which will be used to differentiate between Kotlin and Swift sdks.
* Removed `User-Id` header

## Testing
<img width="388" alt="image" src="https://github.com/user-attachments/assets/1f4dede5-2506-4048-8a7f-bbbde164e9e7">
