### PR TITLE
Avoid catching CancellationException in `runWrappedSuspending`

### DIFF
--- a/core/src/commonMain/kotlin/com/powersync/db/Functions.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/Functions.kt
@@ -2,6 +2,7 @@ package com.powersync.db
 
 import co.touchlab.kermit.Logger
 import com.powersync.PowerSyncException
+import kotlinx.coroutines.CancellationException
 
 public fun <R> runWrapped(block: () -> R): R =
     try {
@@ -20,6 +21,10 @@ public suspend fun <R> runWrappedSuspending(block: suspend () -> R): R =
     try {
         block()
     } catch (t: Throwable) {
+        if (t is CancellationException) {
+            throw t
+        }
+
         if (t is PowerSyncException) {
             Logger.e("PowerSyncException: ${t.message}")
             throw t


### PR DESCRIPTION
Just like in https://github.com/powersync-ja/powersync-kotlin/pull/104#discussion_r1916084097 , you should never catch `CancellationException`