### PR TITLE
chore: upgrade to kotlin 2.0.20

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ xcuserdata
 local.properties
 .idea
 .fleet
+.kotlin
 .DS_Store
 captures
 .externalNativeBuild

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     alias(libs.plugins.jetbrainsCompose) apply false
+    alias(libs.plugins.compose.compiler) apply false
     alias(libs.plugins.androidApplication) apply false
     alias(libs.plugins.androidLibrary) apply false
     alias(libs.plugins.kotlinMultiplatform) apply false

--- a/compose/build.gradle.kts
+++ b/compose/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.androidLibrary)
     alias(libs.plugins.jetbrainsCompose)
+    alias(libs.plugins.compose.compiler)
     id("com.powersync.plugins.sonatype")
 }
 

--- a/demos/hello-powersync/build.gradle.kts
+++ b/demos/hello-powersync/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(projectLibs.plugins.androidApplication) apply false
     alias(projectLibs.plugins.androidLibrary) apply false
     alias(projectLibs.plugins.jetbrainsCompose) apply false
+    alias(projectLibs.plugins.compose.compiler) apply false
     alias(projectLibs.plugins.kotlinMultiplatform) apply false
     alias(projectLibs.plugins.cocoapods) apply false
     alias(libs.plugins.buildKonfig) apply false

--- a/demos/hello-powersync/composeApp/build.gradle.kts
+++ b/demos/hello-powersync/composeApp/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     alias(projectLibs.plugins.cocoapods)
     alias(projectLibs.plugins.androidApplication)
     alias(projectLibs.plugins.jetbrainsCompose)
+    alias(projectLibs.plugins.compose.compiler)
     alias(projectLibs.plugins.skie)
     alias(libs.plugins.buildKonfig)
 }
@@ -38,8 +39,8 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             api("com.powersync:core")
-            api("com.powersync:connector-supabase")
-            api("com.powersync:compose")
+            implementation("com.powersync:connector-supabase")
+            implementation("com.powersync:compose")
             implementation(projectLibs.bundles.sqldelight)
             implementation(projectLibs.kotlinx.datetime)
             implementation(compose.runtime)
@@ -74,9 +75,6 @@ android {
     }
     buildFeatures {
         compose = true
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion = projectLibs.versions.compose.compiler.get()
     }
     packaging {
         resources {

--- a/demos/hello-powersync/composeApp/composeApp.podspec
+++ b/demos/hello-powersync/composeApp/composeApp.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |spec|
     spec.summary                  = 'A shared library for Hello PowerSync app'
     spec.vendored_frameworks      = 'build/cocoapods/framework/composeApp.framework'
     spec.libraries                = 'c++'
-    spec.ios.deployment_target = '15.2'
+    spec.ios.deployment_target    = '15.2'
     spec.dependency 'powersync-sqlite-core'
                 
     if !Dir.exist?('build/cocoapods/framework/composeApp.framework') || Dir.empty?('build/cocoapods/framework/composeApp.framework')
@@ -21,6 +21,10 @@ Pod::Spec.new do |spec|
 
         Alternatively, proper pod installation is performed during Gradle sync in the IDE (if Podfile location is set)"
     end
+                
+    spec.xcconfig = {
+        'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO',
+    }
                 
     spec.pod_target_xcconfig = {
         'KOTLIN_PROJECT_PATH' => ':composeApp',
@@ -46,5 +50,5 @@ Pod::Spec.new do |spec|
             SCRIPT
         }
     ]
-    spec.resources = ['build/compose/ios/composeApp/compose-resources']
+    spec.resources = ['build/compose/cocoapods/compose-resources']
 end

--- a/demos/hello-powersync/gradle/wrapper/gradle-wrapper.properties
+++ b/demos/hello-powersync/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/demos/hello-powersync/iosApp/Podfile.lock
+++ b/demos/hello-powersync/iosApp/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
   - composeApp (1.0.0):
     - powersync-sqlite-core
-  - powersync-sqlite-core (0.1.6)
+  - powersync-sqlite-core (0.2.1)
 
 DEPENDENCIES:
   - composeApp (from `../composeApp`)
@@ -15,8 +15,8 @@ EXTERNAL SOURCES:
     :path: "../composeApp"
 
 SPEC CHECKSUMS:
-  composeApp: d4907701ff82fa92100d8460385b83c9b30955ba
-  powersync-sqlite-core: 4c38c8f470f6dca61346789fd5436a6826d1e3dd
+  composeApp: d8d73ede600d0ced841c96b458570e50cad2d030
+  powersync-sqlite-core: 38ead13d8b21920cfbc79e9b3415b833574a506d
 
 PODFILE CHECKSUM: 4680f51fbb293d1385fb2467ada435cc1f16ab3d
 

--- a/demos/hello-powersync/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/demos/hello-powersync/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -105,8 +105,8 @@
 				7555FF77242A565900829871 /* Sources */,
 				7555FF79242A565900829871 /* Resources */,
 				EF8A45596C10845FBC80C40F /* Frameworks */,
-				CFB5C47A514C8D54DDE968FF /* [CP] Copy Pods Resources */,
 				BDEF1F2128374088F98D10FB /* [CP] Embed Pods Frameworks */,
+				35538324538A9B616ADCBF80 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -163,6 +163,23 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		35538324538A9B616ADCBF80 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-iosApp/Pods-iosApp-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-iosApp/Pods-iosApp-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-iosApp/Pods-iosApp-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		BDEF1F2128374088F98D10FB /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -178,23 +195,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-iosApp/Pods-iosApp-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		CFB5C47A514C8D54DDE968FF /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-iosApp/Pods-iosApp-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-iosApp/Pods-iosApp-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-iosApp/Pods-iosApp-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		FD6F5E7B50FDDEA472B254A2 /* [CP] Check Pods Manifest.lock */ = {

--- a/demos/supabase-todolist/androidApp/build.gradle.kts
+++ b/demos/supabase-todolist/androidApp/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     kotlin("multiplatform")
     id("com.android.application")
+    alias(libs.plugins.compose.compiler)
     id("org.jetbrains.compose")
 }
 

--- a/demos/supabase-todolist/build.gradle.kts
+++ b/demos/supabase-todolist/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.androidApplication) apply false
     alias(libs.plugins.androidLibrary) apply false
     alias(libs.plugins.jetbrainsCompose) apply false
+    alias(libs.plugins.compose.compiler) apply false
     alias(libs.plugins.kotlinMultiplatform) apply false
     alias(libs.plugins.cocoapods) apply false
 }

--- a/demos/supabase-todolist/desktopApp/build.gradle.kts
+++ b/demos/supabase-todolist/desktopApp/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.jetbrainsCompose)
+    alias(libs.plugins.compose.compiler)
 }
 
 kotlin {

--- a/demos/supabase-todolist/gradle/libs.versions.toml
+++ b/demos/supabase-todolist/gradle/libs.versions.toml
@@ -6,9 +6,7 @@ android-compileSdk = "34"
 java = "17"
 
 # Dependencies
-powersync-core = "0.2.1"
-
-kotlin = "1.9.23"
+kotlin = "2.0.20"
 coroutines = "1.8.0"
 kotlinx-datetime = "0.5.0"
 kotlinx-io = "0.3.0"
@@ -20,16 +18,14 @@ supabase = "2.3.1"
 junit = "4.13.2"
 
 compose = "1.6.11"
-compose-preview = "1.6.8"
-compose-compiler = "1.5.14"
+compose-preview = "1.7.2"
 
 # plugins
 android-gradle-plugin = "8.5.1"
-skie = "0.8.2"
 
 # Sample - Android
 androidx-core = "1.13.1"
-androidx-activity-compose = "1.9.1"
+androidx-activity-compose = "1.9.2"
 
 androidx-appcompat = "1.7.0"
 androidx-espresso-core = "3.6.1"
@@ -37,8 +33,6 @@ androidx-material = "1.12.0"
 androidx-test-junit = "1.2.1"
 
 [libraries]
-powersync-sqlite-core = { module = "co.powersync:powersync-sqlite-core", version.ref = "powersync-core" }
-
 test-junit = { group = "junit", name = "junit", version.ref = "junit" }
 test-junitKtx = { module = "androidx.test.ext:junit-ktx", version.ref = "androidx-test-junit" }
 test-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
@@ -66,7 +60,6 @@ androidx-activity-compose = { module = "androidx.activity:activity-compose", ver
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "androidx-espresso-core" }
 androidx-material = { group = "com.google.android.material", name = "material", version.ref = "androidx-material" }
 compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "compose-preview" }
-compose-compiler = { module = "androidx.compose.compiler:compiler", version.ref = "compose-compiler" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "android-gradle-plugin" }
@@ -74,7 +67,7 @@ androidLibrary = { id = "com.android.library", version.ref = "android-gradle-plu
 jetbrainsCompose = { id = "org.jetbrains.compose", version.ref = "compose" }
 cocoapods = { id = "org.jetbrains.kotlin.native.cocoapods", version.ref = "kotlin" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
-skie = { id = "co.touchlab.skie", version.ref = "skie" }
+compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 buildKonfig = { id = "com.codingfeline.buildkonfig", version.ref = "buildKonfig" }
 
 [bundles]

--- a/demos/supabase-todolist/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/demos/supabase-todolist/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -118,6 +118,7 @@
 				7555FF79242A565900829871 /* Resources */,
 				F85CB1118929364A9C6EFABC /* Frameworks */,
 				3C5ACF3A4AAFF294B2A5839B /* [CP] Embed Pods Frameworks */,
+				79E17356D7D971831C2A4119 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -190,7 +191,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd \"$SRCROOT/..\"\n./gradlew :shared:embedAndSignAppleFrameworkForXcode\n";
 		};
 		3C5ACF3A4AAFF294B2A5839B /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -229,6 +229,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		79E17356D7D971831C2A4119 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-iosApp/Pods-iosApp-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-iosApp/Pods-iosApp-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-iosApp/Pods-iosApp-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/demos/supabase-todolist/shared/build.gradle.kts
+++ b/demos/supabase-todolist/shared/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.androidLibrary)
     alias(libs.plugins.jetbrainsCompose)
+    alias(libs.plugins.compose.compiler)
     alias(libs.plugins.cocoapods)
     alias(libs.plugins.buildKonfig)
 }
@@ -38,8 +39,9 @@ kotlin {
     }
     sourceSets {
         commonMain.dependencies {
+            // Need to use api here otherwise Database driver can't be accessed
             api("com.powersync:core")
-            api("com.powersync:connector-supabase")
+            implementation("com.powersync:connector-supabase")
             implementation(libs.uuid)
             implementation(compose.runtime)
             implementation(compose.foundation)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,13 +3,13 @@
 android-minSdk = "24"
 android-targetSdk = "34"
 android-compileSdk = "34"
-configurationAnnotations = "0.8.2"
+configurationAnnotations = "0.8.4"
 java = "17"
 idea = "222.4459.24" # Flamingo | 2022.2.1 (see https://plugins.jetbrains.com/docs/intellij/android-studio-releases-list.html)
 
 # Dependencies
 kermit = "2.0.4"
-kotlin = "1.9.24"
+kotlin = "2.0.20"
 coroutines = "1.8.0"
 kotlinx-datetime = "0.5.0"
 kotlinx-io = "0.3.0"
@@ -24,30 +24,26 @@ supabase = "2.3.1"
 junit = "4.13.2"
 
 compose = "1.6.11"
-compose-preview = "1.6.8"
-compose-compiler = "1.5.14"
+compose-preview = "1.7.2"
 
 # plugins
 android-gradle-plugin = "8.5.1"
 kmmBridge = "0.5.7"
-skie = "0.8.2"
+skie = "0.9.0-RC.5"
 maven-publish = "0.27.0"
 download-plugin = "5.5.0"
 grammerKit = "0.1.12"
 
 # Sample - Android
 androidx-core = "1.13.1"
-androidx-activity-compose = "1.9.1"
+androidx-activity-compose = "1.9.2"
 
 androidx-appcompat = "1.7.0"
-androidx-constraintlayout = "2.1.4"
 androidx-espresso-core = "3.6.1"
 androidx-material = "1.12.0"
 androidx-test-junit = "1.2.1"
-org-jetbrains-kotlin-jvm = "1.9.22"
 
 [libraries]
-compose-compiler = { module = "androidx.compose.compiler:compiler", version.ref = "compose-compiler" }
 configuration-annotations = { module = "co.touchlab.skie:configuration-annotations", version.ref = "configurationAnnotations" }
 kermit = { module = "co.touchlab:kermit", version.ref = "kermit" }
 powersync-sqlite-core = { module = "co.powersync:powersync-sqlite-core", version.ref = "powersync-core" }
@@ -97,6 +93,7 @@ compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview"
 androidApplication = { id = "com.android.application", version.ref = "android-gradle-plugin" }
 androidLibrary = { id = "com.android.library", version.ref = "android-gradle-plugin" }
 jetbrainsCompose = { id = "org.jetbrains.compose", version.ref = "compose" }
+compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 cocoapods = { id = "org.jetbrains.kotlin.native.cocoapods", version.ref = "kotlin" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }


### PR DESCRIPTION
## Description
Kotlin 2.0.20 is out and fixes issues related to using Kotlin with XCode 16 which has required us upgrading from 1.9.24.

## Work Done
* Needed to add and use new compose compiler plugin (https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-compiler.html#migrating-a-compose-multiplatform-project)
* Removed `kotlinCompilerExtensionVersion` from `hello-powersync` as this is no longer required (https://android-developers.googleblog.com/2024/04/jetpack-compose-compiler-moving-to-kotlin-repository.html)
* Needed to move to SKIE `0.9.0-RC5` as this supports Kotlin 2.0.20
* Removed unused dependencies
* `hello-powersync` required a gradle upgrade to 8.7 in order to run
* Git Ignored `.kotlin` folders
* Changed from `api` to `implelementation` where possible in `demos`

## Testing
1. Ran both `supabase-todolist` and `hello-powersync` demos in Android and iOS and confirmed they still run 
2. Created a new XCFramework for PowerSync Swift SDK and used that in the Swift Kotlin Demo app