### PR TITLE
Some tests for jvm. Column name off-by-one. updateHasSynced() logic f…

### DIFF
--- a/core-test/.gitignore
+++ b/core-test/.gitignore
@@ -1,0 +1,2 @@
+# The testdb file should be deleted after tests run, but just in case, ignore.
+testdb

--- a/core-test/build.gradle.kts
+++ b/core-test/build.gradle.kts
@@ -1,0 +1,81 @@
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
+import org.jetbrains.kotlin.konan.target.HostManager
+
+plugins {
+    alias(libs.plugins.kotlinMultiplatform)
+//    alias(libs.plugins.androidLibrary)
+    alias(libs.plugins.kotlinter)
+}
+
+kotlin {
+//    androidTarget()
+    jvm()
+//    iosX64()
+//    iosArm64()
+//    iosSimulatorArm64()
+
+    targets.configureEach {
+        compilations.configureEach {
+            compileTaskProvider.get().compilerOptions {
+                freeCompilerArgs.add("-Xexpect-actual-classes")
+            }
+        }
+    }
+
+    explicitApi()
+
+    sourceSets {
+        all {
+            languageSettings {
+                optIn("kotlinx.cinterop.ExperimentalForeignApi")
+            }
+        }
+
+        commonMain.dependencies {
+            implementation(project(":core"))
+
+        }
+
+//        androidUnitTest.dependencies {
+//            implementation("org.robolectric:robolectric:4.14")
+//        }
+
+        commonTest.dependencies {
+            implementation(libs.kotlin.test)
+            implementation(libs.test.coroutines)
+            implementation(libs.stately.concurrency)
+        }
+    }
+}
+
+/*
+android {
+    kotlin {
+        jvmToolchain(17)
+    }
+
+    buildFeatures {
+        buildConfig = true
+    }
+
+    buildTypes {
+        release {
+            buildConfigField("boolean", "DEBUG", "false")
+        }
+        debug {
+            buildConfigField("boolean", "DEBUG", "true")
+        }
+    }
+
+    namespace = "com.powersync"
+    compileSdk =
+        libs.versions.android.compileSdk
+            .get()
+            .toInt()
+    defaultConfig {
+        minSdk =
+            libs.versions.android.minSdk
+                .get()
+                .toInt()
+    }
+}*/

--- a/core-test/src/androidUnitTest/kotlin/com/powersync/psdb/PowerSyncDatabaseTest.android.kt
+++ b/core-test/src/androidUnitTest/kotlin/com/powersync/psdb/PowerSyncDatabaseTest.android.kt
@@ -1,0 +1,15 @@
+package com.powersync.psdb
+
+import com.powersync.DatabaseDriverFactory
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+actual abstract class RobolectricTest actual constructor()
+
+actual val factory: DatabaseDriverFactory
+    get() = DatabaseDriverFactory(RuntimeEnvironment.getApplication())

--- a/core-test/src/commonTest/kotlin/com/powersync/psdb/PowerSyncDatabaseTest.kt
+++ b/core-test/src/commonTest/kotlin/com/powersync/psdb/PowerSyncDatabaseTest.kt
@@ -1,0 +1,361 @@
+package com.powersync.psdb
+
+import co.touchlab.stately.concurrency.AtomicBoolean
+import com.powersync.DatabaseDriverFactory
+import com.powersync.PowerSyncDatabase
+import com.powersync.PowerSyncException
+import com.powersync.db.getString
+import com.powersync.db.schema.Column
+import com.powersync.db.schema.Schema
+import com.powersync.db.schema.Table
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+expect abstract class RobolectricTest()
+
+expect fun cleanupDb()
+
+class PowerSyncDatabaseTest : RobolectricTest() {
+    private lateinit var database: PowerSyncDatabase
+
+    @BeforeTest
+    fun testOk() {
+        database = PowerSyncDatabase(
+            factory = factory,
+            schema = Schema(
+                Table(name = "users", columns = listOf(Column.text("name"), Column.text("email")))
+            ),
+            dbFilename = "testdb"
+        )
+    }
+
+    @AfterTest
+    fun tearDown() {
+        runBlocking {
+            database.disconnectAndClear()
+        }
+        cleanupDb()
+    }
+
+    @Test
+    fun testInsertAndGet() {
+        runBlocking {
+            database.execute(
+                sql = "INSERT INTO users (id, name, email) VALUES (?, ?, ?)",
+                parameters = listOf("1", "Test User", "test@example.com")
+            )
+
+            val user = database.get(
+                sql = "SELECT id, name, email FROM users WHERE id = ?",
+                parameters = listOf("1")
+            ) { cursor ->
+                listOf(
+                    cursor.getString(0)!!,
+                    cursor.getString(1)!!,
+                    cursor.getString(2)!!
+                )
+            }
+
+            assertEquals(user[0], "1")
+            assertEquals(user[1], "Test User")
+            assertEquals(user[2], "test@example.com")
+        }
+    }
+
+    @Test
+    fun testWriteTransactionWithInserts() {
+        runBlocking {
+            database.writeTransaction { tx ->
+                tx.execute(
+                    sql = "INSERT INTO users (id, name, email) VALUES (?, ?, ?)",
+                    parameters = listOf("2", "Another User", "another@example.com")
+                )
+                tx.execute(
+                    sql = "INSERT INTO users (id, name, email) VALUES (?, ?, ?)",
+                    parameters = listOf("3", "Third User", "third@example.com")
+                )
+            }
+
+            val users = database.getAll(
+                sql = "SELECT id, name, email FROM users WHERE id IN (?, ?)",
+                parameters = listOf("2", "3")
+            ) { cursor ->
+                listOf(
+                    cursor.getString(0)!!,
+                    cursor.getString(1)!!,
+                    cursor.getString(2)!!
+                )
+            }
+
+            assertEquals(users.size, 2)
+            assertEquals(users[0][0], "2")
+            assertEquals(users[0][1], "Another User")
+            assertEquals(users[0][2], "another@example.com")
+            assertEquals(users[1][0], "3")
+            assertEquals(users[1][1], "Third User")
+            assertEquals(users[1][2], "third@example.com")
+        }
+    }
+
+    @Test
+    fun testInsertAndUpdateTransaction() {
+        runBlocking {
+            database.writeTransaction { tx ->
+                // Insert a new user
+                tx.execute(
+                    sql = "INSERT INTO users (id, name, email) VALUES (?, ?, ?)",
+                    parameters = listOf("4", "Initial User", "initial@example.com")
+                )
+                // Update the user's name and email
+                tx.execute(
+                    sql = "UPDATE users SET name = ?, email = ? WHERE id = ?",
+                    parameters = listOf("Updated User", "updated@example.com", "4")
+                )
+            }
+
+            val user = database.get(
+                sql = "SELECT id, name, email FROM users WHERE id = ?",
+                parameters = listOf("4")
+            ) { cursor ->
+                listOf(
+                    cursor.getString(0)!!,
+                    cursor.getString(1)!!,
+                    cursor.getString(2)!!
+                )
+            }
+
+            assertEquals(user[0], "4")
+            assertEquals(user[1], "Updated User")
+            assertEquals(user[2], "updated@example.com")
+        }
+    }
+
+    @Test
+    fun testInsertAndDeleteTransaction() {
+        runBlocking {
+            database.writeTransaction { tx ->
+                // Insert a new user
+                tx.execute(
+                    sql = "INSERT INTO users (id, name, email) VALUES (?, ?, ?)",
+                    parameters = listOf("5", "User to Delete", "delete@example.com")
+                )
+                // Delete the user
+                tx.execute(
+                    sql = "DELETE FROM users WHERE id = ?",
+                    parameters = listOf("5")
+                )
+            }
+
+            val user = database.getAll(
+                sql = "SELECT id, name, email FROM users WHERE id = ?",
+                parameters = listOf("5")
+            ) { cursor ->
+                listOf(
+                    cursor.getString(0),
+                    cursor.getString(1),
+                    cursor.getString(2)
+                )
+            }
+
+            assertTrue(user.isEmpty())
+        }
+    }
+
+    @Test
+    fun testInsertAndGetByColumnName() {
+        runBlocking {
+            database.execute(
+                sql = "INSERT INTO users (id, name, email) VALUES (?, ?, ?)",
+                parameters = listOf("6", "Column Name User", "columnname@example.com")
+            )
+
+            val user = database.get(
+                sql = "SELECT id, name, email FROM users WHERE id = ?",
+                parameters = listOf("6")
+            ) { cursor ->
+                listOf(
+                    cursor.getString("id"),
+                    cursor.getString("name"),
+                    cursor.getString("email")
+                )
+            }
+
+            assertEquals(user[0], "6")
+            assertEquals(user[1], "Column Name User")
+            assertEquals(user[2], "columnname@example.com")
+        }
+    }
+
+    @Test
+    fun testAccessInvalidColumnName() {
+        runBlocking {
+            database.execute(
+                sql = "INSERT INTO users (id, name, email) VALUES (?, ?, ?)",
+                parameters = listOf("7", "Hello", "invalidcolumn@example.com")
+            )
+            val user = database.get(
+                sql = "SELECT id, name, email FROM users WHERE id = ?",
+                parameters = listOf("7")
+            ) { cursor ->
+                listOf(
+                    cursor.getString("id"),
+                    cursor.getString("name"),
+                    cursor.getString("email")
+                )
+            }
+            assertEquals(user[0], "7")
+            assertEquals(user[1], "Hello")
+            assertEquals(user[2], "invalidcolumn@example.com")
+
+            assertFails {
+                database.get(
+                    sql = "SELECT id, name, email FROM users WHERE id = ?",
+                    parameters = listOf("7")
+                ) { cursor ->
+                    listOf(
+                        cursor.getString("invalid_column_name")
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testQueryOutsideTransaction() {
+        val isDone = AtomicBoolean(false)
+        runBlocking {
+            val txJob = launch {
+                database.writeTransaction { tx ->
+                    // Insert a new user within the transaction
+                    tx.execute(
+                        sql = "INSERT INTO users (id, name, email) VALUES (?, ?, ?)",
+                        parameters = listOf("8", "Transaction User", "transaction@example.com")
+                    )
+                    // This isn't great, but it's a test.
+                    while (!isDone.value) {
+                    }
+                }
+            }
+
+            suspend fun userListQuery(): List<List<String?>> {
+                return database.getAll(
+                    sql = "SELECT id, name, email FROM users WHERE id = ?",
+                    parameters = listOf("8")
+                ) { cursor ->
+                    listOf(
+                        cursor.getString(0),
+                        cursor.getString(1),
+                        cursor.getString(2)
+                    )
+                }
+            }
+
+            // Query outside the transaction should not see the new user
+            assertEquals(userListQuery().size, 0)
+
+            isDone.value = true
+
+            txJob.join()
+
+            // Query after the transaction is complete should see the new user
+            assertEquals(userListQuery().size, 1)
+        }
+    }
+
+    @Test
+    fun testQueryNonExistentTable() {
+        runBlocking {
+            assertFailsWith(PowerSyncException::class) {
+                database.get(
+                    sql = "SELECT * FROM non_existent_table",
+                    parameters = emptyList()
+                ) { cursor ->
+                    emptyList<String>()
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testBulkInsertTransaction() {
+        runBlocking {
+            database.writeTransaction { tx ->
+                for (i in 1..100) {
+                    tx.execute(
+                        sql = "INSERT INTO users (id, name, email) VALUES (?, ?, ?)",
+                        parameters = listOf(i.toString(), "User $i", "user$i@example.com")
+                    )
+                }
+            }
+
+            val users = database.getAll(
+                sql = "SELECT id, name, email FROM users",
+                parameters = emptyList()
+            ) { cursor ->
+                listOf(
+                    cursor.getString(0)!!,
+                    cursor.getString(1)!!,
+                    cursor.getString(2)!!
+                )
+            }
+
+            assertEquals(users.size, 100)
+            for (i in 1..100) {
+                assertEquals(users[i - 1][0], i.toString())
+                assertEquals(users[i - 1][1], "User $i")
+                assertEquals(users[i - 1][2], "user$i@example.com")
+            }
+        }
+    }
+
+    @Test
+    fun testInsertWithNullValues() {
+        runBlocking {
+            database.writeTransaction { tx ->
+                tx.execute(
+                    sql = "INSERT INTO users (id, name, email) VALUES (?, ?, ?)",
+                    parameters = listOf("9", null, "nullname@example.com")
+                )
+                tx.execute(
+                    sql = "INSERT INTO users (id, name, email) VALUES (?, ?, ?)",
+                    parameters = listOf("10", "Null Email User", null)
+                )
+                tx.execute(
+                    sql = "INSERT INTO users (id, name, email) VALUES (?, ?, ?)",
+                    parameters = listOf("11", null, null)
+                )
+            }
+
+            val users = database.getAll(
+                sql = "SELECT id, name, email FROM users WHERE id IN (?, ?, ?) order by CAST(id as decimal)",
+                parameters = listOf("9", "10", "11")
+            ) { cursor ->
+                listOf(
+                    cursor.getString(0),
+                    cursor.getString(1),
+                    cursor.getString(2)
+                )
+            }
+
+            assertEquals(users.size, 3)
+            assertEquals(users[0][0], "9")
+            assertEquals(users[0][1], null)
+            assertEquals(users[0][2], "nullname@example.com")
+            assertEquals(users[1][0], "10")
+            assertEquals(users[1][1], "Null Email User")
+            assertEquals(users[1][2], null)
+            assertEquals(users[2][0], "11")
+            assertEquals(users[2][1], null)
+            assertEquals(users[2][2], null)
+        }
+    }
+}
+
+expect val factory: DatabaseDriverFactory

--- a/core-test/src/iosTest/kotlin/com/powersync/psdb/PowerSyncDatabaseTest.ios.kt
+++ b/core-test/src/iosTest/kotlin/com/powersync/psdb/PowerSyncDatabaseTest.ios.kt
@@ -1,0 +1,15 @@
+package com.powersync.psdb
+
+import com.powersync.DatabaseDriverFactory
+
+actual abstract class RobolectricTest actual constructor()
+
+actual val factory: DatabaseDriverFactory
+    get() = DatabaseDriverFactory()
+
+actual fun cleanupDb() {
+//    val testDbFile = File("testdb")
+//    if(testDbFile.exists()){
+//        testDbFile.delete()
+//    }
+}

--- a/core-test/src/jvmTest/kotlin/com/powersync/psdb/PowerSyncDatabaseTest.jvm.kt
+++ b/core-test/src/jvmTest/kotlin/com/powersync/psdb/PowerSyncDatabaseTest.jvm.kt
@@ -1,0 +1,16 @@
+package com.powersync.psdb
+
+import com.powersync.DatabaseDriverFactory
+import java.io.File
+
+actual abstract class RobolectricTest actual constructor()
+
+actual val factory: DatabaseDriverFactory
+    get() = DatabaseDriverFactory()
+
+actual fun cleanupDb() {
+    val testDbFile = File("testdb")
+    if(testDbFile.exists()){
+        testDbFile.delete()
+    }
+}

--- a/core/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
@@ -286,7 +286,12 @@ internal class PowerSyncDatabaseImpl(
             }
 
         val hasSynced = timestamp != ""
-        if (hasSynced != currentStatus.hasSynced) {
+        if(!hasSynced){
+            // No data has been synced which results in an empty timestamp string
+            // and can be safely ignored.
+            return
+        }
+        if (currentStatus.hasSynced != true) {
             val formattedDateTime = "${timestamp!!.replace(" ", "T").toLocalDateTime()}Z"
             val lastSyncedAt = Instant.parse(formattedDateTime)
             currentStatus.update(hasSynced = hasSynced, lastSyncedAt = lastSyncedAt)

--- a/persistence/src/jvmMain/kotlin/com/powersync/persistence/driver/JdbcPreparedStatement.kt
+++ b/persistence/src/jvmMain/kotlin/com/powersync/persistence/driver/JdbcPreparedStatement.kt
@@ -138,7 +138,7 @@ internal class JdbcCursor(val resultSet: ResultSet) : ColNamesSqlCursor {
     override fun getString(index: Int): String? = resultSet.getString(index + 1)
     override fun getBytes(index: Int): ByteArray? = resultSet.getBytes(index + 1)
     override fun getBoolean(index: Int): Boolean? = getAtIndex(index, resultSet::getBoolean)
-    override fun columnName(index: Int): String? = resultSet.metaData.getColumnName(index)
+    override fun columnName(index: Int): String? = resultSet.metaData.getColumnName(index + 1)
     override val columnCount: Int = resultSet.metaData.columnCount
 
     fun getByte(index: Int): Byte? = getAtIndex(index, resultSet::getByte)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,6 +21,7 @@ dependencyResolutionManagement {
 rootProject.name = "powersync-root"
 
 include(":core")
+include(":core-test")
 include(":connectors:supabase")
 
 include(":dialect")


### PR DESCRIPTION
I started adding more tests for the db logic itself. Both Android and iOS need work to set up the correct native binary link. The jvm tests run, which surfaced an error with column names. Android and iOS are both zero-based, but jvm is 1-based. Additionally, the changes to `updateHasSynced()` changed how initial logic works. Previously, the code would've triggered an NPE and exited early.