### PR TITLE
Fix release pipeline

### DIFF
--- a/plugins/sonatype/src/main/kotlin/com/powersync/plugins/sonatype/SonatypeCentralExtension.kt
+++ b/plugins/sonatype/src/main/kotlin/com/powersync/plugins/sonatype/SonatypeCentralExtension.kt
@@ -18,6 +18,7 @@ public abstract class SonatypeCentralExtension(
         public const val NAME: String = "sonatypePublishing"
         public const val GROUP: String = "publishing"
         public const val REPO_DIR: String = "sonatypeLocal"
+        public const val UNIFIED_REPO_DIR: String = "testingLocal"
         public const val BUNDLE_DIR: String = "sonatypeBundles"
 
         public const val PUBLISH_TASK_NAME: String = "publishAllPublicationsToSonatypeRepository"
@@ -34,7 +35,11 @@ public abstract class SonatypeCentralExtension(
         log.info("Setting up the `:${PUBLISH_LOCAL_TASK_NAME}` task")
         project.gradlePublishing.repositories.maven { repo ->
             repo.name = REPO_DIR
-            repo.url = project.uri(project.rootProject.layout.buildDirectory.dir(REPO_DIR))
+            repo.url = project.uri(project.layout.buildDirectory.dir(REPO_DIR))
+        }
+        project.gradlePublishing.repositories.maven { repo ->
+            repo.name = UNIFIED_REPO_DIR
+            repo.url = project.uri(project.rootProject.layout.buildDirectory.dir(UNIFIED_REPO_DIR))
         }
 
         log.info("Setting up the `:${COMPONENT_BUNDLE_TASK_NAME}` task")

--- a/plugins/sonatype/src/main/kotlin/com/powersync/plugins/sonatype/SonatypeCentralExtension.kt
+++ b/plugins/sonatype/src/main/kotlin/com/powersync/plugins/sonatype/SonatypeCentralExtension.kt
@@ -18,7 +18,6 @@ public abstract class SonatypeCentralExtension(
         public const val NAME: String = "sonatypePublishing"
         public const val GROUP: String = "publishing"
         public const val REPO_DIR: String = "sonatypeLocal"
-        public const val UNIFIED_REPO_DIR: String = "testingLocal"
         public const val BUNDLE_DIR: String = "sonatypeBundles"
 
         public const val PUBLISH_TASK_NAME: String = "publishAllPublicationsToSonatypeRepository"
@@ -36,10 +35,6 @@ public abstract class SonatypeCentralExtension(
         project.gradlePublishing.repositories.maven { repo ->
             repo.name = REPO_DIR
             repo.url = project.uri(project.layout.buildDirectory.dir(REPO_DIR))
-        }
-        project.gradlePublishing.repositories.maven { repo ->
-            repo.name = UNIFIED_REPO_DIR
-            repo.url = project.uri(project.rootProject.layout.buildDirectory.dir(UNIFIED_REPO_DIR))
         }
 
         log.info("Setting up the `:${COMPONENT_BUNDLE_TASK_NAME}` task")


### PR DESCRIPTION
In 3a57b1b6a8dbe11f25faeed2b81c2132c59fa45c, I've changed the destination for the publishing tasks from a per-project directory to a single directory for the entire project. This is useful for me to test that publishing is working locally. Unfortunately, I overlooked that the rest of our Sonatype publishing pipeline depends on these per-project files 🙃 

This reverts that change, which should fix the release pipeline.