### PR TITLE
Disable Skie SuspendInterop

### DIFF
--- a/PowerSync/build.gradle.kts
+++ b/PowerSync/build.gradle.kts
@@ -1,5 +1,6 @@
 import co.touchlab.faktory.artifactmanager.ArtifactManager
 import co.touchlab.faktory.capitalized
+import co.touchlab.skie.configuration.SuspendInterop
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 import java.net.URL
 import java.security.MessageDigest
@@ -36,6 +37,16 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             api(project(":core"))
+        }
+    }
+}
+
+skie {
+    features {
+        group {
+            // We turn this off as the suspend interop feature results in
+            // threading issues when implementing SDK in Swift
+            SuspendInterop.Enabled(false)
         }
     }
 }


### PR DESCRIPTION
## Description

The setting to disable Skie SuspendInterop was removed in #75, this causes a compile time error in the Beta 6 as it requires the `__` prefix when overriding suspend functions in Swift see this [link](https://skie.touchlab.co/features/suspend#overriding-suspend-functions) for more details.

This PR disables SuspendInterop as it was in Beta 5.

## Work done

- Disable SuspendInterop for Skie

## Testing

I tested this locally by generating a SPM dev build using the gradle script (`spmDevBuild`) and linking the `powersync-kotlin-swift-demo` to the local package. I confirmed that it fixes compile time errors and the demo runs as expected.