### PR TITLE
fix: sync status not updating correctly

### DIFF
--- a/core/src/commonMain/kotlin/com/powersync/sync/SyncStatus.kt
+++ b/core/src/commonMain/kotlin/com/powersync/sync/SyncStatus.kt
@@ -98,26 +98,26 @@ public data class SyncStatus internal constructor(
      * Updates the internal sync status indicators and emits Flow updates
      */
     internal fun update(
-        connected: Boolean = data.connected,
-        connecting: Boolean = data.connecting,
-        downloading: Boolean = data.downloading,
-        uploading: Boolean = data.uploading,
-        hasSynced: Boolean? = data.hasSynced,
-        lastSyncedAt: Instant? = data.lastSyncedAt,
-        uploadError: Any? = data.uploadError,
-        downloadError: Any? = data.downloadError,
-        clearUploadError: Boolean? = false,
-        clearDownloadError: Boolean? = false,
+        connected: Boolean? = null,
+        connecting: Boolean? = null,
+        downloading: Boolean? = null,
+        uploading: Boolean? = null,
+        hasSynced: Boolean? = null,
+        lastSyncedAt: Instant? = null,
+        uploadError: Any? = null,
+        downloadError: Any? = null,
+        clearUploadError: Boolean = false,
+        clearDownloadError: Boolean = false,
     ) {
         data = data.copy(
-            connected = connected,
-            connecting = connecting,
-            downloading = downloading,
-            uploading = uploading,
-            lastSyncedAt = lastSyncedAt,
-            hasSynced = hasSynced,
-            uploadError = if (clearUploadError == true) null else uploadError,
-            downloadError = if (clearDownloadError == true) null else downloadError,
+            connected = connected ?: data.connected,
+            connecting = connecting ?: data.connecting,
+            downloading = downloading ?: data.downloading,
+            uploading = uploading ?: data.uploading,
+            lastSyncedAt = lastSyncedAt ?: data.lastSyncedAt,
+            hasSynced = hasSynced ?: data.hasSynced,
+            uploadError = if (clearUploadError) null else uploadError,
+            downloadError = if (clearDownloadError) null else downloadError,
         )
         stateFlow.value = data
     }

--- a/demos/supabase-todolist/shared/src/commonMain/kotlin/com/powersync/demos/App.kt
+++ b/demos/supabase-todolist/shared/src/commonMain/kotlin/com/powersync/demos/App.kt
@@ -5,6 +5,7 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -35,8 +36,9 @@ fun App(factory: DatabaseDriverFactory, modifier: Modifier = Modifier) {
         )
     }
     val db = remember { PowerSyncDatabase(factory, schema) }
-    val syncStatus = db.currentStatus
-    val status = syncStatus.asFlow().collectAsState(initial = null)
+    val status = db.currentStatus.asFlow().collectAsState(initial = null)
+    val hasSynced by remember { derivedStateOf { status.value?.hasSynced } }
+
 
     val navController = remember { NavController(Screen.Home) }
     val authViewModel = remember {
@@ -91,6 +93,7 @@ fun App(factory: DatabaseDriverFactory, modifier: Modifier = Modifier) {
                 onItemDeleteClicked = lists.value::onItemDeleteClicked,
                 onAddItemClicked = lists.value::onAddItemClicked,
                 onInputTextChanged = lists.value::onInputTextChanged,
+                hasSynced = hasSynced
             )
         }
 

--- a/demos/supabase-todolist/shared/src/commonMain/kotlin/com/powersync/demos/screens/HomeScreen.kt
+++ b/demos/supabase-todolist/shared/src/commonMain/kotlin/com/powersync/demos/screens/HomeScreen.kt
@@ -1,14 +1,18 @@
 package com.powersync.demos.screens
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -25,13 +29,13 @@ internal fun HomeScreen(
     items: List<ListItem>,
     inputText: String,
     isConnected: Boolean?,
+    hasSynced: Boolean?,
     onSignOutSelected: () -> Unit,
     onItemClicked: (item: ListItem) -> Unit,
     onItemDeleteClicked: (item: ListItem) -> Unit,
     onAddItemClicked: () -> Unit,
     onInputTextChanged: (value: String) -> Unit,
 ) {
-
     Column(modifier) {
         TopAppBar(
             title = {
@@ -50,19 +54,35 @@ internal fun HomeScreen(
             }
         )
 
-        Input(
-            text = inputText,
-            onAddClicked = onAddItemClicked,
-            onTextChanged = onInputTextChanged,
-            screen = Screen.Home
-        )
+        when {
+                hasSynced == null || hasSynced == false -> {
+                    Box(
+                        modifier = Modifier.fillMaxSize().background(MaterialTheme.colors.background),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = "Busy with initial sync...",
+                            style = MaterialTheme.typography.h6
+                        )
+                    }
+                }
+            else -> {
 
-        Box(Modifier.weight(1F)) {
-            ListContent(
-                items = items,
-                onItemClicked = onItemClicked,
-                onItemDeleteClicked = onItemDeleteClicked
-            )
+                Input(
+                    text = inputText,
+                    onAddClicked = onAddItemClicked,
+                    onTextChanged = onInputTextChanged,
+                    screen = Screen.Home
+                )
+
+                Box(Modifier.weight(1F)) {
+                    ListContent(
+                        items = items,
+                        onItemClicked = onItemClicked,
+                        onItemDeleteClicked = onItemDeleteClicked
+                    )
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Description
There was an issue where `hasSynced` was being reset after becoming true. This issue was due to the `update` function in the `SyncStatus` class using the `copy` method and expecting default values to be persisted. However when the `update` function is run and `copy` is invoked it does not know about the default values in the `update` function so it overwrites the previous values with null.

This fixes the issue by not relying on default values from the `update` function.

Previously
```
status = { connected: true, hasSynced: true }

status.update(connected:false)

status = { connected false, hasSynced: null }
``` 

Now
```
status = { connected: true, hasSynced: true }

status.update(connected:false)

status = { connected false, hasSynced: true }
``` 

I have also included an example implementation of using `hasSynced` in the demo.

## Testing
Implemented the change in the demo and tested to confirm it shows "busy syncing..." when hasSynced is not true and shows the content otherwise