### PR TITLE
Fix Windows deployment CI and add Windows testing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,9 +32,10 @@ jobs:
       - name: Build native lib
         run: |
           ./gradlew \
-          -PGITHUB_PUBLISH_TOKEN=${{ secrets.GITHUB_TOKEN }} \
-          -Ppowersync.binaries.cross-arch=true \
-          :core:cmakeJvmBuild
+            -PGITHUB_PUBLISH_TOKEN=${{ secrets.GITHUB_TOKEN }} \
+            -Ppowersync.binaries.cross-arch=true \
+            :core:cmakeJvmBuild
+        shell: bash
       - name: Upload build
         uses: actions/upload-artifact@v4
         with:
@@ -49,8 +50,7 @@ jobs:
         uses: gradle/wrapper-validation-action@v1
       - uses: actions/cache@v3
         with:
-          path: |
-            ~/.konan
+          path: ~/.konan
           key: ${{ runner.os }}-${{ hashFiles('**/.lock') }}
       - name: Set up JDK 17
         uses: actions/setup-java@v3
@@ -69,14 +69,15 @@ jobs:
       - name: Gradle publish
         run: |
           ./gradlew \
-          -PGITHUB_PUBLISH_TOKEN="${{ secrets.GITHUB_TOKEN }}" \
-          -PsigningInMemoryKey="${{ secrets.SIGNING_KEY }}" \
-          -PsigningInMemoryKeyId="${{ secrets.SIGNING_KEY_ID }}" \
-          -PsigningInMemoryKeyPassword="${{ secrets.SIGNING_PASSWORD }}" \
-          -PcentralPortal.username="${{secrets.SONATYPE_USERNAME}}" \
-          -PcentralPortal.password="${{secrets.SONATYPE_PASSWORD}}" \
-          -Ppowersync.binaries.provided="true" \
-          publishAllPublicationsToSonatypeRepository
+            -PGITHUB_PUBLISH_TOKEN="${{ secrets.GITHUB_TOKEN }}" \
+            -PsigningInMemoryKey="${{ secrets.SIGNING_KEY }}" \
+            -PsigningInMemoryKeyId="${{ secrets.SIGNING_KEY_ID }}" \
+            -PsigningInMemoryKeyPassword="${{ secrets.SIGNING_PASSWORD }}" \
+            -PcentralPortal.username="${{secrets.SONATYPE_USERNAME}}" \
+            -PcentralPortal.password="${{secrets.SONATYPE_PASSWORD}}" \
+            -Ppowersync.binaries.provided="true" \
+            publishAllPublicationsToSonatypeRepository
+        shell: bash
   # This will change Package.swift in Github packages to direct to new maven central KMMBridge zip file
   call-kmmbridge-publish:
     needs: deploy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,12 +15,12 @@ jobs:
     strategy:
       matrix:
         include:
-          - target: iosSimulatorArm64Test
-            os: macos-latest
-          - target: testDebugUnitTest
-            os: ubuntu-latest
-          - target: testReleaseUnitTest
-            os: ubuntu-latest
+          - os: macos-latest
+            targets: iosSimulatorArm64Test jvmTest
+          - os: ubuntu-latest
+            targets: testDebugUnitTest testReleaseUnitTest jvmTest
+          - os: windows-latest
+            targets: jvmTest
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -29,8 +29,7 @@ jobs:
       uses: gradle/wrapper-validation-action@v1
     - uses: actions/cache@v4
       with:
-        path: |
-          ~/.konan
+        path: ~/.konan
         key: ${{ runner.os }}-${{ hashFiles('**/.lock') }}
     - name: Set up JDK 17
       uses: actions/setup-java@v3
@@ -43,5 +42,6 @@ jobs:
     - name: Build and run tests with Gradle
       run: |
         ./gradlew \
-        ${{ matrix.target }} \
-        -PGITHUB_PUBLISH_TOKEN=${{ secrets.GITHUB_TOKEN }}
+          -PGITHUB_PUBLISH_TOKEN=${{ secrets.GITHUB_TOKEN }} \
+          ${{ matrix.targets }}
+      shell: bash


### PR DESCRIPTION
The Windows default shell does not support multi-line commands.
This updates the CI to :
- Run JVM tests on Linux, Mac & Windows
- Update run scripts to use the Bash shell (which supports muilti-line commands on all platforms)