### PR TITLE
fix: null pointer in updateHasSynced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.0.0-BETA22
+* Revert `updateHasSynced` internal change that resulted in an error
+
 ## 1.0.0-BETA21
 
 * Improve error handling for Swift by adding @Throws annotation so errors can be handled in Swift

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 1.0.0-BETA22
-* Revert `updateHasSynced` internal change that resulted in an error
+* Fix `updateHasSynced` internal null pointer exception
 
 ## 1.0.0-BETA21
 

--- a/core/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
@@ -279,17 +279,28 @@ internal class PowerSyncDatabaseImpl(
     }
 
     private suspend fun updateHasSynced() {
-        // Query the database to see if any data has been synced.
-        val timestamp =
-            internalDb.getOptional("SELECT powersync_last_synced_at() as synced_at", null) { cursor ->
-                cursor.getString(0) ?: ""
+        try {
+            data class SyncedAt(
+                val syncedAt: String?,
+            )
+            // Query the database to see if any data has been synced
+            val timestamp =
+                internalDb
+                    .getOptional("SELECT powersync_last_synced_at() as synced_at", null) { cursor ->
+                        SyncedAt(syncedAt = cursor.getStringOptional("synced_at"))
+                    }?.syncedAt
+            val hasSynced = timestamp != null
+            if (hasSynced != currentStatus.hasSynced) {
+                val formattedDateTime = "${timestamp!!.replace(" ","T").toLocalDateTime()}Z"
+                val lastSyncedAt = Instant.parse(formattedDateTime)
+                currentStatus.update(hasSynced = hasSynced, lastSyncedAt = lastSyncedAt)
             }
-
-        val hasSynced = timestamp != ""
-        if (hasSynced != currentStatus.hasSynced) {
-            val formattedDateTime = "${timestamp!!.replace(" ", "T").toLocalDateTime()}Z"
-            val lastSyncedAt = Instant.parse(formattedDateTime)
-            currentStatus.update(hasSynced = hasSynced, lastSyncedAt = lastSyncedAt)
+        } catch (e: Exception) {
+            if (e is NullPointerException) {
+                // No data has been synced which results in a null pointer exception
+                // and can be safely ignored.
+                return
+            }
         }
     }
 

--- a/core/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
@@ -279,28 +279,20 @@ internal class PowerSyncDatabaseImpl(
     }
 
     private suspend fun updateHasSynced() {
-        try {
-            data class SyncedAt(
-                val syncedAt: String?,
-            )
-            // Query the database to see if any data has been synced
-            val timestamp =
-                internalDb
-                    .getOptional("SELECT powersync_last_synced_at() as synced_at", null) { cursor ->
-                        SyncedAt(syncedAt = cursor.getStringOptional("synced_at"))
-                    }?.syncedAt
-            val hasSynced = timestamp != null
-            if (hasSynced != currentStatus.hasSynced) {
-                val formattedDateTime = "${timestamp!!.replace(" ","T").toLocalDateTime()}Z"
-                val lastSyncedAt = Instant.parse(formattedDateTime)
-                currentStatus.update(hasSynced = hasSynced, lastSyncedAt = lastSyncedAt)
-            }
-        } catch (e: Exception) {
-            if (e is NullPointerException) {
-                // No data has been synced which results in a null pointer exception
-                // and can be safely ignored.
-                return
-            }
+        data class SyncedAt(
+            val syncedAt: String?,
+        )
+        // Query the database to see if any data has been synced
+        val timestamp =
+            internalDb
+                .getOptional("SELECT powersync_last_synced_at() as synced_at", null) { cursor ->
+                    SyncedAt(syncedAt = cursor.getStringOptional("synced_at"))
+                }?.syncedAt
+        val hasSynced = timestamp != null
+        if (currentStatus.hasSynced != null && hasSynced != currentStatus.hasSynced) {
+            val formattedDateTime = "${timestamp!!.replace(" ","T").toLocalDateTime()}Z"
+            val lastSyncedAt = Instant.parse(formattedDateTime)
+            currentStatus.update(hasSynced = hasSynced, lastSyncedAt = lastSyncedAt)
         }
     }
 

--- a/core/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
@@ -295,6 +295,8 @@ internal class PowerSyncDatabaseImpl(
                 val lastSyncedAt = Instant.parse(formattedDateTime)
                 currentStatus.update(hasSynced = hasSynced, lastSyncedAt = lastSyncedAt)
             }
+        } else {
+            currentStatus.update(hasSynced = false)
         }
     }
 

--- a/core/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
@@ -288,11 +288,13 @@ internal class PowerSyncDatabaseImpl(
                 .getOptional("SELECT powersync_last_synced_at() as synced_at", null) { cursor ->
                     SyncedAt(syncedAt = cursor.getStringOptional("synced_at"))
                 }?.syncedAt
-        val hasSynced = timestamp != null
-        if (currentStatus.hasSynced != null && hasSynced != currentStatus.hasSynced) {
-            val formattedDateTime = "${timestamp!!.replace(" ","T").toLocalDateTime()}Z"
-            val lastSyncedAt = Instant.parse(formattedDateTime)
-            currentStatus.update(hasSynced = hasSynced, lastSyncedAt = lastSyncedAt)
+        if (timestamp != null) {
+            val hasSynced = true
+            if (currentStatus.hasSynced != null && hasSynced != currentStatus.hasSynced) {
+                val formattedDateTime = "${timestamp.replace(" ", "T").toLocalDateTime()}Z"
+                val lastSyncedAt = Instant.parse(formattedDateTime)
+                currentStatus.update(hasSynced = hasSynced, lastSyncedAt = lastSyncedAt)
+            }
         }
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ development=true
 RELEASE_SIGNING_ENABLED=true
 # Library config
 GROUP=com.powersync
-LIBRARY_VERSION=1.0.0-BETA21
+LIBRARY_VERSION=1.0.0-BETA22
 GITHUB_REPO=https://github.com/powersync-ja/powersync-kotlin.git
 # POM
 POM_URL=https://github.com/powersync-ja/powersync-kotlin/


### PR DESCRIPTION
## Description
Fix issue in `updateHasSynced` where null timestamp was allowed through. The issue was that `currentStatus.hasSynced` is initialized to `null` and not `false` so this check `if (hasSynced != currentStatus.hasSynced)` was always true.

## Testing 
Tested in Swift SDK and ran the supabase todolist app

