### PR TITLE
chore: make execute throwable in swift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
+## 1.0.0-BETA23
+
+* Make `execute` throwable for Swift
+
 ## 1.0.0-BETA22
+
 * Fix `updateHasSynced` internal null pointer exception
 
 ## 1.0.0-BETA21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.0.0-BETA23
 
-* Make `execute` throwable for Swift
+* Make `execute` and `PowerSyncTransaction` functions throwable for Swift
 
 ## 1.0.0-BETA22
 

--- a/core/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
@@ -13,7 +13,7 @@ import com.powersync.db.crud.CrudRow
 import com.powersync.db.crud.CrudTransaction
 import com.powersync.db.internal.InternalDatabaseImpl
 import com.powersync.db.internal.InternalTable
-import com.powersync.db.internal.PowerSyncTransaction
+import com.powersync.db.internal.ThrowableTransactionCallback
 import com.powersync.db.schema.Schema
 import com.powersync.sync.SyncStatus
 import com.powersync.sync.SyncStream
@@ -222,9 +222,9 @@ internal class PowerSyncDatabaseImpl(
         mapper: (SqlCursor) -> RowType,
     ): Flow<List<RowType>> = internalDb.watch(sql, parameters, mapper)
 
-    override suspend fun <R> readTransaction(callback: (PowerSyncTransaction) -> R): R = internalDb.writeTransaction(callback)
+    override suspend fun <R> readTransaction(callback: ThrowableTransactionCallback<R>): R = internalDb.writeTransaction(callback)
 
-    override suspend fun <R> writeTransaction(callback: (PowerSyncTransaction) -> R): R = internalDb.writeTransaction(callback)
+    override suspend fun <R> writeTransaction(callback: ThrowableTransactionCallback<R>): R = internalDb.writeTransaction(callback)
 
     override suspend fun execute(
         sql: String,

--- a/core/src/commonMain/kotlin/com/powersync/db/Queries.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/Queries.kt
@@ -1,7 +1,7 @@
 package com.powersync.db
 
 import com.powersync.PowerSyncException
-import com.powersync.db.internal.PowerSyncTransaction
+import com.powersync.db.internal.ThrowableTransactionCallback
 import kotlinx.coroutines.flow.Flow
 import kotlin.coroutines.cancellation.CancellationException
 
@@ -58,8 +58,8 @@ public interface Queries {
     ): Flow<List<RowType>>
 
     @Throws(PowerSyncException::class, CancellationException::class)
-    public suspend fun <R> writeTransaction(callback: (PowerSyncTransaction) -> R): R
+    public suspend fun <R> writeTransaction(callback: ThrowableTransactionCallback<R>): R
 
     @Throws(PowerSyncException::class, CancellationException::class)
-    public suspend fun <R> readTransaction(callback: (PowerSyncTransaction) -> R): R
+    public suspend fun <R> readTransaction(callback: ThrowableTransactionCallback<R>): R
 }

--- a/core/src/commonMain/kotlin/com/powersync/db/internal/InternalDatabaseImpl.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/internal/InternalDatabaseImpl.kt
@@ -7,11 +7,13 @@ import app.cash.sqldelight.coroutines.mapToList
 import app.cash.sqldelight.db.QueryResult
 import app.cash.sqldelight.db.SqlPreparedStatement
 import com.persistence.PowersyncQueries
+import com.powersync.PowerSyncException
 import com.powersync.PsSqlDriver
 import com.powersync.db.SqlCursor
 import com.powersync.db.runWrapped
 import com.powersync.persistence.PsDatabase
 import com.powersync.utils.JsonUtil
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.FlowPreview
@@ -216,26 +218,28 @@ internal class InternalDatabaseImpl(
             }
         }
 
-    override suspend fun <R> readTransaction(callback: (PowerSyncTransaction) -> R): R =
+    override suspend fun <R> readTransaction(callback: ThrowableTransactionCallback<R>): R =
         withContext(dbContext) {
             transactor.transactionWithResult(noEnclosing = true) {
-                val res = callback(transaction)
-                if (res == TransactionResponse.ROLLBACK) {
-                    rollback(null as R)
-                } else {
-                    res
+                runWrapped {
+                    val result = callback.execute(transaction)
+                    if (result is PowerSyncException) {
+                        throw result
+                    }
+                    result
                 }
             }
         }
 
-    override suspend fun <R> writeTransaction(callback: (PowerSyncTransaction) -> R): R =
+    override suspend fun <R> writeTransaction(callback: ThrowableTransactionCallback<R>): R =
         withContext(dbContext) {
             transactor.transactionWithResult(noEnclosing = true) {
-                val res = callback(transaction)
-                if (res == TransactionResponse.ROLLBACK) {
-                    rollback(null as R)
-                } else {
-                    res
+                runWrapped {
+                    val result = callback.execute(transaction)
+                    if (result is PowerSyncException) {
+                        throw result
+                    }
+                    result
                 }
             }
         }
@@ -344,7 +348,10 @@ internal fun getBindersFromParams(parameters: List<Any?>?): (SqlPreparedStatemen
     }
 }
 
-public enum class TransactionResponse {
-    ROLLBACK,
+/**
+ * Kotlin allows SAM (Single Abstract Method) interfaces to be treated like lambda expressions.
+ */
+public fun interface ThrowableTransactionCallback<R> {
+    @Throws(PowerSyncException::class, CancellationException::class)
+    public fun execute(transaction: PowerSyncTransaction): R
 }
-

--- a/core/src/commonMain/kotlin/com/powersync/db/internal/InternalDatabaseImpl.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/internal/InternalDatabaseImpl.kt
@@ -216,7 +216,7 @@ internal class InternalDatabaseImpl(
             }
         }
 
-    override suspend fun <R> readTransaction(callback: PowerSyncTransaction.() -> R): R =
+    override suspend fun <R> readTransaction(callback: (PowerSyncTransaction) -> R): R =
         withContext(dbContext) {
             transactor.transactionWithResult(noEnclosing = true) {
                 val res = callback(transaction)
@@ -228,7 +228,7 @@ internal class InternalDatabaseImpl(
             }
         }
 
-    override suspend fun <R> writeTransaction(callback: PowerSyncTransaction.() -> R): R =
+    override suspend fun <R> writeTransaction(callback: (PowerSyncTransaction) -> R): R =
         withContext(dbContext) {
             transactor.transactionWithResult(noEnclosing = true) {
                 val res = callback(transaction)

--- a/core/src/commonMain/kotlin/com/powersync/db/internal/InternalDatabaseImpl.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/internal/InternalDatabaseImpl.kt
@@ -219,14 +219,24 @@ internal class InternalDatabaseImpl(
     override suspend fun <R> readTransaction(callback: PowerSyncTransaction.() -> R): R =
         withContext(dbContext) {
             transactor.transactionWithResult(noEnclosing = true) {
-                callback(transaction)
+                val res = callback(transaction)
+                if (res == TransactionResponse.ROLLBACK) {
+                    rollback(null as R)
+                } else {
+                    res
+                }
             }
         }
 
     override suspend fun <R> writeTransaction(callback: PowerSyncTransaction.() -> R): R =
         withContext(dbContext) {
             transactor.transactionWithResult(noEnclosing = true) {
-                callback(transaction)
+                val res = callback(transaction)
+                if (res == TransactionResponse.ROLLBACK) {
+                    rollback(null as R)
+                } else {
+                    res
+                }
             }
         }
 
@@ -333,3 +343,8 @@ internal fun getBindersFromParams(parameters: List<Any?>?): (SqlPreparedStatemen
         }
     }
 }
+
+public enum class TransactionResponse {
+    ROLLBACK,
+}
+

--- a/core/src/commonMain/kotlin/com/powersync/db/internal/InternalDatabaseImpl.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/internal/InternalDatabaseImpl.kt
@@ -91,13 +91,15 @@ internal class InternalDatabaseImpl(
     ): Long {
         val numParams = parameters?.size ?: 0
 
-        return driver
-            .execute(
-                identifier = null,
-                sql = sql,
-                parameters = numParams,
-                binders = getBindersFromParams(parameters),
-            ).value
+        return runWrapped {
+            driver
+                .execute(
+                    identifier = null,
+                    sql = sql,
+                    parameters = numParams,
+                    binders = getBindersFromParams(parameters),
+                ).value
+        }
     }
 
     override suspend fun <RowType : Any> get(

--- a/core/src/commonMain/kotlin/com/powersync/db/internal/PowerSyncTransaction.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/internal/PowerSyncTransaction.kt
@@ -1,25 +1,31 @@
 package com.powersync.db.internal
 
+import com.powersync.PowerSyncException
 import com.powersync.db.SqlCursor
+import kotlin.coroutines.cancellation.CancellationException
 
 public interface PowerSyncTransaction {
+    @Throws(PowerSyncException::class, CancellationException::class)
     public fun execute(
         sql: String,
         parameters: List<Any?>? = listOf(),
     ): Long
 
+    @Throws(PowerSyncException::class, CancellationException::class)
     public fun <RowType : Any> getOptional(
         sql: String,
         parameters: List<Any?>? = listOf(),
         mapper: (SqlCursor) -> RowType,
     ): RowType?
 
+    @Throws(PowerSyncException::class, CancellationException::class)
     public fun <RowType : Any> getAll(
         sql: String,
         parameters: List<Any?>? = listOf(),
         mapper: (SqlCursor) -> RowType,
     ): List<RowType>
 
+    @Throws(PowerSyncException::class, CancellationException::class)
     public fun <RowType : Any> get(
         sql: String,
         parameters: List<Any?>? = listOf(),

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ development=true
 RELEASE_SIGNING_ENABLED=true
 # Library config
 GROUP=com.powersync
-LIBRARY_VERSION=1.0.0-BETA22
+LIBRARY_VERSION=1.0.0-BETA23
 GITHUB_REPO=https://github.com/powersync-ja/powersync-kotlin.git
 # POM
 POM_URL=https://github.com/powersync-ja/powersync-kotlin/


### PR DESCRIPTION
## Description
Make `execute` throwable in Swift so users of the Swift SDK can handle errors thrown in the `execute` function

See Swift PR https://github.com/powersync-ja/powersync-swift/pull/21 for new tests included to confirm this