### PR TITLE
Feat/add wait for first sync

### DIFF
--- a/core/src/commonMain/kotlin/com/powersync/PowerSyncDatabase.kt
+++ b/core/src/commonMain/kotlin/com/powersync/PowerSyncDatabase.kt
@@ -23,6 +23,11 @@ public interface PowerSyncDatabase : Queries {
     public val currentStatus: SyncStatus
 
     /**
+     * Suspend function that resolves when the first sync has occurred
+     */
+    public suspend fun waitForFirstSync()
+
+    /**
      *  Connect to the PowerSync service, and keep the databases in sync.
      *
      *  The connection is automatically re-opened if it fails for any reason.

--- a/core/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
@@ -302,8 +302,6 @@ internal class PowerSyncDatabaseImpl(
                 val formattedDateTime = "${timestamp!!.replace(" ","T").toLocalDateTime()}Z"
                 val lastSyncedAt = Instant.parse(formattedDateTime)
                 currentStatus.update(hasSynced = hasSynced, lastSyncedAt = lastSyncedAt)
-                Logger.i("AFTER")
-                Logger.i(currentStatus.toString())
             }
         } catch (e: Exception) {
             if(e is NullPointerException) {
@@ -315,17 +313,11 @@ internal class PowerSyncDatabaseImpl(
     }
 
     override suspend fun waitForFirstSync() {
-        Logger.i("Waiting for first sync")
         if (currentStatus.hasSynced == true) {
-            Logger.i("Sync has happened")
             return
         }
 
-        Logger.i("Sync has not happened")
-
         currentStatus.asFlow().first { status ->
-            Logger.i("HERE")
-            Logger.i(currentStatus.toString())
             if (status.hasSynced == true) {
                 Logger.i("Sync has just completed")
                 true
@@ -333,8 +325,6 @@ internal class PowerSyncDatabaseImpl(
                 false
             }
         }
-        Logger.i("HELLO")
-
     }
 
     /**

--- a/core/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
@@ -318,12 +318,7 @@ internal class PowerSyncDatabaseImpl(
         }
 
         currentStatus.asFlow().first { status ->
-            if (status.hasSynced == true) {
-                Logger.i("Sync has just completed")
-                true
-            } else {
-                false
-            }
+            status.hasSynced == true
         }
     }
 

--- a/core/src/commonMain/kotlin/com/powersync/sync/SyncStatus.kt
+++ b/core/src/commonMain/kotlin/com/powersync/sync/SyncStatus.kt
@@ -150,7 +150,7 @@ public data class SyncStatus internal constructor(
         get() = data.downloadError
 
     override fun toString(): String {
-        return "SyncStatus(connected=$connected, connecting=$connecting, downloading=$downloading, uploading=$uploading, lastSyncedAt=$lastSyncedAt, hasSynced: $hasSynced, error=$anyError)"
+        return "SyncStatus(connected=$connected, connecting=$connecting, downloading=$downloading, uploading=$uploading, lastSyncedAt=$lastSyncedAt, hasSynced=$hasSynced, error=$anyError)"
     }
 
     public companion object {


### PR DESCRIPTION
## Description
Add public `waitForFirstSync` function that will only resolve after the first sync

## Work Done
* Added `waitForFirstSync` function to `PowerSyncDatabaseImpl` and `PowerSyncDatabase` interface
* Fixed issue in SyncStatus output where a colon should have been an equals sign

## Testing
Added `waitForFirstSync` before and after `updateHasSynced` function. 
1. If it is placed before then it stops the app as hasSynced is never updated. 
2. If its placed afterwards then the app continues as expected.