### PR TITLE
chore: update kmmbridge action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,7 +59,7 @@ jobs:
     permissions:
       contents: write
       packages: write
-    uses: touchlab/KMMBridgeGithubWorkflow/.github/workflows/faktorybuildautoversion.yml@v1.1
+    uses: touchlab/KMMBridgeGithubWorkflow/.github/workflows/faktorybuildautoversion.yml@v1.2
     with:
       jvmVersion: 17
       versionBaseProperty: LIBRARY_VERSION


### PR DESCRIPTION
## Description
This resolves the issue of kmmbridge job being cancelled for old macos machine version being used. More info here https://github.com/touchlab/KMMBridgeGithubWorkflow/releases/tag/v1.2

