### PR TITLE
fix: custom write checkpoint logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.0.0-BETA6
+
+* Fix Custom Write Checkpoint application logic
 
 ## 1.0.0-BETA5
 

--- a/core/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
@@ -252,7 +252,7 @@ internal class PowerSyncDatabaseImpl(
         writeTransaction { tx ->
             internalDb.queries.deleteEntriesWithIdLessThan(lastTransactionId.toLong())
 
-            if (writeCheckpoint != null && bucketStorage.hasCrud()) {
+            if (writeCheckpoint != null && !bucketStorage.hasCrud()) {
                 tx.execute(
                     "UPDATE ps_buckets SET target_op = CAST(? AS INTEGER) WHERE name='\$local'",
                     listOf(writeCheckpoint),

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ development=true
 RELEASE_SIGNING_ENABLED=true
 # Library config
 GROUP=com.powersync
-LIBRARY_VERSION=1.0.0-BETA5
+LIBRARY_VERSION=1.0.0-BETA6
 GITHUB_REPO=https://github.com/powersync-ja/powersync-kotlin.git
 # POM
 POM_URL=https://github.com/powersync-ja/powersync-kotlin/


### PR DESCRIPTION
# Overview

This aligns the logic for Custom Write Checkpoints with the JS and Dart SDKs by correcting an error in the logical tests.

For reference see:
- Dart [implementation](https://github.com/powersync-ja/powersync.dart/blob/fb2f312247d44f74efaaa097c090190f9514e607/packages/powersync/lib/src/database/powersync_db_mixin.dart#L406)
- JS [implementation](https://github.com/powersync-ja/powersync-js/blob/30825f3e6137a86cf37a2e393e9e193bcf1debc4/packages/common/src/client/AbstractPowerSyncDatabase.ts#L577)