### PR TITLE
Prepare release for 1.0.0-BETA26

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     uses: ./.github/workflows/test.yml
   deploy:
-    needs: [test, build-native]
+    needs: [test]
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,39 +8,6 @@ permissions:
 jobs:
   test:
     uses: ./.github/workflows/test.yml
-  build-native:
-    name: Build native lib
-    strategy:
-      matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Validate Gradle Wrapper
-        uses: gradle/actions/wrapper-validation@v4
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-      - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v4
-      - name: Install cross-compiler
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: sudo apt install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
-      - name: Build native lib
-        run: |
-          ./gradlew \
-            -PGITHUB_PUBLISH_TOKEN=${{ secrets.GITHUB_TOKEN }} \
-            -Ppowersync.binaries.cross-arch=true \
-            :core:cmakeJvmBuild
-        shell: bash
-      - name: Upload build
-        uses: actions/upload-artifact@v4
-        with:
-          name: binaries-${{ matrix.os }}
-          path: core/build/binaries/desktop/sqlite/
   deploy:
     needs: [test, build-native]
     runs-on: macos-latest
@@ -58,14 +25,7 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v3
-      - name: Download native binaries
-        uses: actions/download-artifact@v4
-        with:
-          path: core/binaries/desktop
-          merge-multiple: true
-      - name: Display downloaded files
-        run: ls -lR core/binaries/desktop
+        uses: gradle/actions/setup-gradle@v4
       - name: Gradle publish
         run: |
           ./gradlew \
@@ -75,7 +35,7 @@ jobs:
             -PsigningInMemoryKeyPassword="${{ secrets.SIGNING_PASSWORD }}" \
             -PcentralPortal.username="${{secrets.SONATYPE_USERNAME}}" \
             -PcentralPortal.password="${{secrets.SONATYPE_PASSWORD}}" \
-            -Ppowersync.binaries.provided="true" \
+            -Ppowersync.binaries.allPlatforms="true" \
             publishAllPublicationsToSonatypeRepository
         shell: bash
   # This will change Package.swift in Github packages to direct to new maven central KMMBridge zip file

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.0-BETA26
+
+* Support bucket priorities and partial syncs.
+* Android: Add ProGuard rules to prevent methods called through JNI from being minified or removed.
+
 ## 1.0.0-BETA25
 
 * JVM: Lower minimum supported version from 17 to 8.

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ development=true
 RELEASE_SIGNING_ENABLED=true
 # Library config
 GROUP=com.powersync
-LIBRARY_VERSION=1.0.0-BETA25
+LIBRARY_VERSION=1.0.0-BETA26
 GITHUB_REPO=https://github.com/powersync-ja/powersync-kotlin.git
 # POM
 POM_URL=https://github.com/powersync-ja/powersync-kotlin/


### PR DESCRIPTION
First, this adapts the release workflow after the changes in https://github.com/powersync-ja/powersync-kotlin/pull/129: Since we're not compiling native code for the JVM release anymore, we don't need separate builds for cross-platform support either. We just need to make sure that the downloaded binaries for the core SQLite extensions are present for all platforms we support.
For this, I ran `./gradlew -Ppowersync.binaries.allPlatforms="true" publishAllPublicationsToSonatypeLocalRepository` manually and validated that the emitted `core-jvm-1.0.0-BETA26.jar` contains all the libraries we need.

Apart from that change, this is a regular version bump.