### PR TITLE
feat: add SqlCursor function improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
+## 1.0.0-BETA20
+* Add cursor optional functions: `getStringOptional`, `getLongOptional`, `getDoubleOptional`, `getBooleanOptional` and `getBytesOptional` when using the column name which allow for optional return types
+* Throw errors for invalid column on all cursor functions
+* `getString`, `getLong`, `getBytes`, `getDouble` and `getBoolean` used with the column name will now throw an error for non-null values and expect a non optional return type
+
 ## 1.0.0-BETA19
 
-* Allow cursor to columns by name
+* Allow cursor to get values by column name e.g. `getStringOptional("id")`
 * BREAKING CHANGE: If you were using `SqlCursor` from SqlDelight previously for your own custom mapper then you must now change to `SqlCursor` exported by the PowerSync module.
 
   Previously you would import it like this:

--- a/core/src/commonMain/kotlin/com/powersync/db/SqlCursor.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/SqlCursor.kt
@@ -1,5 +1,7 @@
 package com.powersync.db
 
+import co.touchlab.skie.configuration.annotations.FunctionInterop
+
 public interface SqlCursor {
     public fun getBoolean(index: Int): Boolean?
 
@@ -18,8 +20,42 @@ public interface SqlCursor {
     public val columnNames: Map<String, Int>
 }
 
-public fun SqlCursor.getBoolean(name: String): Boolean? = columnNames[name]?.let { getBoolean(it) }
-public fun SqlCursor.getBytes(name: String): ByteArray? = columnNames[name]?.let { getBytes(it) }
-public fun SqlCursor.getDouble(name: String): Double? = columnNames[name]?.let { getDouble(it) }
-public fun SqlCursor.getLong(name: String): Long? = columnNames[name]?.let { getLong(it) }
-public fun SqlCursor.getString(name: String): String? = columnNames[name]?.let { getString(it) }
+private inline fun <T> SqlCursor.getColumnValue(
+    name: String,
+    getValue: (Int) -> T?,
+): T {
+    val index = columnNames[name] ?: throw IllegalArgumentException("Column '$name' not found")
+    return getValue(index) ?: throw IllegalArgumentException("Null value found for column '$name'")
+}
+
+private inline fun <T> SqlCursor.getColumnValueOptional(
+    name: String,
+    getValue: (Int) -> T?,
+): T? = columnNames[name]?.let { getValue(it) }
+
+// This causes a collision the functions created in Swift and there we need to disable this conversion
+@FunctionInterop.FileScopeConversion.Disabled
+public fun SqlCursor.getBoolean(name: String): Boolean = getColumnValue(name) { getBoolean(it) }
+
+@FunctionInterop.FileScopeConversion.Disabled
+public fun SqlCursor.getBytes(name: String): ByteArray = getColumnValue(name) { getBytes(it) }
+
+@FunctionInterop.FileScopeConversion.Disabled
+public fun SqlCursor.getDouble(name: String): Double = getColumnValue(name) { getDouble(it) }
+
+@FunctionInterop.FileScopeConversion.Disabled
+public fun SqlCursor.getLong(name: String): Long = getColumnValue(name) { getLong(it) }
+
+@FunctionInterop.FileScopeConversion.Disabled
+public fun SqlCursor.getString(name: String): String = getColumnValue(name) { getString(it) }
+
+public fun SqlCursor.getBooleanOptional(name: String): Boolean? = getColumnValueOptional(name) { getBoolean(it) }
+
+public fun SqlCursor.getBytesOptional(name: String): ByteArray? = getColumnValueOptional(name) { getBytes(it) }
+
+public fun SqlCursor.getDoubleOptional(name: String): Double? = getColumnValueOptional(name) { getDouble(it) }
+
+public fun SqlCursor.getLongOptional(name: String): Long? = getColumnValueOptional(name) { getLong(it) }
+
+@FunctionInterop.FileScopeConversion.Disabled
+public fun SqlCursor.getStringOptional(name: String): String? = getColumnValueOptional(name) { getString(it) }

--- a/demos/android-supabase-todolist/app/src/main/java/com/powersync/androidexample/powersync/List.kt
+++ b/demos/android-supabase-todolist/app/src/main/java/com/powersync/androidexample/powersync/List.kt
@@ -3,11 +3,11 @@ package com.powersync.demos.powersync
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.powersync.PowerSyncDatabase
+import com.powersync.db.getString
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 
 internal class ListContent(
     private val db: PowerSyncDatabase,
@@ -30,10 +30,10 @@ internal class ListContent(
             GROUP BY $LISTS_TABLE.id
         """) { cursor ->
             ListItem(
-                id = cursor.getString(0)!!,
-                createdAt = cursor.getString(1)!!,
-                name = cursor.getString(2)!!,
-                ownerId = cursor.getString(3)!!
+                id = cursor.getString("id"),
+                createdAt = cursor.getString("created_at"),
+                name = cursor.getString("name"),
+                ownerId = cursor.getString("owner_id")
             )
         }
     }

--- a/demos/android-supabase-todolist/app/src/main/java/com/powersync/androidexample/powersync/Todo.kt
+++ b/demos/android-supabase-todolist/app/src/main/java/com/powersync/androidexample/powersync/Todo.kt
@@ -4,6 +4,9 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import co.touchlab.kermit.Logger
 import com.powersync.PowerSyncDatabase
+import com.powersync.db.getLongOptional
+import com.powersync.db.getString
+import com.powersync.db.getStringOptional
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -31,15 +34,15 @@ internal class Todo(
         if(listId != null) listOf(listId) else null
         ) { cursor ->
             TodoItem(
-                id = cursor.getString(0)!!,
-                createdAt = cursor.getString(1),
-                completedAt = cursor.getString(2),
-                description = cursor.getString(3)!!,
-                createdBy = cursor.getString(4),
-                completedBy = cursor.getString(5),
-                completed = cursor.getLong(6) == 1L,
-                listId = cursor.getString(7)!!,
-                photoId = cursor.getString(8)
+                id = cursor.getString("id"),
+                createdAt = cursor.getStringOptional("created_at"),
+                completedAt = cursor.getStringOptional("completed_at"),
+                description = cursor.getString("description"),
+                createdBy = cursor.getStringOptional("created_by"),
+                completedBy = cursor.getStringOptional("completed_by"),
+                completed = cursor.getLongOptional("completed") == 1L,
+                listId = cursor.getString("list_id"),
+                photoId = cursor.getStringOptional("photo_id")
             )
         }
     }

--- a/demos/hello-powersync/composeApp/src/commonMain/kotlin/com/powersync/demos/PowerSync.kt
+++ b/demos/hello-powersync/composeApp/src/commonMain/kotlin/com/powersync/demos/PowerSync.kt
@@ -3,6 +3,7 @@ package com.powersync.demos
 import com.powersync.DatabaseDriverFactory
 import com.powersync.PowerSyncDatabase
 import com.powersync.connector.supabase.SupabaseConnector
+import com.powersync.db.getString
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.runBlocking
 
@@ -18,7 +19,7 @@ class PowerSync(
     private val database = PowerSyncDatabase(driverFactory, AppSchema)
 
     val db: PowerSyncDatabase
-        get() = database;
+        get() = database
 
     init {
         runBlocking {
@@ -38,9 +39,9 @@ class PowerSync(
     fun watchUsers(): Flow<List<User>> {
         return database.watch("SELECT * FROM customers", mapper = { cursor ->
             User(
-                id = cursor.getString(0)!!,
-                name = cursor.getString(1)!!,
-                email = cursor.getString(2)!!
+                id = cursor.getString("id"),
+                name = cursor.getString("name"),
+                email = cursor.getString("email")
             )
         })
     }

--- a/demos/supabase-todolist/shared/src/commonMain/kotlin/com/powersync/demos/powersync/Todo.kt
+++ b/demos/supabase-todolist/shared/src/commonMain/kotlin/com/powersync/demos/powersync/Todo.kt
@@ -4,6 +4,9 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import co.touchlab.kermit.Logger
 import com.powersync.PowerSyncDatabase
+import com.powersync.db.getLongOptional
+import com.powersync.db.getString
+import com.powersync.db.getStringOptional
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -31,15 +34,15 @@ internal class Todo(
         if(listId != null) listOf(listId) else null
         ) { cursor ->
             TodoItem(
-                id = cursor.getString(0)!!,
-                createdAt = cursor.getString(1),
-                completedAt = cursor.getString(2),
-                description = cursor.getString(3)!!,
-                createdBy = cursor.getString(4),
-                completedBy = cursor.getString(5),
-                completed = cursor.getLong(6) == 1L,
-                listId = cursor.getString(7)!!,
-                photoId = cursor.getString(8)
+                id = cursor.getString("id"),
+                createdAt = cursor.getStringOptional("created_at"),
+                completedAt = cursor.getStringOptional("completed_at"),
+                description = cursor.getString("description"),
+                createdBy = cursor.getStringOptional("created_by"),
+                completedBy = cursor.getStringOptional("completed_by"),
+                completed = cursor.getLongOptional("completed") == 1L,
+                listId = cursor.getString("list_id"),
+                photoId = cursor.getStringOptional("photo_id"),
             )
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ development=true
 RELEASE_SIGNING_ENABLED=true
 # Library config
 GROUP=com.powersync
-LIBRARY_VERSION=1.0.0-BETA19
+LIBRARY_VERSION=1.0.0-BETA20
 GITHUB_REPO=https://github.com/powersync-ja/powersync-kotlin.git
 # POM
 POM_URL=https://github.com/powersync-ja/powersync-kotlin/


### PR DESCRIPTION
## Description

* Add additional SqlCursor functions `getStringOptional`, `getLongOptional`, `getDoubleOptional`, `getBooleanOptional` and `getBytesOptional` when using the column name as a parameter which return optional types. 
* `getString`, `getLong`, `getBytes`, `getDouble` and `getBoolean` used with the column name parameter will now throw an error for non-null values and expect a non-optional return type
* Throw errors for invalid columns on all cursor functions that use the column name parameter
* Update version to Beta20

Previously you would need to assert types and cast
```kotlin
return Todo(
  id: cursor.getString(name: "id")!,
  photoId: cursor.getString(name: "photo_id"),
  isComplete: cursor.getBoolean(name: "completed")! as! Bool,
)
```

now you can use this:

```kotlin
return Todo(
  id: cursor.getString(name: "id"),
  photoId: cursor.getStringOptional(name: "photo_id"),
  isComplete: cursor.getBoolean(name: "completed"),
)
```

## Testing
I've run all the demos and confirmed they work as they did previously. 