### PR TITLE
feat: do not invalidate credentials on io error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,7 @@
 ## 1.0.0-BETA16
 
 * Add `close` method to database methods
-* Throw when error is a `CancellationError` in syncStream and only invalidate credentials when error is not IOException.
-
+* Throw when error is a `CancellationError` and remove invalidation for all errors in `streamingSync` catch.
 ## 1.0.0-BETA15
 
 * Update powersync-sqlite-core to 0.3.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 1.0.0-BETA16
 
-*  Add `close` method to database methods
+* Add `close` method to database methods
+* Throw when error is a `CancellationError` in syncStream and only invalidate credentials when error is not IOException.
 
 ## 1.0.0-BETA15
 

--- a/core/src/commonMain/kotlin/com/powersync/sync/SyncStream.kt
+++ b/core/src/commonMain/kotlin/com/powersync/sync/SyncStream.kt
@@ -31,7 +31,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.datetime.Clock
-import kotlinx.io.IOException
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
@@ -102,11 +101,6 @@ internal class SyncStream(
                 }
 
                 logger.e(e) { "Error in streamingSync: $e" }
-                // If there is a network issue don't invalidate the credentials
-                if (e !is IOException) {
-                    invalidCredentials = true
-                }
-
                 status.update(
                     downloadError = e,
                 )

--- a/core/src/commonMain/kotlin/com/powersync/sync/SyncStream.kt
+++ b/core/src/commonMain/kotlin/com/powersync/sync/SyncStream.kt
@@ -97,11 +97,11 @@ internal class SyncStream(
 //                    break;
 //                }
             } catch (e: Exception) {
-                // If the coroutine was cancelled, don't log an error
-                if (e !is CancellationException) {
-                    logger.e(e) { "Error in streamingSync: $e" }
+                if (e is CancellationException) {
+                    throw e
                 }
 
+                logger.e(e) { "Error in streamingSync: $e" }
                 // If there is a network issue don't invalidate the credentials
                 if (e !is IOException) {
                     invalidCredentials = true

--- a/core/src/commonMain/kotlin/com/powersync/sync/SyncStream.kt
+++ b/core/src/commonMain/kotlin/com/powersync/sync/SyncStream.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.datetime.Clock
+import kotlinx.io.IOException
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
@@ -98,9 +99,14 @@ internal class SyncStream(
             } catch (e: Exception) {
                 // If the coroutine was cancelled, don't log an error
                 if (e !is CancellationException) {
-                    logger.e(e) { "Error in streamingSync" }
+                    logger.e(e) { "Error in streamingSync: $e" }
                 }
-                invalidCredentials = true
+
+                // If there is a network issue don't invalidate the credentials
+                if (e !is IOException) {
+                    invalidCredentials = true
+                }
+
                 status.update(
                     downloadError = e,
                 )

--- a/core/src/commonTest/kotlin/com/powersync/sync/SyncStreamTest.kt
+++ b/core/src/commonTest/kotlin/com/powersync/sync/SyncStreamTest.kt
@@ -10,17 +10,13 @@ import com.powersync.connectors.PowerSyncCredentials
 import com.powersync.db.crud.CrudEntry
 import com.powersync.db.crud.UpdateType
 import dev.mokkery.answering.returns
-import dev.mokkery.answering.throws
 import dev.mokkery.everySuspend
 import dev.mokkery.mock
 import dev.mokkery.verify
-import dev.mokkery.verify.VerifyMode
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeout
-import kotlinx.io.IOException
 import kotlinx.serialization.json.JsonObject
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -168,137 +164,6 @@ class SyncStreamTest {
             assertEquals(false, syncStream.status.connected)
 
             // Clean up
-            job.cancel()
-        }
-
-    @Test
-    fun testStreamingSyncHandlesCancellation() =
-        runTest {
-            // Setup mocks
-            bucketStorage =
-                mock<BucketStorage> {
-                    everySuspend { getClientId() } returns "test-client-id"
-                    everySuspend { getBucketStates() } throws CancellationException("Test cancellation")
-                }
-
-            connector =
-                mock<PowerSyncBackendConnector> {
-                    everySuspend { getCredentialsCached() } returns null
-                    everySuspend { invalidateCredentials() } returns Unit
-                }
-
-            syncStream =
-                SyncStream(
-                    bucketStorage = bucketStorage,
-                    connector = connector,
-                    uploadCrud = { },
-                    retryDelayMs = 10,
-                    logger = logger,
-                    params = JsonObject(emptyMap()),
-                )
-
-            val job =
-                launch {
-                    syncStream.streamingSync()
-                }
-
-            delay(100) // Give time for error handling
-
-            // Verify no error was logged for CancellationException
-            assertEquals(0, testLogWriter.logs.count { it.severity == Severity.Error })
-
-            // Verify credentials were invalidated
-            verify(VerifyMode.exactly(1)) { syncStream.invalidateCredentials() }
-
-            job.cancel()
-        }
-
-    @Test
-    fun testStreamingSyncHandlesIOException() =
-        runTest {
-            bucketStorage =
-                mock<BucketStorage> {
-                    everySuspend { getClientId() } returns "test-client-id"
-                    everySuspend { getBucketStates() } throws IOException("Test IO error")
-                }
-
-            connector =
-                mock<PowerSyncBackendConnector> {
-                    everySuspend { getCredentialsCached() } returns null
-                    everySuspend { invalidateCredentials() } returns Unit
-                }
-
-            syncStream =
-                SyncStream(
-                    bucketStorage = bucketStorage,
-                    connector = connector,
-                    uploadCrud = { },
-                    retryDelayMs = 10,
-                    logger = logger,
-                    params = JsonObject(emptyMap()),
-                )
-
-            val job =
-                launch {
-                    syncStream.streamingSync()
-                }
-
-            delay(9)
-
-            // Verify error was logged
-            assertContains(
-                testLogWriter.logs
-                    .first {
-                        it.severity == Severity.Error
-                    }.message,
-                "Error in streamingSync: java.io.IOException: Test IO error",
-            )
-
-            // Verify credentials weren't invalidated for IOException
-            verify(VerifyMode.exactly(0)) { syncStream.invalidateCredentials() }
-
-            job.cancel()
-        }
-
-    @Test
-    fun testStreamingSyncHandlesOtherException() =
-        runTest {
-            bucketStorage =
-                mock<BucketStorage> {
-                    everySuspend { getClientId() } returns "test-client-id"
-                    everySuspend { getBucketStates() } throws IllegalStateException("Test error")
-                }
-
-            connector =
-                mock<PowerSyncBackendConnector> {
-                    everySuspend { getCredentialsCached() } returns null
-                    everySuspend { invalidateCredentials() } returns Unit
-                }
-
-            syncStream =
-                SyncStream(
-                    bucketStorage = bucketStorage,
-                    connector = connector,
-                    uploadCrud = { },
-                    retryDelayMs = 10,
-                    logger = logger,
-                    params = JsonObject(emptyMap()),
-                )
-
-            val job =
-                launch {
-                    syncStream.streamingSync()
-                }
-
-            delay(9) // Give time for error handling
-
-            // Verify error was logged for non-CancellationException
-            assertEquals(1, testLogWriter.logs.count { it.severity == Severity.Error })
-            assertContains(testLogWriter.logs.first { it.severity == Severity.Error }.message, "Error in streamingSync")
-
-            // Verify credentials were invalidated for non-IOException
-            verify(VerifyMode.exactly(1)) { syncStream.invalidateCredentials() }
-
             job.cancel()
         }
 }

--- a/core/src/commonTest/kotlin/com/powersync/sync/SyncStreamTest.kt
+++ b/core/src/commonTest/kotlin/com/powersync/sync/SyncStreamTest.kt
@@ -6,13 +6,21 @@ import co.touchlab.kermit.TestConfig
 import co.touchlab.kermit.TestLogWriter
 import com.powersync.bucket.BucketStorage
 import com.powersync.connectors.PowerSyncBackendConnector
+import com.powersync.connectors.PowerSyncCredentials
 import com.powersync.db.crud.CrudEntry
 import com.powersync.db.crud.UpdateType
 import dev.mokkery.answering.returns
+import dev.mokkery.answering.throws
 import dev.mokkery.everySuspend
 import dev.mokkery.mock
 import dev.mokkery.verify
+import dev.mokkery.verify.VerifyMode
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
+import kotlinx.io.IOException
 import kotlinx.serialization.json.JsonObject
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -111,5 +119,186 @@ class SyncStreamTest {
                 assertEquals(message, "Error uploading crud")
                 assertEquals(Severity.Error, severity)
             }
+        }
+
+    @Test
+    fun testStreamingSyncBasicFlow() =
+        runTest {
+            bucketStorage =
+                mock<BucketStorage> {
+                    everySuspend { getClientId() } returns "test-client-id"
+                    everySuspend { getBucketStates() } returns emptyList()
+                }
+
+            connector =
+                mock<PowerSyncBackendConnector> {
+                    everySuspend { getCredentialsCached() } returns
+                        PowerSyncCredentials(
+                            token = "test-token",
+                            userId = "test-user",
+                            endpoint = "https://test.com",
+                        )
+                }
+
+            syncStream =
+                SyncStream(
+                    bucketStorage = bucketStorage,
+                    connector = connector,
+                    uploadCrud = { },
+                    retryDelayMs = 10,
+                    logger = logger,
+                    params = JsonObject(emptyMap()),
+                )
+
+            // Launch streaming sync in a coroutine that we'll cancel after verification
+            val job =
+                launch {
+                    syncStream.streamingSync()
+                }
+
+            // Wait for status to update
+            withTimeout(1000) {
+                while (!syncStream.status.connecting) {
+                    delay(10)
+                }
+            }
+
+            // Verify initial state
+            assertEquals(true, syncStream.status.connecting)
+            assertEquals(false, syncStream.status.connected)
+
+            // Clean up
+            job.cancel()
+        }
+
+    @Test
+    fun testStreamingSyncHandlesCancellation() =
+        runTest {
+            // Setup mocks
+            bucketStorage =
+                mock<BucketStorage> {
+                    everySuspend { getClientId() } returns "test-client-id"
+                    everySuspend { getBucketStates() } throws CancellationException("Test cancellation")
+                }
+
+            connector =
+                mock<PowerSyncBackendConnector> {
+                    everySuspend { getCredentialsCached() } returns null
+                    everySuspend { invalidateCredentials() } returns Unit
+                }
+
+            syncStream =
+                SyncStream(
+                    bucketStorage = bucketStorage,
+                    connector = connector,
+                    uploadCrud = { },
+                    retryDelayMs = 10,
+                    logger = logger,
+                    params = JsonObject(emptyMap()),
+                )
+
+            val job =
+                launch {
+                    syncStream.streamingSync()
+                }
+
+            delay(100) // Give time for error handling
+
+            // Verify no error was logged for CancellationException
+            assertEquals(0, testLogWriter.logs.count { it.severity == Severity.Error })
+
+            // Verify credentials were invalidated
+            verify(VerifyMode.exactly(1)) { syncStream.invalidateCredentials() }
+
+            job.cancel()
+        }
+
+    @Test
+    fun testStreamingSyncHandlesIOException() =
+        runTest {
+            bucketStorage =
+                mock<BucketStorage> {
+                    everySuspend { getClientId() } returns "test-client-id"
+                    everySuspend { getBucketStates() } throws IOException("Test IO error")
+                }
+
+            connector =
+                mock<PowerSyncBackendConnector> {
+                    everySuspend { getCredentialsCached() } returns null
+                    everySuspend { invalidateCredentials() } returns Unit
+                }
+
+            syncStream =
+                SyncStream(
+                    bucketStorage = bucketStorage,
+                    connector = connector,
+                    uploadCrud = { },
+                    retryDelayMs = 10,
+                    logger = logger,
+                    params = JsonObject(emptyMap()),
+                )
+
+            val job =
+                launch {
+                    syncStream.streamingSync()
+                }
+
+            delay(9)
+
+            // Verify error was logged
+            assertContains(
+                testLogWriter.logs
+                    .first {
+                        it.severity == Severity.Error
+                    }.message,
+                "Error in streamingSync: java.io.IOException: Test IO error",
+            )
+
+            // Verify credentials weren't invalidated for IOException
+            verify(VerifyMode.exactly(0)) { syncStream.invalidateCredentials() }
+
+            job.cancel()
+        }
+
+    @Test
+    fun testStreamingSyncHandlesOtherException() =
+        runTest {
+            bucketStorage =
+                mock<BucketStorage> {
+                    everySuspend { getClientId() } returns "test-client-id"
+                    everySuspend { getBucketStates() } throws IllegalStateException("Test error")
+                }
+
+            connector =
+                mock<PowerSyncBackendConnector> {
+                    everySuspend { getCredentialsCached() } returns null
+                    everySuspend { invalidateCredentials() } returns Unit
+                }
+
+            syncStream =
+                SyncStream(
+                    bucketStorage = bucketStorage,
+                    connector = connector,
+                    uploadCrud = { },
+                    retryDelayMs = 10,
+                    logger = logger,
+                    params = JsonObject(emptyMap()),
+                )
+
+            val job =
+                launch {
+                    syncStream.streamingSync()
+                }
+
+            delay(9) // Give time for error handling
+
+            // Verify error was logged for non-CancellationException
+            assertEquals(1, testLogWriter.logs.count { it.severity == Severity.Error })
+            assertContains(testLogWriter.logs.first { it.severity == Severity.Error }.message, "Error in streamingSync")
+
+            // Verify credentials were invalidated for non-IOException
+            verify(VerifyMode.exactly(1)) { syncStream.invalidateCredentials() }
+
+            job.cancel()
         }
 }


### PR DESCRIPTION
## Description
This aims to resolve https://github.com/powersync-ja/powersync-kotlin/issues/102 where credentials are invalidated even though there is no network. It appears this was included before invalidation was properly handled and can be removed.