### PR TITLE
fix: transaction resulting in race condition when not using the correct context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.0-BETA12
+
+* Use transaction context in `writeTransaction` in `BucketStorageImpl` to avoid race condition issues in Swift SDK.
+
 ## 1.0.0-BETA11
 
 * Update version to fix deployment issue of previous release

--- a/core/src/commonMain/kotlin/com/powersync/bucket/BucketStorageImpl.kt
+++ b/core/src/commonMain/kotlin/com/powersync/bucket/BucketStorageImpl.kt
@@ -93,14 +93,14 @@ internal class BucketStorageImpl(
 
         logger.i { "[updateLocalTarget] Updating target to checkpoint $opId" }
 
-        return db.writeTransaction {
+        return db.writeTransaction { tx ->
             if (hasCrud()) {
                 logger.w { "[updateLocalTarget] ps crud is not empty" }
                 return@writeTransaction false
             }
 
             val seqAfter =
-                db.getOptional("SELECT seq FROM sqlite_sequence WHERE name = '${InternalTable.CRUD}'") {
+                tx.getOptional("SELECT seq FROM sqlite_sequence WHERE name = '${InternalTable.CRUD}'") {
                     it.getLong(0)!!
                 }
                     ?: // assert isNotEmpty
@@ -112,7 +112,7 @@ internal class BucketStorageImpl(
                 return@writeTransaction false
             }
 
-            db.execute(
+            tx.execute(
                 "UPDATE ${InternalTable.BUCKETS} SET target_op = CAST(? as INTEGER) WHERE name='\$local'",
                 listOf(opId),
             )


### PR DESCRIPTION
## Description
There is an issue in the Swift SDK where this happens sporadically `Uncaught Kotlin exception: kotlin.IllegalStateException: Transaction objects (TransactionWithReturn and TransactionWithoutReturn) must be used
only within the transaction lambda scope.`. My hunch is that this is as a result of the bucketStorage not using the correct context. This changes the `writeTransaction` to use the transaction context passed as a callback which should fix the issue.