### PR TITLE
Synchronized transactions

### DIFF
--- a/core/src/androidMain/kotlin/com/powersync/DatabaseDriverFactory.android.kt
+++ b/core/src/androidMain/kotlin/com/powersync/DatabaseDriverFactory.android.kt
@@ -2,7 +2,6 @@ package com.powersync
 
 import android.content.Context
 import androidx.sqlite.db.SupportSQLiteDatabase
-import app.cash.sqldelight.async.coroutines.synchronous
 import app.cash.sqldelight.driver.android.AndroidSqliteDriver
 import com.powersync.db.internal.InternalSchema
 import io.requery.android.database.sqlite.RequerySQLiteOpenHelperFactory
@@ -37,7 +36,7 @@ public actual class DatabaseDriverFactory(
         scope: CoroutineScope,
         dbFilename: String,
     ): PsSqlDriver {
-        val schema = InternalSchema.synchronous()
+        val schema = InternalSchema
 
         this.driver =
             PsSqlDriver(

--- a/core/src/commonMain/kotlin/com/powersync/bucket/BucketStorage.kt
+++ b/core/src/commonMain/kotlin/com/powersync/bucket/BucketStorage.kt
@@ -1,6 +1,7 @@
 package com.powersync.bucket
 
 import com.powersync.db.crud.CrudEntry
+import com.powersync.db.internal.PowerSyncTransaction
 import com.powersync.sync.SyncDataBatch
 import com.powersync.sync.SyncLocalDatabaseResult
 
@@ -11,7 +12,11 @@ internal interface BucketStorage {
 
     suspend fun nextCrudItem(): CrudEntry?
 
+    fun nextCrudItem(transaction: PowerSyncTransaction): CrudEntry?
+
     suspend fun hasCrud(): Boolean
+
+    fun hasCrud(transaction: PowerSyncTransaction): Boolean
 
     suspend fun updateLocalTarget(checkpointCallback: suspend () -> String): Boolean
 

--- a/core/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
@@ -1,7 +1,5 @@
 package com.powersync.db
 
-import app.cash.sqldelight.async.coroutines.awaitAsList
-import app.cash.sqldelight.async.coroutines.awaitAsOne
 import app.cash.sqldelight.db.SqlCursor
 import co.touchlab.kermit.Logger
 import com.powersync.DatabaseDriverFactory
@@ -69,7 +67,7 @@ internal class PowerSyncDatabaseImpl(
 
     init {
         runBlocking {
-            val sqliteVersion = internalDb.queries.sqliteVersion().awaitAsOne()
+            val sqliteVersion = internalDb.queries.sqliteVersion().executeAsOne()
             logger.d { "SQLiteVersion: $sqliteVersion" }
             checkVersion()
             logger.d { "PowerSyncVersion: ${getPowerSyncVersion()}" }
@@ -82,8 +80,8 @@ internal class PowerSyncDatabaseImpl(
     private suspend fun applySchema() {
         val schemaJson = JsonUtil.json.encodeToString(schema)
 
-        this.writeTransaction { tx ->
-            internalDb.queries.replaceSchema(schemaJson).awaitAsOne()
+        internalDb.writeTransaction {
+            internalDb.queries.replaceSchema(schemaJson).executeAsOne()
         }
     }
 
@@ -142,7 +140,7 @@ internal class PowerSyncDatabaseImpl(
         }
 
         val entries =
-            internalDb.queries.getCrudEntries((limit + 1).toLong()).awaitAsList().map {
+            internalDb.queries.getCrudEntries((limit + 1).toLong()).executeAsList().map {
                 CrudEntry.fromRow(
                     CrudRow(
                         id = it.id.toString(),
@@ -167,9 +165,9 @@ internal class PowerSyncDatabaseImpl(
     }
 
     override suspend fun getNextCrudTransaction(): CrudTransaction? {
-        return this.readTransaction {
+        return internalDb.readTransaction {
             val entry =
-                bucketStorage.nextCrudItem()
+                bucketStorage.nextCrudItem(this)
                     ?: return@readTransaction null
 
             val txId = entry.transactionId
@@ -177,7 +175,7 @@ internal class PowerSyncDatabaseImpl(
                 if (txId == null) {
                     listOf(entry)
                 } else {
-                    internalDb.queries.getCrudEntryByTxId(txId.toLong()).awaitAsList().map {
+                    internalDb.queries.getCrudEntryByTxId(txId.toLong()).executeAsList().map {
                         CrudEntry.fromRow(
                             CrudRow(
                                 id = it.id.toString(),
@@ -199,7 +197,7 @@ internal class PowerSyncDatabaseImpl(
         }
     }
 
-    override suspend fun getPowerSyncVersion(): String = internalDb.queries.powerSyncVersion().awaitAsOne()
+    override suspend fun getPowerSyncVersion(): String = internalDb.queries.powerSyncVersion().executeAsOne()
 
     override suspend fun <RowType : Any> get(
         sql: String,
@@ -225,9 +223,11 @@ internal class PowerSyncDatabaseImpl(
         mapper: (SqlCursor) -> RowType,
     ): Flow<List<RowType>> = internalDb.watch(sql, parameters, mapper)
 
-    override suspend fun <R> readTransaction(callback: suspend (tx: PowerSyncTransaction) -> R): R = internalDb.writeTransaction(callback)
+    override suspend fun <R> readTransaction(callback: (tx: PowerSyncTransaction) -> R): R =
+        internalDb.writeTransaction(callback)
 
-    override suspend fun <R> writeTransaction(callback: suspend (tx: PowerSyncTransaction) -> R): R = internalDb.writeTransaction(callback)
+    override suspend fun <R> writeTransaction(callback: (tx: PowerSyncTransaction) -> R): R =
+        internalDb.writeTransaction(callback)
 
     override suspend fun execute(
         sql: String,
@@ -238,16 +238,16 @@ internal class PowerSyncDatabaseImpl(
         lastTransactionId: Int,
         writeCheckpoint: String?,
     ) {
-        writeTransaction { tx ->
+        internalDb.writeTransaction {
             internalDb.queries.deleteEntriesWithIdLessThan(lastTransactionId.toLong())
 
-            if (writeCheckpoint != null && !bucketStorage.hasCrud()) {
-                tx.execute(
+            if (writeCheckpoint != null && !bucketStorage.hasCrud(this)) {
+                execute(
                     "UPDATE ps_buckets SET target_op = CAST(? AS INTEGER) WHERE name='\$local'",
                     listOf(writeCheckpoint),
                 )
             } else {
-                tx.execute(
+                execute(
                     "UPDATE ps_buckets SET target_op = CAST(? AS INTEGER) WHERE name='\$local'",
                     listOf(bucketStorage.getMaxOpId()),
                 )
@@ -275,8 +275,8 @@ internal class PowerSyncDatabaseImpl(
     override suspend fun disconnectAndClear(clearLocal: Boolean) {
         disconnect()
 
-        this.writeTransaction {
-            internalDb.queries.powersyncClear(if (clearLocal) "1" else "0").awaitAsOne()
+        internalDb.writeTransaction {
+            internalDb.queries.powersyncClear(if (clearLocal) "1" else "0").executeAsOne()
         }
         currentStatus.update(lastSyncedAt = null, hasSynced = false)
     }

--- a/core/src/commonMain/kotlin/com/powersync/db/Queries.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/Queries.kt
@@ -51,7 +51,7 @@ public interface Queries {
         mapper: (SqlCursor) -> RowType,
     ): Flow<List<RowType>>
 
-    public suspend fun <R> writeTransaction(callback: suspend (PowerSyncTransaction) -> R): R
+    public suspend fun <R> writeTransaction(callback: (PowerSyncTransaction) -> R): R
 
-    public suspend fun <R> readTransaction(callback: suspend (PowerSyncTransaction) -> R): R
+    public suspend fun <R> readTransaction(callback: (PowerSyncTransaction) -> R): R
 }

--- a/core/src/commonMain/kotlin/com/powersync/db/internal/InternalDatabase.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/internal/InternalDatabase.kt
@@ -2,13 +2,11 @@ package com.powersync.db.internal
 
 import app.cash.sqldelight.db.Closeable
 import com.persistence.PowersyncQueries
-import com.powersync.PsSqlDriver
 import com.powersync.db.Queries
 import com.powersync.persistence.PsDatabase
 import kotlinx.coroutines.flow.Flow
 
 internal interface InternalDatabase : Queries, Closeable {
-    val driver: PsSqlDriver
     val transactor: PsDatabase
     val queries: PowersyncQueries
 

--- a/core/src/commonMain/kotlin/com/powersync/db/internal/InternalDatabaseImpl.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/internal/InternalDatabaseImpl.kt
@@ -2,8 +2,6 @@ package com.powersync.db.internal
 
 import app.cash.sqldelight.ExecutableQuery
 import app.cash.sqldelight.Query
-import app.cash.sqldelight.async.coroutines.awaitAsList
-import app.cash.sqldelight.async.coroutines.awaitAsOneOrNull
 import app.cash.sqldelight.coroutines.asFlow
 import app.cash.sqldelight.coroutines.mapToList
 import app.cash.sqldelight.db.QueryResult
@@ -14,44 +12,50 @@ import com.powersync.PsSqlDriver
 import com.powersync.persistence.PsDatabase
 import com.powersync.utils.JsonUtil
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.IO
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.encodeToString
 
 @OptIn(FlowPreview::class)
 internal class InternalDatabaseImpl(
-    override val driver: PsSqlDriver,
+    private val driver: PsSqlDriver,
     private val scope: CoroutineScope,
 ) : InternalDatabase {
     override val transactor: PsDatabase = PsDatabase(driver)
     override val queries: PowersyncQueries = transactor.powersyncQueries
+
+    // Could be scope.coroutineContext, but the default is GlobalScope, which seems like a bad idea. To discuss.
+    private val dbContext = Dispatchers.IO
     private val transaction =
         object : PowerSyncTransaction {
-            override suspend fun execute(
+            override fun execute(
                 sql: String,
                 parameters: List<Any?>?,
-            ): Long = this@InternalDatabaseImpl.execute(sql, parameters ?: emptyList())
+            ): Long = this@InternalDatabaseImpl.executeSync(sql, parameters ?: emptyList())
 
-            override suspend fun <RowType : Any> get(
+            override fun <RowType : Any> get(
                 sql: String,
                 parameters: List<Any?>?,
                 mapper: (SqlCursor) -> RowType,
-            ): RowType = this@InternalDatabaseImpl.get(sql, parameters ?: emptyList(), mapper)
+            ): RowType = this@InternalDatabaseImpl.getSync(sql, parameters ?: emptyList(), mapper)
 
-            override suspend fun <RowType : Any> getAll(
+            override fun <RowType : Any> getAll(
                 sql: String,
                 parameters: List<Any?>?,
                 mapper: (SqlCursor) -> RowType,
-            ): List<RowType> = this@InternalDatabaseImpl.getAll(sql, parameters ?: emptyList(), mapper)
+            ): List<RowType> = this@InternalDatabaseImpl.getAllSync(sql, parameters ?: emptyList(), mapper)
 
-            override suspend fun <RowType : Any> getOptional(
+            override fun <RowType : Any> getOptional(
                 sql: String,
                 parameters: List<Any?>?,
                 mapper: (SqlCursor) -> RowType,
-            ): RowType? = this@InternalDatabaseImpl.getOptional(sql, parameters ?: emptyList(), mapper)
+            ): RowType? = this@InternalDatabaseImpl.getOptionalSync(sql, parameters ?: emptyList(), mapper)
         }
 
     companion object {
@@ -78,6 +82,11 @@ internal class InternalDatabaseImpl(
     override suspend fun execute(
         sql: String,
         parameters: List<Any?>?,
+    ): Long = withContext(dbContext) { executeSync(sql, parameters) }
+
+    private fun executeSync(
+        sql: String,
+        parameters: List<Any?>?,
     ): Long {
         val numParams = parameters?.size ?: 0
 
@@ -87,10 +96,16 @@ internal class InternalDatabaseImpl(
                 sql = sql,
                 parameters = numParams,
                 binders = getBindersFromParams(parameters),
-            ).await()
+            ).value
     }
 
     override suspend fun <RowType : Any> get(
+        sql: String,
+        parameters: List<Any?>?,
+        mapper: (SqlCursor) -> RowType,
+    ): RowType = withContext(dbContext) { getSync(sql, parameters, mapper) }
+
+    private fun <RowType : Any> getSync(
         sql: String,
         parameters: List<Any?>?,
         mapper: (SqlCursor) -> RowType,
@@ -102,11 +117,17 @@ internal class InternalDatabaseImpl(
                     parameters = parameters?.size ?: 0,
                     binders = getBindersFromParams(parameters),
                     mapper = mapper,
-                ).awaitAsOneOrNull()
+                ).executeAsOneOrNull()
         return requireNotNull(result) { "Query returned no result" }
     }
 
     override suspend fun <RowType : Any> getAll(
+        sql: String,
+        parameters: List<Any?>?,
+        mapper: (SqlCursor) -> RowType,
+    ): List<RowType> = withContext(dbContext) { getAllSync(sql, parameters, mapper) }
+
+    private fun <RowType : Any> getAllSync(
         sql: String,
         parameters: List<Any?>?,
         mapper: (SqlCursor) -> RowType,
@@ -117,9 +138,15 @@ internal class InternalDatabaseImpl(
                 parameters = parameters?.size ?: 0,
                 binders = getBindersFromParams(parameters),
                 mapper = mapper,
-            ).awaitAsList()
+            ).executeAsList()
 
     override suspend fun <RowType : Any> getOptional(
+        sql: String,
+        parameters: List<Any?>?,
+        mapper: (SqlCursor) -> RowType,
+    ): RowType? = withContext(dbContext) { getOptionalSync(sql, parameters, mapper) }
+
+    private fun <RowType : Any> getOptionalSync(
         sql: String,
         parameters: List<Any?>?,
         mapper: (SqlCursor) -> RowType,
@@ -130,7 +157,7 @@ internal class InternalDatabaseImpl(
                 parameters = parameters?.size ?: 0,
                 binders = getBindersFromParams(parameters),
                 mapper = mapper,
-            ).awaitAsOneOrNull()
+            ).executeAsOneOrNull()
 
     override fun <RowType : Any> watch(
         sql: String,
@@ -182,14 +209,18 @@ internal class InternalDatabaseImpl(
             }
         }
 
-    override suspend fun <R> readTransaction(callback: suspend (PowerSyncTransaction) -> R): R =
-        transactor.transactionWithResult(noEnclosing = true) {
-            callback(transaction)
+    override suspend fun <R> readTransaction(callback: PowerSyncTransaction.() -> R): R =
+        withContext(dbContext) {
+            transactor.transactionWithResult(noEnclosing = true) {
+                callback(transaction)
+            }
         }
 
-    override suspend fun <R> writeTransaction(callback: suspend (PowerSyncTransaction) -> R): R =
-        transactor.transactionWithResult(noEnclosing = true) {
-            callback(transaction)
+    override suspend fun <R> writeTransaction(callback: PowerSyncTransaction.() -> R): R =
+        withContext(dbContext) {
+            transactor.transactionWithResult(noEnclosing = true) {
+                callback(transaction)
+            }
         }
 
     // Register callback for table updates

--- a/core/src/commonMain/kotlin/com/powersync/db/internal/InternalSchema.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/internal/InternalSchema.kt
@@ -5,16 +5,16 @@ import app.cash.sqldelight.db.QueryResult
 import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.db.SqlSchema
 
-internal object InternalSchema : SqlSchema<QueryResult.AsyncValue<Unit>> {
+internal object InternalSchema : SqlSchema<QueryResult.Value<Unit>> {
     override val version: Long
         get() = 1
 
-    override fun create(driver: SqlDriver): QueryResult.AsyncValue<Unit> = QueryResult.AsyncValue {}
+    override fun create(driver: SqlDriver): QueryResult.Value<Unit> = QueryResult.Value(Unit)
 
     override fun migrate(
         driver: SqlDriver,
         oldVersion: Long,
         newVersion: Long,
         vararg callbacks: AfterVersion,
-    ): QueryResult.AsyncValue<Unit> = QueryResult.AsyncValue {}
+    ): QueryResult.Value<Unit> = QueryResult.Value(Unit)
 }

--- a/core/src/commonMain/kotlin/com/powersync/db/internal/PowerSyncTransaction.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/internal/PowerSyncTransaction.kt
@@ -3,24 +3,24 @@ package com.powersync.db.internal
 import app.cash.sqldelight.db.SqlCursor
 
 public interface PowerSyncTransaction {
-    public suspend fun execute(
+    public fun execute(
         sql: String,
         parameters: List<Any?>? = listOf(),
     ): Long
 
-    public suspend fun <RowType : Any> getOptional(
+    public fun <RowType : Any> getOptional(
         sql: String,
         parameters: List<Any?>? = listOf(),
         mapper: (SqlCursor) -> RowType,
     ): RowType?
 
-    public suspend fun <RowType : Any> getAll(
+    public fun <RowType : Any> getAll(
         sql: String,
         parameters: List<Any?>? = listOf(),
         mapper: (SqlCursor) -> RowType,
     ): List<RowType>
 
-    public suspend fun <RowType : Any> get(
+    public fun <RowType : Any> get(
         sql: String,
         parameters: List<Any?>? = listOf(),
         mapper: (SqlCursor) -> RowType,

--- a/core/src/iosMain/kotlin/com/powersync/DatabaseDriverFactory.ios.kt
+++ b/core/src/iosMain/kotlin/com/powersync/DatabaseDriverFactory.ios.kt
@@ -1,6 +1,5 @@
 package com.powersync
 
-import app.cash.sqldelight.async.coroutines.synchronous
 import app.cash.sqldelight.driver.native.NativeSqliteDriver
 import app.cash.sqldelight.driver.native.wrapConnection
 import co.touchlab.sqliter.DatabaseConfiguration
@@ -51,7 +50,7 @@ public actual class DatabaseDriverFactory {
         scope: CoroutineScope,
         dbFilename: String,
     ): PsSqlDriver {
-        val schema = InternalSchema.synchronous()
+        val schema = InternalSchema
         this.driver =
             PsSqlDriver(
                 scope = scope,

--- a/core/src/jvmMain/kotlin/com/powersync/DatabaseDriverFactory.jvm.kt
+++ b/core/src/jvmMain/kotlin/com/powersync/DatabaseDriverFactory.jvm.kt
@@ -1,6 +1,5 @@
 package com.powersync
 
-import app.cash.sqldelight.async.coroutines.synchronous
 import com.powersync.db.internal.InternalSchema
 import kotlinx.coroutines.CoroutineScope
 import java.nio.file.Path
@@ -34,7 +33,7 @@ public actual class DatabaseDriverFactory {
         scope: CoroutineScope,
         dbFilename: String,
     ): PsSqlDriver {
-        val schema = InternalSchema.synchronous()
+        val schema = InternalSchema
 
         val driver =
             PSJdbcSqliteDriver(

--- a/persistence/build.gradle.kts
+++ b/persistence/build.gradle.kts
@@ -78,7 +78,6 @@ sqldelight {
     databases {
         create("PsDatabase") {
             packageName.set("com.powersync.persistence")
-            generateAsync.set(true)
             dialect(project(":dialect"))
         }
     }


### PR DESCRIPTION
* Remove async from sqldelight config
* Remove suspend from the transaction block and methods available on the PowerSyncTransaction interface
* Some access cleanup to ensure all direct db access is handled by `InternalDatabaseImpl`
* Move calls to the actual db off of caller thread inside `InternalDatabaseImpl`