### PR TITLE
chore(persistence): add minSdk

### DIFF
--- a/persistence/build.gradle.kts
+++ b/persistence/build.gradle.kts
@@ -54,6 +54,9 @@ android {
             buildConfigField("boolean", "DEBUG", "true")
         }
     }
+    defaultConfig {
+        minSdk = libs.versions.android.minSdk.get().toInt()
+    }
 
     namespace = "com.powersync.persistence"
     compileSdk = libs.versions.android.compileSdk.get().toInt()


### PR DESCRIPTION
## Description
Currently `persistence` module has no `minSdk` version set which results in an error being shown. This adds a minSdk version to the `build.gradle.kts` file of `persistence` module to avoid seeing this error.