### PR TITLE
fix: race condition in transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## 1.0.0-BETA13
+
+* Move iOS database driver to use IO dispatcher which should avoid race conditions and improve performance.
+
 ## 1.0.0-BETA12
 
-* Use transaction context in `writeTransaction` in `BucketStorageImpl` to avoid race condition issues in Swift SDK.
+* Use transaction context in `writeTransaction` in `BucketStorageImpl`.
 
 ## 1.0.0-BETA11
 

--- a/core/src/iosMain/kotlin/com/powersync/DatabaseDriverFactory.ios.kt
+++ b/core/src/iosMain/kotlin/com/powersync/DatabaseDriverFactory.ios.kt
@@ -17,6 +17,8 @@ import kotlinx.cinterop.asStableRef
 import kotlinx.cinterop.staticCFunction
 import kotlinx.cinterop.toKString
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
 
 @Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
 @OptIn(ExperimentalForeignApi::class)
@@ -51,10 +53,13 @@ public actual class DatabaseDriverFactory {
         scope: CoroutineScope,
         dbFilename: String,
     ): PsSqlDriver {
+        val dbDispatcher = Dispatchers.IO
+        val dbScope = CoroutineScope(scope.coroutineContext + dbDispatcher)
+
         val schema = InternalSchema.synchronous()
         this.driver =
             PsSqlDriver(
-                scope = scope,
+                scope = dbScope,
                 driver =
                     NativeSqliteDriver(
                         configuration =

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ development=true
 RELEASE_SIGNING_ENABLED=true
 # Library config
 GROUP=com.powersync
-LIBRARY_VERSION=1.0.0-BETA12
+LIBRARY_VERSION=1.0.0-BETA13
 GITHUB_REPO=https://github.com/powersync-ja/powersync-kotlin.git
 # POM
 POM_URL=https://github.com/powersync-ja/powersync-kotlin/


### PR DESCRIPTION
## Problem
We were sporadically encountering `IllegalStateException` with the message "Transaction objects must be used only within the transaction lambda scope." This typically indicates a race condition where transaction objects are being accessed across different threads or coroutine contexts. I initially thought it was because of a transaction in BucketStorageImpl was using the wrong context (which was addressed in this PR https://github.com/powersync-ja/powersync-kotlin/pull/89) but this was not the case as the issue persisted.

## Root Cause
Database operations were not consistently running on the same dispatcher, which could lead to transaction objects being accessed from different threads. SQLDelight requires transaction operations to maintain thread confinement for safety.

## Solution
Added a dedicated IO dispatcher for all database operations by modifying the database driver creation:
```kotlin
val dbDispatcher = Dispatchers.IO
val dbScope = CoroutineScope(scope.coroutineContext + dbDispatcher)
```
This will also improve DB operation performance as the operations are now always running on the correct dispatcher.

## Testing
Testing in the Swift demo no longer produces this error (although it's tough to say that this is definitively resolved since the error was sporadic). 