### PR TITLE
Fix: on Intel x64, os.arch is either amd64 or x86_64 depending on the JVM.

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -295,8 +295,8 @@ val getBinaries = if (binariesAreProvided) {
     val cmakeJvmBuilds = when {
         crossArch -> listOfNotNull(aarch64, x64)
         arch == "aarch64" -> listOfNotNull(aarch64)
-        arch == "amd64" -> listOfNotNull(x64)
-        else -> error("Unknown architecture: $arch")
+        arch == "amd64" || arch == "x86_64" -> listOfNotNull(x64)
+        else -> error("Unsupported architecture: $arch")
     }
 
     tasks.register<Copy>("cmakeJvmBuild") {
@@ -327,8 +327,8 @@ val downloadPowersyncDesktopBinaries = tasks.register<Download>("downloadPowersy
         src(when {
             crossArch -> listOfNotNull(aarch64, x64)
             arch == "aarch64" -> listOfNotNull(aarch64)
-            arch == "amd64" -> listOfNotNull(x64)
-            else -> error("Unknown architecture: $arch")
+            arch == "amd64" || arch == "x86_64" -> listOfNotNull(x64)
+            else -> error("Unsupported architecture: $arch")
         })
     }
     dest(binariesFolder.map { it.dir("powersync") })

--- a/core/src/jvmMain/kotlin/com/powersync/ExtractLib.kt
+++ b/core/src/jvmMain/kotlin/com/powersync/ExtractLib.kt
@@ -20,8 +20,8 @@ internal fun extractLib(fileName: String): Path {
     val arch =
         when (val sysArch = System.getProperty("os.arch")) {
             "aarch64" -> "aarch64"
-            "amd64" -> "x64"
-            else -> error("Unknown architecture: $sysArch")
+            "amd64", "x86_64" -> "x64"
+            else -> error("Unsupported architecture: $sysArch")
         }
 
     val path = "/$prefix${fileName}_$arch.$extension"


### PR DESCRIPTION
For some reason, the call-kmmbridge-publish job [installs an x64 JDK](https://github.com/powersync-ja/powersync-kotlin/actions/runs/12684995488/job/35355117625#step:12:6) on [an arm64 Mac OS runner](https://github.com/powersync-ja/powersync-kotlin/actions/runs/12684995488/job/35355117625#step:1:8). I'm guessing that it's because [KMMBridgeGithubWorkflow](https://github.com/touchlab/KMMBridgeGithubWorkflow) (which is deprecated by the way) [uses actions/setup-java@v2](https://github.com/touchlab/KMMBridgeGithubWorkflow/blob/f98a8b44a278cbea152e8ef1571f7e2054863188/.github/workflows/faktorybuildautoversion.yml#L108C15-L108C36), when current version of [actions/setup-java](https://github.com/actions/setup-java) is v4.

This led to the realization that some JVM [use the identifier "x86_64"](https://github.com/powersync-ja/powersync-kotlin/actions/runs/12684995488/job/35355117625#step:15:47) instead of "amd64" to identify what we call the x64 architecture.
This PR simply adds the "x86_64" identifier as an alias to "amd64" when detecting the system architecture.