### PR TITLE
chore: update version to fix pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.0-BETA11
+
+* Update version to fix deployment issue of previous release
+
 ## 1.0.0-BETA10
 
 * Change Swift package name from `PowerSync` to `PowerSyncKotlin`

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ development=true
 RELEASE_SIGNING_ENABLED=true
 # Library config
 GROUP=com.powersync
-LIBRARY_VERSION=1.0.0-BETA10
+LIBRARY_VERSION=1.0.0-BETA11
 GITHUB_REPO=https://github.com/powersync-ja/powersync-kotlin.git
 # POM
 POM_URL=https://github.com/powersync-ja/powersync-kotlin/


### PR DESCRIPTION
## Description
There's a conflict on deployment as Beta 10 was released in Maven but did not complete. This updates the version to avoid the conflict and will result in a complete release. See error here https://github.com/powersync-ja/powersync-kotlin/actions/runs/12238823826/job/34138685054