### PR TITLE
chore: add changes to disconnectAndClear

### DIFF
--- a/core/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
@@ -284,8 +284,8 @@ internal class PowerSyncDatabaseImpl(
     override suspend fun disconnectAndClear(clearLocal: Boolean) {
         disconnect()
 
-        this.writeTransaction { tx ->
-            tx.execute("select powersync_clear(?)", listOf(if(clearLocal) 1 else 0))
+        this.writeTransaction {
+            internalDb.queries.powersyncClear(if(clearLocal) "1" else "0").awaitAsOne()
         }
         currentStatus.update(lastSyncedAt = null, hasSynced = false)
     }

--- a/core/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
@@ -285,18 +285,9 @@ internal class PowerSyncDatabaseImpl(
         disconnect()
 
         this.writeTransaction { tx ->
-            tx.execute("DELETE FROM ${InternalTable.OPLOG}")
-            tx.execute("DELETE FROM ${InternalTable.CRUD}")
-            tx.execute("DELETE FROM ${InternalTable.BUCKETS}")
-            tx.execute("DELETE FROM ${InternalTable.UNTYPED}")
-
-            val tableGlob = if (clearLocal) "ps_data_*" else "ps_data__*"
-            val existingTableRows = internalDb.getExistingTableNames(tableGlob)
-
-            for (row in existingTableRows) {
-                tx.execute("DELETE FROM ${quoteIdentifier(row)}")
-            }
+            tx.execute("select powersync_clear(?)", listOf(if(clearLocal) 1 else 0))
         }
+        currentStatus.update(lastSyncedAt = null, hasSynced = false)
     }
 
     private suspend fun updateHasSynced() {

--- a/dialect/README.md
+++ b/dialect/README.md
@@ -1,0 +1,27 @@
+# SQLDelight Custom PowerSync Dialect
+
+This defines the custom PowerSync SQLite functions to be used in the `PowerSync.sq` file found in the `persistence` module.
+
+## Example
+```kotlin
+public class PowerSyncTypeResolver(private val parentResolver: TypeResolver) :
+    TypeResolver by SqliteTypeResolver(parentResolver) {
+    override fun functionType(functionExpr: SqlFunctionExpr): IntermediateType? {
+        when (functionExpr.functionName.text) {
+            "powersync_replace_schema" -> return IntermediateType(
+                PrimitiveType.TEXT
+            )
+        }
+        return parentResolver.functionType(functionExpr)
+    }
+}
+```
+
+allows
+
+```sql
+replaceSchema:
+SELECT powersync_replace_schema(?);
+```
+
+To be used in the `PowerSync.sq` file in the `persistence` module.

--- a/dialect/src/main/kotlin/com/powersync/sqlite/PowerSyncDialect.kt
+++ b/dialect/src/main/kotlin/com/powersync/sqlite/PowerSyncDialect.kt
@@ -16,7 +16,7 @@ public class PowerSyncTypeResolver(private val parentResolver: TypeResolver) :
     TypeResolver by SqliteTypeResolver(parentResolver) {
     override fun functionType(functionExpr: SqlFunctionExpr): IntermediateType? {
         when (functionExpr.functionName.text) {
-            "sqlite_version", "powersync_rs_version", "powersync_replace_schema" -> return IntermediateType(
+            "sqlite_version", "powersync_rs_version", "powersync_replace_schema", "powersync_clear" -> return IntermediateType(
                 PrimitiveType.TEXT
             )
         }

--- a/persistence/src/commonMain/sqldelight/com/persistence/Powersync.sq
+++ b/persistence/src/commonMain/sqldelight/com/persistence/Powersync.sq
@@ -8,6 +8,9 @@ SELECT powersync_rs_version();
 replaceSchema:
 SELECT powersync_replace_schema(?);
 
+powersyncClear:
+SELECT powersync_clear(?);
+
 -- CRUD operations
 hasCrud:
 SELECT 1 FROM ps_crud LIMIT 1;


### PR DESCRIPTION
## Description
Implement new `powersync_clear()` function and update hasSynced status in `disconnectAndClear`.

## Work Done
* Replaced old clearing implementation with the new `powersync_clear()` in `disconnectAndClear` function. This required a change to the `dialect` module to include `powersync_clear` as a valid type and the `PowerSync.sq` file used to load the custom PowerSync functions as queries in the `persistence` module.
* Added an update to the currentStatus to update `hasSynced` to `false` and `lastSynced` to `null`

## Video
https://github.com/user-attachments/assets/4324dfbe-fdb9-415d-95e8-ae1256ff248d

