### PR TITLE
Adds JNIExport to powersync_init so that it is exported in the Windows DLL

### DIFF
--- a/core/src/jvmNative/cpp/sqlite_bindings.cpp
+++ b/core/src/jvmNative/cpp/sqlite_bindings.cpp
@@ -70,6 +70,7 @@ static void rollback_hook(void *pool) {
     }
 }
 
+JNIEXPORT
 int powersync_init(sqlite3 *db, char **pzErrMsg, const sqlite3_api_routines *pApi) {
     sqlite3_initialize();
 


### PR DESCRIPTION
Fixes the startup issue on Windows.