### PR TITLE
Improve Watch Queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ captures
 Pods/
 dialect/bin
 .build
+.vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.0-BETA27
+
+* Improved watch query internals. Added the ability to throttle watched queries.
+
 ## 1.0.0-BETA26
 
 * Support bucket priorities and partial syncs.

--- a/core-tests-android/src/androidTest/java/com/powersync/AndroidDatabaseTest.kt
+++ b/core-tests-android/src/androidTest/java/com/powersync/AndroidDatabaseTest.kt
@@ -96,8 +96,6 @@ class AndroidDatabaseTest {
             }
         }
 
-    @Test
-    fun testThrottledTableUpdates() =
         runTest {
             turbineScope {
                 // Avoids skipping delays

--- a/core-tests-android/src/androidTest/java/com/powersync/AndroidDatabaseTest.kt
+++ b/core-tests-android/src/androidTest/java/com/powersync/AndroidDatabaseTest.kt
@@ -1,23 +1,18 @@
 package com.powersync
 
-import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
 import app.cash.turbine.turbineScope
 import com.powersync.db.schema.Schema
 import com.powersync.testutils.UserRow
+import kotlinx.coroutines.*
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.advanceTimeBy
 import org.junit.After
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.*
-
-
-import org.junit.Test
-import org.junit.runner.RunWith
-
 import org.junit.Assert.*
 import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class AndroidDatabaseTest {
@@ -93,60 +88,6 @@ class AndroidDatabaseTest {
 
                 query.expectNoEvents()
                 query.cancel()
-            }
-        }
-
-        runTest {
-            turbineScope {
-                // Avoids skipping delays
-                withContext(Dispatchers.Default) {
-                    val query =
-                        database.watch(
-                            "SELECT * FROM users",
-                            throttleMs = 1000
-                        ) { UserRow.from(it) }.testIn(this)
-
-                    // Wait for initial query
-                    assertEquals(0, query.awaitItem().size)
-
-                    database.execute(
-                        "INSERT INTO users (id, name, email) VALUES (uuid(), ?, ?)",
-                        listOf("Test", "test@example.org"),
-                    )
-
-                    database.writeTransaction {
-                        it.execute(
-                            "INSERT INTO users (id, name, email) VALUES (uuid(), ?, ?)",
-                            listOf("Test2", "test2@example.org"),
-                        )
-                        it.execute(
-                            "INSERT INTO users (id, name, email) VALUES (uuid(), ?, ?)",
-                            listOf("Test3", "test3@example.org"),
-                        )
-                    }
-
-                    assertEquals(3, query.awaitItem().size)
-
-                    try {
-                        database.writeTransaction {
-                            it.execute("DELETE FROM users;")
-                            it.execute("syntax error, revert please")
-                        }
-                    } catch (e: Exception) {
-                        // Ignore
-                    }
-
-                    database.execute(
-                        "INSERT INTO users (id, name, email) VALUES (uuid(), ?, ?)",
-                        listOf("Test4", "test4@example.org"),
-                    )
-                    assertEquals(4, query.awaitItem().size)
-
-                    query.expectNoEvents()
-                    query.cancel()
-
-                }
-
             }
         }
 }

--- a/core/src/commonMain/kotlin/com/powersync/PsSqlDriver.kt
+++ b/core/src/commonMain/kotlin/com/powersync/PsSqlDriver.kt
@@ -34,20 +34,24 @@ internal class PsSqlDriver(
     }
 
     // Flows on table updates containing tables
-    fun updatesOnTables(tableNames: Set<String>, throttleMs: Long?): Flow<Unit> {
+    fun updatesOnTables(
+        tableNames: Set<String>,
+        throttleMs: Long?,
+    ): Flow<Unit> {
         // Spread the input table names in order to account for internal views
         val resolvedTableNames =
             tableNames
                 .flatMap { t -> setOf("ps_data__$t", "ps_data_local__$t", t) }
                 .toSet()
-        var flow = tableUpdatesFlow
-            .asSharedFlow()
-            .filter {
-                it
-                    .intersect(
-                        resolvedTableNames,
-                    ).isNotEmpty()
-            }
+        var flow =
+            tableUpdatesFlow
+                .asSharedFlow()
+                .filter {
+                    it
+                        .intersect(
+                            resolvedTableNames,
+                        ).isNotEmpty()
+                }
 
         if (throttleMs != null) {
             flow = flow.throttle(throttleMs)

--- a/core/src/commonMain/kotlin/com/powersync/PsSqlDriver.kt
+++ b/core/src/commonMain/kotlin/com/powersync/PsSqlDriver.kt
@@ -27,20 +27,18 @@ internal class PsSqlDriver(
     }
 
     fun clearTableUpdates() {
-        // This should only ever be executed on rollback which should be executed via the
-        // IO Dispatcher.
+        // This should only ever be executed by an execute operation which should
+        // always be executed with the IO Dispatcher
         runBlocking {
             pendingUpdates.clear()
         }
     }
 
     // Flows on any table change
-    // This specifically returns a SharedFlow for timing considerations
-    fun updatesOnTables(): SharedFlow<Set<String>> {
-        // Spread the input table names in order to account for internal views
-        return tableUpdatesFlow
+    // This specifically returns a SharedFlow for downstream timing considerations
+    fun updatesOnTables(): SharedFlow<Set<String>> =
+        tableUpdatesFlow
             .asSharedFlow()
-    }
 
     suspend fun fireTableUpdates() {
         val updates = pendingUpdates.toSet(true)

--- a/core/src/commonMain/kotlin/com/powersync/PsSqlDriver.kt
+++ b/core/src/commonMain/kotlin/com/powersync/PsSqlDriver.kt
@@ -3,10 +3,11 @@ package com.powersync
 import app.cash.sqldelight.db.SqlDriver
 import com.powersync.utils.AtomicMutableSet
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.launch
 
 internal class PsSqlDriver(
     private val driver: SqlDriver,
@@ -19,17 +20,13 @@ internal class PsSqlDriver(
     private val pendingUpdates = AtomicMutableSet<String>()
 
     fun updateTable(tableName: String) {
-        // This should only ever be executed by an execute operation which should
-        // always be executed with the IO Dispatcher
-        runBlocking {
+        scope.launch {
             pendingUpdates.add(tableName)
         }
     }
 
     fun clearTableUpdates() {
-        // This should only ever be executed by an execute operation which should
-        // always be executed with the IO Dispatcher
-        runBlocking {
+        scope.launch {
             pendingUpdates.clear()
         }
     }
@@ -41,7 +38,12 @@ internal class PsSqlDriver(
             .asSharedFlow()
 
     suspend fun fireTableUpdates() {
-        val updates = pendingUpdates.toSet(true)
-        tableUpdatesFlow.emit(updates)
+        // Use the same scope as the async table updates, this should help with queuing
+        val job =
+            scope.async {
+                val updates = pendingUpdates.toSet(true)
+                tableUpdatesFlow.emit(updates)
+            }
+        job.await()
     }
 }

--- a/core/src/commonMain/kotlin/com/powersync/bucket/BucketStorageImpl.kt
+++ b/core/src/commonMain/kotlin/com/powersync/bucket/BucketStorageImpl.kt
@@ -18,7 +18,6 @@ internal class BucketStorageImpl(
     private val db: InternalDatabase,
     private val logger: Logger,
 ) : BucketStorage {
-    private val tableNames: MutableSet<String> = mutableSetOf()
     private var hasCompletedSync = AtomicBoolean(false)
     private var pendingBucketDeletes = AtomicBoolean(false)
 
@@ -30,18 +29,6 @@ internal class BucketStorageImpl(
     companion object {
         const val MAX_OP_ID = "9223372036854775807"
         const val COMPACT_OPERATION_INTERVAL = 1_000
-    }
-
-    init {
-        readTableNames()
-    }
-
-    private fun readTableNames() {
-        tableNames.clear()
-        // Query to get existing table names
-        val names = db.getExistingTableNames("ps_data_*")
-
-        tableNames.addAll(names)
     }
 
     override fun getMaxOpId(): String = MAX_OP_ID

--- a/core/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
@@ -142,8 +142,10 @@ internal class PowerSyncDatabaseImpl(
         uploadJob =
             scope.launch {
                 internalDb
-                    .updatesOnTables(setOf(InternalTable.CRUD.toString()))
-                    .debounce(crudThrottleMs)
+                    .updatesOnTables(
+                        setOf(InternalTable.CRUD.toString()),
+                        throttleMs = crudThrottleMs
+                    )
                     .collect {
                         syncStream!!.triggerCrudUpload()
                     }
@@ -213,7 +215,8 @@ internal class PowerSyncDatabaseImpl(
         }
     }
 
-    override suspend fun getPowerSyncVersion(): String = internalDb.queries.powerSyncVersion().executeAsOne()
+    override suspend fun getPowerSyncVersion(): String =
+        internalDb.queries.powerSyncVersion().executeAsOne()
 
     override suspend fun <RowType : Any> get(
         sql: String,
@@ -240,9 +243,11 @@ internal class PowerSyncDatabaseImpl(
         mapper: (SqlCursor) -> RowType,
     ): Flow<List<RowType>> = internalDb.watch(sql, parameters, throttleMs, mapper)
 
-    override suspend fun <R> readTransaction(callback: ThrowableTransactionCallback<R>): R = internalDb.writeTransaction(callback)
+    override suspend fun <R> readTransaction(callback: ThrowableTransactionCallback<R>): R =
+        internalDb.writeTransaction(callback)
 
-    override suspend fun <R> writeTransaction(callback: ThrowableTransactionCallback<R>): R = internalDb.writeTransaction(callback)
+    override suspend fun <R> writeTransaction(callback: ThrowableTransactionCallback<R>): R =
+        internalDb.writeTransaction(callback)
 
     override suspend fun execute(
         sql: String,

--- a/core/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
@@ -139,11 +139,12 @@ internal class PowerSyncDatabaseImpl(
             }
         }
 
-        uploadJob =
+        uploadJob = 
             scope.launch {
-                internalDb.updatesOnTables(setOf(InternalTable.CRUD.toString())).debounce(crudThrottleMs).collect {
-                    syncStream!!.triggerCrudUpload()
-                }
+                internalDb.updatesOnTables(setOf(InternalTable.CRUD.toString()))
+                    .debounce(crudThrottleMs).collect {
+                        syncStream!!.triggerCrudUpload()
+                    }
             }
     }
 
@@ -210,7 +211,8 @@ internal class PowerSyncDatabaseImpl(
         }
     }
 
-    override suspend fun getPowerSyncVersion(): String = internalDb.queries.powerSyncVersion().executeAsOne()
+    override suspend fun getPowerSyncVersion(): String =
+        internalDb.queries.powerSyncVersion().executeAsOne()
 
     override suspend fun <RowType : Any> get(
         sql: String,
@@ -233,12 +235,15 @@ internal class PowerSyncDatabaseImpl(
     override fun <RowType : Any> watch(
         sql: String,
         parameters: List<Any?>?,
+        throttleMs: Long?,
         mapper: (SqlCursor) -> RowType,
-    ): Flow<List<RowType>> = internalDb.watch(sql, parameters, mapper)
+    ): Flow<List<RowType>> = internalDb.watch(sql, parameters, throttleMs, mapper)
 
-    override suspend fun <R> readTransaction(callback: ThrowableTransactionCallback<R>): R = internalDb.writeTransaction(callback)
+    override suspend fun <R> readTransaction(callback: ThrowableTransactionCallback<R>): R =
+        internalDb.writeTransaction(callback)
 
-    override suspend fun <R> writeTransaction(callback: ThrowableTransactionCallback<R>): R = internalDb.writeTransaction(callback)
+    override suspend fun <R> writeTransaction(callback: ThrowableTransactionCallback<R>): R =
+        internalDb.writeTransaction(callback)
 
     override suspend fun execute(
         sql: String,
@@ -280,7 +285,11 @@ internal class PowerSyncDatabaseImpl(
             syncStream = null
         }
 
-        currentStatus.update(connected = false, connecting = false, lastSyncedAt = currentStatus.lastSyncedAt)
+        currentStatus.update(
+            connected = false,
+            connecting = false,
+            lastSyncedAt = currentStatus.lastSyncedAt
+        )
     }
 
     override suspend fun disconnectAndClear(clearLocal: Boolean) {

--- a/core/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
@@ -141,7 +141,7 @@ internal class PowerSyncDatabaseImpl(
 
         uploadJob =
             scope.launch {
-                internalDb.updatesOnTable(InternalTable.CRUD.toString()).debounce(crudThrottleMs).collect {
+                internalDb.updatesOnTables(setOf(InternalTable.CRUD.toString())).debounce(crudThrottleMs).collect {
                     syncStream!!.triggerCrudUpload()
                 }
             }

--- a/core/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
@@ -139,10 +139,12 @@ internal class PowerSyncDatabaseImpl(
             }
         }
 
-        uploadJob = 
+        uploadJob =
             scope.launch {
-                internalDb.updatesOnTables(setOf(InternalTable.CRUD.toString()))
-                    .debounce(crudThrottleMs).collect {
+                internalDb
+                    .updatesOnTables(setOf(InternalTable.CRUD.toString()))
+                    .debounce(crudThrottleMs)
+                    .collect {
                         syncStream!!.triggerCrudUpload()
                     }
             }
@@ -211,8 +213,7 @@ internal class PowerSyncDatabaseImpl(
         }
     }
 
-    override suspend fun getPowerSyncVersion(): String =
-        internalDb.queries.powerSyncVersion().executeAsOne()
+    override suspend fun getPowerSyncVersion(): String = internalDb.queries.powerSyncVersion().executeAsOne()
 
     override suspend fun <RowType : Any> get(
         sql: String,
@@ -239,11 +240,9 @@ internal class PowerSyncDatabaseImpl(
         mapper: (SqlCursor) -> RowType,
     ): Flow<List<RowType>> = internalDb.watch(sql, parameters, throttleMs, mapper)
 
-    override suspend fun <R> readTransaction(callback: ThrowableTransactionCallback<R>): R =
-        internalDb.writeTransaction(callback)
+    override suspend fun <R> readTransaction(callback: ThrowableTransactionCallback<R>): R = internalDb.writeTransaction(callback)
 
-    override suspend fun <R> writeTransaction(callback: ThrowableTransactionCallback<R>): R =
-        internalDb.writeTransaction(callback)
+    override suspend fun <R> writeTransaction(callback: ThrowableTransactionCallback<R>): R = internalDb.writeTransaction(callback)
 
     override suspend fun execute(
         sql: String,
@@ -288,7 +287,7 @@ internal class PowerSyncDatabaseImpl(
         currentStatus.update(
             connected = false,
             connecting = false,
-            lastSyncedAt = currentStatus.lastSyncedAt
+            lastSyncedAt = currentStatus.lastSyncedAt,
         )
     }
 

--- a/core/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
@@ -28,7 +28,6 @@ import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -144,9 +143,8 @@ internal class PowerSyncDatabaseImpl(
                 internalDb
                     .updatesOnTables(
                         setOf(InternalTable.CRUD.toString()),
-                        throttleMs = crudThrottleMs
-                    )
-                    .collect {
+                        throttleMs = crudThrottleMs,
+                    ).collect {
                         syncStream!!.triggerCrudUpload()
                     }
             }
@@ -215,8 +213,7 @@ internal class PowerSyncDatabaseImpl(
         }
     }
 
-    override suspend fun getPowerSyncVersion(): String =
-        internalDb.queries.powerSyncVersion().executeAsOne()
+    override suspend fun getPowerSyncVersion(): String = internalDb.queries.powerSyncVersion().executeAsOne()
 
     override suspend fun <RowType : Any> get(
         sql: String,
@@ -243,11 +240,9 @@ internal class PowerSyncDatabaseImpl(
         mapper: (SqlCursor) -> RowType,
     ): Flow<List<RowType>> = internalDb.watch(sql, parameters, throttleMs, mapper)
 
-    override suspend fun <R> readTransaction(callback: ThrowableTransactionCallback<R>): R =
-        internalDb.writeTransaction(callback)
+    override suspend fun <R> readTransaction(callback: ThrowableTransactionCallback<R>): R = internalDb.writeTransaction(callback)
 
-    override suspend fun <R> writeTransaction(callback: ThrowableTransactionCallback<R>): R =
-        internalDb.writeTransaction(callback)
+    override suspend fun <R> writeTransaction(callback: ThrowableTransactionCallback<R>): R = internalDb.writeTransaction(callback)
 
     override suspend fun execute(
         sql: String,

--- a/core/src/commonMain/kotlin/com/powersync/db/Queries.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/Queries.kt
@@ -54,6 +54,10 @@ public interface Queries {
     public fun <RowType : Any> watch(
         sql: String,
         parameters: List<Any?>? = listOf(),
+        /**
+         * Specify the minimum interval, in milliseconds, between queries.
+         */
+        throttleMs: Long? = null,
         mapper: (SqlCursor) -> RowType,
     ): Flow<List<RowType>>
 

--- a/core/src/commonMain/kotlin/com/powersync/db/internal/InternalDatabase.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/internal/InternalDatabase.kt
@@ -12,7 +12,5 @@ internal interface InternalDatabase :
     val transactor: PsDatabase
     val queries: PowersyncQueries
 
-    fun getExistingTableNames(tableGlob: String): List<String>
-
     fun updatesOnTables(tableNames: Set<String>): Flow<Unit>
 }

--- a/core/src/commonMain/kotlin/com/powersync/db/internal/InternalDatabase.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/internal/InternalDatabase.kt
@@ -4,7 +4,6 @@ import app.cash.sqldelight.db.Closeable
 import com.persistence.PowersyncQueries
 import com.powersync.db.Queries
 import com.powersync.persistence.PsDatabase
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharedFlow
 
 internal interface InternalDatabase :

--- a/core/src/commonMain/kotlin/com/powersync/db/internal/InternalDatabase.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/internal/InternalDatabase.kt
@@ -12,5 +12,8 @@ internal interface InternalDatabase :
     val transactor: PsDatabase
     val queries: PowersyncQueries
 
-    fun updatesOnTables(tableNames: Set<String>, throttleMs: Long?): Flow<Unit>
+    fun updatesOnTables(
+        tableNames: Set<String>,
+        throttleMs: Long?,
+    ): Flow<Unit>
 }

--- a/core/src/commonMain/kotlin/com/powersync/db/internal/InternalDatabase.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/internal/InternalDatabase.kt
@@ -12,5 +12,5 @@ internal interface InternalDatabase :
     val transactor: PsDatabase
     val queries: PowersyncQueries
 
-    fun updatesOnTables(tableNames: Set<String>): Flow<Unit>
+    fun updatesOnTables(tableNames: Set<String>, throttleMs: Long?): Flow<Unit>
 }

--- a/core/src/commonMain/kotlin/com/powersync/db/internal/InternalDatabase.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/internal/InternalDatabase.kt
@@ -14,5 +14,5 @@ internal interface InternalDatabase :
 
     fun getExistingTableNames(tableGlob: String): List<String>
 
-    fun updatesOnTable(tableName: String): Flow<Unit>
+    fun updatesOnTables(tableNames: Set<String>): Flow<Unit>
 }

--- a/core/src/commonMain/kotlin/com/powersync/db/internal/InternalDatabase.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/internal/InternalDatabase.kt
@@ -5,6 +5,7 @@ import com.persistence.PowersyncQueries
 import com.powersync.db.Queries
 import com.powersync.persistence.PsDatabase
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharedFlow
 
 internal interface InternalDatabase :
     Queries,
@@ -12,8 +13,5 @@ internal interface InternalDatabase :
     val transactor: PsDatabase
     val queries: PowersyncQueries
 
-    fun updatesOnTables(
-        tableNames: Set<String>,
-        throttleMs: Long?,
-    ): Flow<Unit>
+    fun updatesOnTables(): SharedFlow<Set<String>>
 }

--- a/core/src/commonMain/kotlin/com/powersync/db/internal/InternalDatabaseImpl.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/internal/InternalDatabaseImpl.kt
@@ -158,7 +158,6 @@ internal class InternalDatabaseImpl(
         mapper: (SqlCursor) -> RowType,
     ): Flow<List<RowType>> =
         flow {
-            println("Getting tables for $sql")
             // Fetch the tables asynchronously with getAll
             val tables =
                 getSourceTables(sql, parameters)

--- a/core/src/commonMain/kotlin/com/powersync/db/internal/InternalDatabaseImpl.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/internal/InternalDatabaseImpl.kt
@@ -51,15 +51,13 @@ internal class InternalDatabaseImpl(
                 sql: String,
                 parameters: List<Any?>?,
                 mapper: (SqlCursor) -> RowType,
-            ): List<RowType> =
-                this@InternalDatabaseImpl.getAllSync(sql, parameters ?: emptyList(), mapper)
+            ): List<RowType> = this@InternalDatabaseImpl.getAllSync(sql, parameters ?: emptyList(), mapper)
 
             override fun <RowType : Any> getOptional(
                 sql: String,
                 parameters: List<Any?>?,
                 mapper: (SqlCursor) -> RowType,
-            ): RowType? =
-                this@InternalDatabaseImpl.getOptionalSync(sql, parameters ?: emptyList(), mapper)
+            ): RowType? = this@InternalDatabaseImpl.getOptionalSync(sql, parameters ?: emptyList(), mapper)
         }
 
     companion object {
@@ -223,8 +221,7 @@ internal class InternalDatabaseImpl(
         }
 
     // Register callback for table updates on a specific table
-    override fun updatesOnTables(tableNames: Set<String>): Flow<Unit> =
-        driver.updatesOnTables(tableNames)
+    override fun updatesOnTables(tableNames: Set<String>): Flow<Unit> = driver.updatesOnTables(tableNames)
 
     private suspend fun getSourceTables(
         sql: String,

--- a/core/src/commonMain/kotlin/com/powersync/db/internal/InternalDatabaseImpl.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/internal/InternalDatabaseImpl.kt
@@ -50,15 +50,13 @@ internal class InternalDatabaseImpl(
                 sql: String,
                 parameters: List<Any?>?,
                 mapper: (SqlCursor) -> RowType,
-            ): List<RowType> =
-                this@InternalDatabaseImpl.getAllSync(sql, parameters ?: emptyList(), mapper)
+            ): List<RowType> = this@InternalDatabaseImpl.getAllSync(sql, parameters ?: emptyList(), mapper)
 
             override fun <RowType : Any> getOptional(
                 sql: String,
                 parameters: List<Any?>?,
                 mapper: (SqlCursor) -> RowType,
-            ): RowType? =
-                this@InternalDatabaseImpl.getOptionalSync(sql, parameters ?: emptyList(), mapper)
+            ): RowType? = this@InternalDatabaseImpl.getOptionalSync(sql, parameters ?: emptyList(), mapper)
         }
 
     companion object {
@@ -169,8 +167,7 @@ internal class InternalDatabaseImpl(
                 updatesOnTables(tables, throttleMs = throttleMs ?: DEFAULT_WATCH_THROTTLE_MS)
                     .map {
                         getAll(sql, parameters = parameters, mapper = mapper)
-                    }
-                    .onStart {
+                    }.onStart {
                         // Emit the initial query result
                         emit(getAll(sql, parameters = parameters, mapper = mapper))
                     },
@@ -222,8 +219,10 @@ internal class InternalDatabaseImpl(
         }
 
     // Register callback for table updates on a specific table
-    override fun updatesOnTables(tableNames: Set<String>, throttleMs: Long?): Flow<Unit> =
-        driver.updatesOnTables(tableNames, throttleMs)
+    override fun updatesOnTables(
+        tableNames: Set<String>,
+        throttleMs: Long?,
+    ): Flow<Unit> = driver.updatesOnTables(tableNames, throttleMs)
 
     private suspend fun getSourceTables(
         sql: String,

--- a/core/src/commonMain/kotlin/com/powersync/db/internal/InternalDatabaseImpl.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/internal/InternalDatabaseImpl.kt
@@ -51,13 +51,15 @@ internal class InternalDatabaseImpl(
                 sql: String,
                 parameters: List<Any?>?,
                 mapper: (SqlCursor) -> RowType,
-            ): List<RowType> = this@InternalDatabaseImpl.getAllSync(sql, parameters ?: emptyList(), mapper)
+            ): List<RowType> =
+                this@InternalDatabaseImpl.getAllSync(sql, parameters ?: emptyList(), mapper)
 
             override fun <RowType : Any> getOptional(
                 sql: String,
                 parameters: List<Any?>?,
                 mapper: (SqlCursor) -> RowType,
-            ): RowType? = this@InternalDatabaseImpl.getOptionalSync(sql, parameters ?: emptyList(), mapper)
+            ): RowType? =
+                this@InternalDatabaseImpl.getOptionalSync(sql, parameters ?: emptyList(), mapper)
         }
 
     companion object {
@@ -154,6 +156,7 @@ internal class InternalDatabaseImpl(
     override fun <RowType : Any> watch(
         sql: String,
         parameters: List<Any?>?,
+        throttleMs: Long?,
         mapper: (SqlCursor) -> RowType,
     ): Flow<List<RowType>> =
         flow {
@@ -165,7 +168,7 @@ internal class InternalDatabaseImpl(
 
             emitAll(
                 updatesOnTables(tables)
-                    .debounce(DEFAULT_WATCH_THROTTLE_MS)
+                    .debounce(throttleMs ?: DEFAULT_WATCH_THROTTLE_MS)
                     .map {
                         getAll(sql, parameters = parameters, mapper = mapper)
                     }.onStart {
@@ -220,7 +223,8 @@ internal class InternalDatabaseImpl(
         }
 
     // Register callback for table updates on a specific table
-    override fun updatesOnTables(tableNames: Set<String>): Flow<Unit> = driver.updatesOnTables(tableNames)
+    override fun updatesOnTables(tableNames: Set<String>): Flow<Unit> =
+        driver.updatesOnTables(tableNames)
 
     private suspend fun getSourceTables(
         sql: String,

--- a/core/src/commonMain/kotlin/com/powersync/db/internal/InternalDatabaseImpl.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/internal/InternalDatabaseImpl.kt
@@ -16,7 +16,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
@@ -51,13 +50,15 @@ internal class InternalDatabaseImpl(
                 sql: String,
                 parameters: List<Any?>?,
                 mapper: (SqlCursor) -> RowType,
-            ): List<RowType> = this@InternalDatabaseImpl.getAllSync(sql, parameters ?: emptyList(), mapper)
+            ): List<RowType> =
+                this@InternalDatabaseImpl.getAllSync(sql, parameters ?: emptyList(), mapper)
 
             override fun <RowType : Any> getOptional(
                 sql: String,
                 parameters: List<Any?>?,
                 mapper: (SqlCursor) -> RowType,
-            ): RowType? = this@InternalDatabaseImpl.getOptionalSync(sql, parameters ?: emptyList(), mapper)
+            ): RowType? =
+                this@InternalDatabaseImpl.getOptionalSync(sql, parameters ?: emptyList(), mapper)
         }
 
     companion object {
@@ -165,11 +166,11 @@ internal class InternalDatabaseImpl(
                     .toSet()
 
             emitAll(
-                updatesOnTables(tables)
-                    .debounce(throttleMs ?: DEFAULT_WATCH_THROTTLE_MS)
+                updatesOnTables(tables, throttleMs = throttleMs ?: DEFAULT_WATCH_THROTTLE_MS)
                     .map {
                         getAll(sql, parameters = parameters, mapper = mapper)
-                    }.onStart {
+                    }
+                    .onStart {
                         // Emit the initial query result
                         emit(getAll(sql, parameters = parameters, mapper = mapper))
                     },
@@ -221,7 +222,8 @@ internal class InternalDatabaseImpl(
         }
 
     // Register callback for table updates on a specific table
-    override fun updatesOnTables(tableNames: Set<String>): Flow<Unit> = driver.updatesOnTables(tableNames)
+    override fun updatesOnTables(tableNames: Set<String>, throttleMs: Long?): Flow<Unit> =
+        driver.updatesOnTables(tableNames, throttleMs)
 
     private suspend fun getSourceTables(
         sql: String,

--- a/core/src/commonMain/kotlin/com/powersync/utils/AtomicMutableSet.kt
+++ b/core/src/commonMain/kotlin/com/powersync/utils/AtomicMutableSet.kt
@@ -1,0 +1,28 @@
+package com.powersync.utils
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+internal class AtomicMutableSet<T> {
+    private val mutex = Mutex()
+    private val set = mutableSetOf<T>()
+
+    suspend fun add(element: T): Boolean = mutex.withLock {
+        set.add(element)
+    }
+
+    suspend fun remove(element: T): Boolean = mutex.withLock {
+        set.remove(element)
+    }
+
+    suspend fun clear(): Unit = mutex.withLock {
+        set.clear()
+    }
+
+    suspend fun contains(element: T): Boolean = mutex.withLock {
+        set.contains(element)
+    }
+
+    suspend fun toSet(): Set<T> = mutex.withLock {
+        set.toSet()
+    }
+}

--- a/core/src/commonMain/kotlin/com/powersync/utils/AtomicMutableSet.kt
+++ b/core/src/commonMain/kotlin/com/powersync/utils/AtomicMutableSet.kt
@@ -1,37 +1,26 @@
 package com.powersync.utils
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 
-public class AtomicMutableSet<T> {
-    private val mutex = Mutex()
+import kotlinx.atomicfu.locks.SynchronizedObject
+import kotlinx.atomicfu.locks.synchronized
+
+public class AtomicMutableSet<T> : SynchronizedObject() {
     private val set = mutableSetOf<T>()
 
-    public suspend fun add(element: T): Boolean =
-        mutex.withLock {
-            set.add(element)
+    public fun add(element: T): Boolean =
+        synchronized(this) {
+            return set.add(element)
         }
 
-    public suspend fun remove(element: T): Boolean =
-        mutex.withLock {
-            set.remove(element)
-        }
-
-    public suspend fun clear(): Unit =
-        mutex.withLock {
+    // Synchronized clear method
+    public fun clear(): Unit =
+        synchronized(this) {
             set.clear()
         }
 
-    public suspend fun contains(element: T): Boolean =
-        mutex.withLock {
-            set.contains(element)
-        }
-
-    public suspend fun toSet(clear: Boolean = false): Set<T> =
-        mutex.withLock {
+    public fun toSetAndClear(): Set<T> =
+        synchronized(this) {
             val copied = set.toList().toSet()
-            if (clear) {
-                set.clear()
-            }
+            set.clear()
             copied
         }
 }

--- a/core/src/commonMain/kotlin/com/powersync/utils/AtomicMutableSet.kt
+++ b/core/src/commonMain/kotlin/com/powersync/utils/AtomicMutableSet.kt
@@ -28,7 +28,7 @@ public class AtomicMutableSet<T> {
 
     public suspend fun toSet(clear: Boolean = false): Set<T> =
         mutex.withLock {
-            val copied = set.toSet()
+            val copied = set.toList().toSet()
             if (clear) {
                 set.clear()
             }

--- a/core/src/commonMain/kotlin/com/powersync/utils/AtomicMutableSet.kt
+++ b/core/src/commonMain/kotlin/com/powersync/utils/AtomicMutableSet.kt
@@ -2,27 +2,36 @@ package com.powersync.utils
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
-internal class AtomicMutableSet<T> {
+public class AtomicMutableSet<T> {
     private val mutex = Mutex()
     private val set = mutableSetOf<T>()
 
-    suspend fun add(element: T): Boolean = mutex.withLock {
-        set.add(element)
-    }
+    public suspend fun add(element: T): Boolean =
+        mutex.withLock {
+            set.add(element)
+        }
 
-    suspend fun remove(element: T): Boolean = mutex.withLock {
-        set.remove(element)
-    }
+    public suspend fun remove(element: T): Boolean =
+        mutex.withLock {
+            set.remove(element)
+        }
 
-    suspend fun clear(): Unit = mutex.withLock {
-        set.clear()
-    }
+    public suspend fun clear(): Unit =
+        mutex.withLock {
+            set.clear()
+        }
 
-    suspend fun contains(element: T): Boolean = mutex.withLock {
-        set.contains(element)
-    }
+    public suspend fun contains(element: T): Boolean =
+        mutex.withLock {
+            set.contains(element)
+        }
 
-    suspend fun toSet(): Set<T> = mutex.withLock {
-        set.toSet()
-    }
+    public suspend fun toSet(clear: Boolean = false): Set<T> =
+        mutex.withLock {
+            val copied = set.toSet()
+            if (clear) {
+                set.clear()
+            }
+            copied
+        }
 }

--- a/core/src/commonMain/kotlin/com/powersync/utils/ThrottleFlow.kt
+++ b/core/src/commonMain/kotlin/com/powersync/utils/ThrottleFlow.kt
@@ -11,18 +11,19 @@ import kotlinx.coroutines.flow.*
  * This throttle method acts as a slow consumer, but backpressure is not a concern
  * due to the conflated buffer dropping events during the throttle window.
  */
-internal fun <T> Flow<T>.throttle(windowMs: Long): Flow<T> = flow {
-    // Use a buffer before throttle (ensure only the latest event is kept)
-    val bufferedFlow = this@throttle.buffer(Channel.CONFLATED)
+internal fun <T> Flow<T>.throttle(windowMs: Long): Flow<T> =
+    flow {
+        // Use a buffer before throttle (ensure only the latest event is kept)
+        val bufferedFlow = this@throttle.buffer(Channel.CONFLATED)
 
-    bufferedFlow.collect { value ->
-        // Emit the event immediately (leading edge)
-        emit(value)
+        bufferedFlow.collect { value ->
+            // Emit the event immediately (leading edge)
+            emit(value)
 
-        // Delay for the throttle window to avoid emitting too frequently
-        delay(windowMs)
+            // Delay for the throttle window to avoid emitting too frequently
+            delay(windowMs)
 
-        // The next incoming event will be provided from the buffer.
-        // The next collect will emit the trailing edge
+            // The next incoming event will be provided from the buffer.
+            // The next collect will emit the trailing edge
+        }
     }
-}

--- a/core/src/commonMain/kotlin/com/powersync/utils/ThrottleFlow.kt
+++ b/core/src/commonMain/kotlin/com/powersync/utils/ThrottleFlow.kt
@@ -2,7 +2,9 @@ package com.powersync.utils
 
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.buffer
+import kotlinx.coroutines.flow.flow
 
 /**
  * Throttles a flow with emissions on the leading and trailing edge.

--- a/core/src/commonMain/kotlin/com/powersync/utils/ThrottleFlow.kt
+++ b/core/src/commonMain/kotlin/com/powersync/utils/ThrottleFlow.kt
@@ -1,0 +1,28 @@
+package com.powersync.utils
+
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.*
+
+/**
+ * Throttles a flow with emissions on the leading and trailing edge.
+ * Events, from the incoming flow, during the throttle window are discarded.
+ * Events are discarded by using a conflated buffer.
+ * This throttle method acts as a slow consumer, but backpressure is not a concern
+ * due to the conflated buffer dropping events during the throttle window.
+ */
+internal fun <T> Flow<T>.throttle(windowMs: Long): Flow<T> = flow {
+    // Use a buffer before throttle (ensure only the latest event is kept)
+    val bufferedFlow = this@throttle.buffer(Channel.CONFLATED)
+
+    bufferedFlow.collect { value ->
+        // Emit the event immediately (leading edge)
+        emit(value)
+
+        // Delay for the throttle window to avoid emitting too frequently
+        delay(windowMs)
+
+        // The next incoming event will be provided from the buffer.
+        // The next collect will emit the trailing edge
+    }
+}

--- a/core/src/commonTest/kotlin/com/powersync/bucket/BucketStorageTest.kt
+++ b/core/src/commonTest/kotlin/com/powersync/bucket/BucketStorageTest.kt
@@ -5,7 +5,6 @@ import com.powersync.db.crud.CrudEntry
 import com.powersync.db.crud.UpdateType
 import com.powersync.db.internal.InternalDatabase
 import dev.mokkery.answering.returns
-import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock

--- a/core/src/commonTest/kotlin/com/powersync/bucket/BucketStorageTest.kt
+++ b/core/src/commonTest/kotlin/com/powersync/bucket/BucketStorageTest.kt
@@ -24,9 +24,7 @@ class BucketStorageTest {
     @Test
     fun testGetMaxOpId() {
         mockDb =
-            mock<InternalDatabase> {
-                every { getExistingTableNames("ps_data_*") } returns listOf("list_1", "list_2")
-            }
+            mock<InternalDatabase> {}
         bucketStorage = BucketStorageImpl(mockDb, Logger)
         assertEquals("9223372036854775807", bucketStorage.getMaxOpId())
     }
@@ -36,7 +34,6 @@ class BucketStorageTest {
         runTest {
             mockDb =
                 mock<InternalDatabase> {
-                    every { getExistingTableNames("ps_data_*") } returns listOf("list_1", "list_2")
                     everySuspend {
                         getOptional<String>(
                             any(),
@@ -55,7 +52,6 @@ class BucketStorageTest {
         runTest {
             mockDb =
                 mock<InternalDatabase> {
-                    every { getExistingTableNames("ps_data_*") } returns listOf("list_1", "list_2")
                     everySuspend {
                         getOptional<String>(
                             any(),
@@ -88,7 +84,6 @@ class BucketStorageTest {
                 )
             mockDb =
                 mock<InternalDatabase> {
-                    every { getExistingTableNames("ps_data_*") } returns listOf("list_1", "list_2")
                     everySuspend { getOptional<CrudEntry>(any(), any(), any()) } returns mockCrudEntry
                 }
             bucketStorage = BucketStorageImpl(mockDb, Logger)
@@ -102,7 +97,6 @@ class BucketStorageTest {
         runTest {
             mockDb =
                 mock<InternalDatabase> {
-                    every { getExistingTableNames("ps_data_*") } returns listOf("list_1", "list_2")
                     everySuspend { getOptional<CrudEntry>(any(), any(), any()) } returns null
                 }
             bucketStorage = BucketStorageImpl(mockDb, Logger)
@@ -116,7 +110,6 @@ class BucketStorageTest {
         runTest {
             mockDb =
                 mock<InternalDatabase> {
-                    every { getExistingTableNames("ps_data_*") } returns listOf("list_1", "list_2")
                     everySuspend { getOptional<Long>(any(), any(), any()) } returns 1L
                 }
             bucketStorage = BucketStorageImpl(mockDb, Logger)
@@ -129,7 +122,6 @@ class BucketStorageTest {
         runTest {
             mockDb =
                 mock<InternalDatabase> {
-                    every { getExistingTableNames("ps_data_*") } returns listOf("list_1", "list_2")
                     everySuspend { getOptional<CrudEntry>(any(), any(), any()) } returns null
                 }
             bucketStorage = BucketStorageImpl(mockDb, Logger)
@@ -142,7 +134,6 @@ class BucketStorageTest {
         runBlocking {
             mockDb =
                 mock<InternalDatabase> {
-                    every { getExistingTableNames("ps_data_*") } returns listOf("list_1", "list_2")
                     everySuspend {
                         getOptional<Long>(
                             any(),
@@ -164,7 +155,6 @@ class BucketStorageTest {
             val mockBucketStates = listOf(BucketState("bucket1", "op1"), BucketState("bucket2", "op2"))
             mockDb =
                 mock<InternalDatabase> {
-                    every { getExistingTableNames("ps_data_*") } returns listOf("list_1", "list_2")
                     everySuspend {
                         getOptional<Long>(
                             any(),

--- a/core/src/commonTest/kotlin/com/powersync/utils/JsonTest.kt
+++ b/core/src/commonTest/kotlin/com/powersync/utils/JsonTest.kt
@@ -1,5 +1,10 @@
 package com.powersync.utils
 
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
@@ -34,6 +39,28 @@ class JsonTest {
         val jsonElement = string.toJsonElement()
         assertTrue(jsonElement is JsonPrimitive)
         assertEquals("test", jsonElement.content)
+    }
+
+    @Test
+    fun testThrottle() {
+        runTest {
+            val t =
+                flow {
+                    emit(1)
+                    delay(10)
+                    emit(2)
+                    delay(20)
+                    emit(3)
+                    delay(100)
+                    emit(4)
+                }.throttle(100)
+                    .map {
+                        // Adding a delay here to simulate a slow consumer
+                        delay(1000)
+                        it
+                    }.toList()
+            assertEquals(t, listOf(1, 4))
+        }
     }
 
     @Test

--- a/demos/supabase-todolist/androidApp/src/androidMain/AndroidManifest.xml
+++ b/demos/supabase-todolist/androidApp/src/androidMain/AndroidManifest.xml
@@ -10,7 +10,9 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.AppCompat.Light.NoActionBar"
-        android:enableOnBackInvokedCallback="true">
+        android:enableOnBackInvokedCallback="true"
+        android:networkSecurityConfig="@xml/network_security_config"
+        >
 
 
         <activity

--- a/demos/supabase-todolist/androidApp/src/main/res/xml/network.xml
+++ b/demos/supabase-todolist/androidApp/src/main/res/xml/network.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+
+</PreferenceScreen>

--- a/demos/supabase-todolist/androidApp/src/main/res/xml/network.xml
+++ b/demos/supabase-todolist/androidApp/src/main/res/xml/network.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
-
-</PreferenceScreen>

--- a/demos/supabase-todolist/androidApp/src/main/res/xml/network_security_config.xml
+++ b/demos/supabase-todolist/androidApp/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">localhost</domain>
+    </domain-config>
+</network-security-config>


### PR DESCRIPTION
# Overview

This PR improves the watched query logic by optimizing table update handling, enhancing thread safety, and simplifying the implementation.

## Table Update Optimization

- Table changes in a transaction are now tracked using a `Set`, preventing redundant entries. Since SQLite emits an update per row, the previous implementation could accumulate large arrays of duplicate table changes.

## Thread Safety for Table Updates

- Resolves [issue #135](https://github.com/powersync-ja/powersync-kotlin/issues/135), where the current driver’s pending update storage was not thread-safe.
- The pending table changes set is now protected with Mutex locks.

## Implementation Cleanup

- Replaces the existing SQLDelight watched query interface with a simpler, Flow-based solution.
- The new approach leverages the internal database’s `getAll` method instead of the driver’s synchronous methods.
- Table change flow logic has been refactored for better debouncing, allowing custom `throttleMs` values per query.

## Removal of Blocking Calls

- Previously, the watch query API synchronously determined the tables to watch, which impacted performance (e.g., in the Supabase Todo List app). This logic now uses the asynchronous getAll method, improving efficiency.

## Testing

This was tested locally using both the Kotlin and Swift SDKs.

https://github.com/user-attachments/assets/17350fdb-367b-4987-916c-e3eb540dc911

## Swift

Related Swift PR https://github.com/powersync-ja/powersync-swift/pull/26

