### PR TITLE
Mention bucket priorities on demo readme

### DIFF
--- a/demos/android-supabase-todolist/README.md
+++ b/demos/android-supabase-todolist/README.md
@@ -11,6 +11,29 @@ Follow this guide to:
 2. Create a new PowerSync instance, connecting to the database of the Supabase project. See instructions [here](https://docs.powersync.com/integration-guides/supabase-+-powersync#connect-powersync-to-your-supabase).
 3. Deploy sync rules.
 
+### Opting in to priorities
+
+If you want to use the example with [bucket priorities](https://docs.powersync.com/usage/use-case-examples/prioritized-sync),
+you can adopt the following sync rules instead of the ones suggested by the simpler integration guide:
+
+```YAML
+bucket_definitions:
+  all_lists:
+    priority: 1
+    parameters: select request.user_id() as "user"
+    data:
+      - select * from lists where owner_id = bucket."user"
+
+  list_items:
+    # Separate bucket per list
+    parameters: select id as list_id from lists where owner_id = request.user_id()
+    data:
+      - select * from todos where list_id = bucket.list_id
+```
+
+The project will work with both sync rules, but giving lists a higher priority allows updates to be synchronized before
+all items have been received.
+
 ## Configure project in Android Studio
 
 1. Clone this repo: ```git clone https://github.com/powersync-ja/powersync-kotlin.git```

--- a/demos/supabase-todolist/README.md
+++ b/demos/supabase-todolist/README.md
@@ -13,6 +13,29 @@ To setup your environment, please consult [these instructions](https://www.jetbr
 
 A step-by-step guide on Supabase<>PowerSync integration is available [here](https://docs.powersync.com/integration-guides/supabase).
 
+### Opting in to priorities
+
+If you want to use the example with [bucket priorities](https://docs.powersync.com/usage/use-case-examples/prioritized-sync),
+you can adopt the following sync rules instead of the ones suggested by the simpler integration guide:
+
+```YAML
+bucket_definitions:
+  all_lists:
+    priority: 1
+    parameters: select request.user_id() as "user"
+    data:
+      - select * from lists where owner_id = bucket."user"
+
+  list_items:
+    # Separate bucket per list
+    parameters: select id as list_id from lists where owner_id = request.user_id()
+    data:
+      - select * from todos where list_id = bucket.list_id
+```
+
+The project will work with both sync rules, but giving lists a higher priority allows updates to be synchronized before
+all items have been received.
+
 ## Configure project in Android Studio
 
 1. Clone this repo: ```git clone https://github.com/powersync-ja/powersync-kotlin.git```


### PR DESCRIPTION
Expand the readme of the Android and KMP demos to mention sync rules using bucket priorities. These aren't mentioned by the simple guide explaining how to use PowerSync with Supabase, so mentioning them in the readme points out that the feature exists and how to enable it.
The code works with both definitions without changes.