### PR TITLE
[Fix] Sync Status Updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.0.0-BETA27
 
 * Improved watch query internals. Added the ability to throttle watched queries.
+* Fixed `uploading` and `downloading` sync status indicators.
 
 ## 1.0.0-BETA26
 

--- a/core/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
@@ -128,6 +128,7 @@ internal class PowerSyncDatabaseImpl(
                 currentStatus.update(
                     connected = it.connected,
                     connecting = it.connecting,
+                    uploading = it.uploading,
                     downloading = it.downloading,
                     lastSyncedAt = it.lastSyncedAt,
                     hasSynced = it.hasSynced,

--- a/core/src/commonMain/kotlin/com/powersync/sync/SyncStream.kt
+++ b/core/src/commonMain/kotlin/com/powersync/sync/SyncStream.kt
@@ -290,6 +290,8 @@ internal class SyncStream(
     ): SyncStreamState {
         val (checkpoint) = line
         state.targetCheckpoint = checkpoint
+        status.update(downloading = true)
+
         val bucketsToDelete = state.bucketSet!!.toMutableList()
         val newBuckets = mutableSetOf<String>()
 
@@ -307,7 +309,7 @@ internal class SyncStream(
         state.bucketSet = newBuckets
         bucketStorage.removeBuckets(bucketsToDelete)
         bucketStorage.setTargetCheckpoint(checkpoint)
-        status.update(downloading = true)
+
         return state
     }
 
@@ -386,6 +388,8 @@ internal class SyncStream(
             throw Exception("Checkpoint diff without previous checkpoint")
         }
 
+        status.update(downloading = true)
+
         val newBuckets = mutableMapOf<String, BucketChecksum>()
 
         state.targetCheckpoint!!.checksums.forEach { checksum ->
@@ -415,7 +419,6 @@ internal class SyncStream(
         bucketStorage.removeBuckets(bucketsToDelete)
         bucketStorage.setTargetCheckpoint(state.targetCheckpoint!!)
 
-        status.update(downloading = true)
         return state
     }
 

--- a/demos/supabase-todolist/shared/src/commonMain/kotlin/com/powersync/demos/App.kt
+++ b/demos/supabase-todolist/shared/src/commonMain/kotlin/com/powersync/demos/App.kt
@@ -26,16 +26,19 @@ import com.powersync.demos.screens.SignUpScreen
 import com.powersync.demos.screens.TodosScreen
 import kotlinx.coroutines.runBlocking
 
-
 @Composable
-fun App(factory: DatabaseDriverFactory, modifier: Modifier = Modifier) {
-    val supabase = remember {
-        SupabaseConnector(
-            powerSyncEndpoint = Config.POWERSYNC_URL,
-            supabaseUrl = Config.SUPABASE_URL,
-            supabaseKey = Config.SUPABASE_ANON_KEY
-        )
-    }
+fun App(
+    factory: DatabaseDriverFactory,
+    modifier: Modifier = Modifier,
+) {
+    val supabase =
+        remember {
+            SupabaseConnector(
+                powerSyncEndpoint = Config.POWERSYNC_URL,
+                supabaseUrl = Config.SUPABASE_URL,
+                supabaseKey = Config.SUPABASE_ANON_KEY,
+            )
+        }
     val db = remember { PowerSyncDatabase(factory, schema) }
     val status by db.currentStatus.asFlow().collectAsState(initial = db.currentStatus)
 
@@ -48,9 +51,10 @@ fun App(factory: DatabaseDriverFactory, modifier: Modifier = Modifier) {
     }
 
     val navController = remember { NavController(Screen.Home) }
-    val authViewModel = remember {
-        AuthViewModel(supabase, db, navController)
-    }
+    val authViewModel =
+        remember {
+            AuthViewModel(supabase, db, navController)
+        }
 
     val authState by authViewModel.authState.collectAsState()
     val currentScreen by navController.currentScreen.collectAsState()
@@ -81,7 +85,7 @@ fun App(factory: DatabaseDriverFactory, modifier: Modifier = Modifier) {
 
     when (currentScreen) {
         is Screen.Home -> {
-            if(authState == AuthState.SignedOut) {
+            if (authState == AuthState.SignedOut) {
                 navController.navigate(Screen.SignIn)
             }
 
@@ -93,14 +97,13 @@ fun App(factory: DatabaseDriverFactory, modifier: Modifier = Modifier) {
             HomeScreen(
                 modifier = modifier.background(MaterialTheme.colors.background),
                 items = items,
-                isConnected = status.connected,
                 onSignOutSelected = { handleSignOut() },
                 inputText = listsInputText,
                 onItemClicked = handleOnItemClicked,
                 onItemDeleteClicked = lists.value::onItemDeleteClicked,
                 onAddItemClicked = lists.value::onAddItemClicked,
                 onInputTextChanged = lists.value::onInputTextChanged,
-                hasSynced = hasSyncedLists
+                syncStatus = status,
             )
         }
 
@@ -113,7 +116,7 @@ fun App(factory: DatabaseDriverFactory, modifier: Modifier = Modifier) {
                 modifier = modifier.background(MaterialTheme.colors.background),
                 navController = navController,
                 items = todoItems,
-                isConnected = status.connected,
+                syncStatus = status,
                 inputText = todosInputText,
                 onItemClicked = todos.value::onItemClicked,
                 onItemDoneChanged = todos.value::onItemDoneChanged,
@@ -133,24 +136,24 @@ fun App(factory: DatabaseDriverFactory, modifier: Modifier = Modifier) {
         }
 
         is Screen.SignIn -> {
-            if(authState == AuthState.SignedIn) {
+            if (authState == AuthState.SignedIn) {
                 navController.navigate(Screen.Home)
             }
 
             SignInScreen(
                 navController,
-                authViewModel
+                authViewModel,
             )
         }
 
         is Screen.SignUp -> {
-            if(authState == AuthState.SignedIn) {
+            if (authState == AuthState.SignedIn) {
                 navController.navigate(Screen.Home)
             }
 
             SignUpScreen(
                 navController,
-                authViewModel
+                authViewModel,
             )
         }
     }

--- a/demos/supabase-todolist/shared/src/commonMain/kotlin/com/powersync/demos/App.kt
+++ b/demos/supabase-todolist/shared/src/commonMain/kotlin/com/powersync/demos/App.kt
@@ -24,6 +24,7 @@ import com.powersync.demos.screens.HomeScreen
 import com.powersync.demos.screens.SignInScreen
 import com.powersync.demos.screens.SignUpScreen
 import com.powersync.demos.screens.TodosScreen
+import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.runBlocking
 
 @Composable
@@ -40,7 +41,11 @@ fun App(
             )
         }
     val db = remember { PowerSyncDatabase(factory, schema) }
-    val status by db.currentStatus.asFlow().collectAsState(initial = db.currentStatus)
+    // Debouncing the status flow prevents flicker
+    val status by db.currentStatus
+        .asFlow()
+        .debounce(200)
+        .collectAsState(initial = db.currentStatus)
 
     // This assumes that the buckets for lists has a priority of 1 (but it will work fine with sync
     // rules not defining any priorities at all too). When giving lists a higher priority than

--- a/demos/supabase-todolist/shared/src/commonMain/kotlin/com/powersync/demos/components/WifiIcon.kt
+++ b/demos/supabase-todolist/shared/src/commonMain/kotlin/com/powersync/demos/components/WifiIcon.kt
@@ -2,20 +2,29 @@ package com.powersync.demos.components
 
 import androidx.compose.material.Icon
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Wifi
-import androidx.compose.material.icons.filled.WifiOff
+import androidx.compose.material.icons.filled.Cloud
+import androidx.compose.material.icons.filled.CloudOff
+import androidx.compose.material.icons.filled.CloudSync
+import androidx.compose.material.icons.filled.LeakAdd
+import androidx.compose.material.icons.filled.Thunderstorm
 import androidx.compose.runtime.Composable
+import com.powersync.sync.SyncStatusData
 
 @Composable
-fun WifiIcon(isConnected: Boolean) {
-    val icon = if (isConnected) {
-        Icons.Filled.Wifi
-    } else {
-        Icons.Filled.WifiOff
-    }
+fun WifiIcon(status: SyncStatusData) {
+    val icon =
+        when {
+            status.downloading || status.uploading -> Icons.Filled.CloudSync
+            status.connected -> Icons.Filled.Cloud
+            !status.connected -> Icons.Filled.CloudOff
+            status.connecting -> Icons.Filled.LeakAdd
+            else -> {
+                Icons.Filled.Thunderstorm
+            }
+        }
 
     Icon(
         imageVector = icon,
-        contentDescription = if (isConnected) "Online" else "Offline",
+        contentDescription = status.toString(),
     )
 }

--- a/demos/supabase-todolist/shared/src/commonMain/kotlin/com/powersync/demos/screens/HomeScreen.kt
+++ b/demos/supabase-todolist/shared/src/commonMain/kotlin/com/powersync/demos/screens/HomeScreen.kt
@@ -22,14 +22,14 @@ import com.powersync.demos.components.ListContent
 import com.powersync.demos.components.Menu
 import com.powersync.demos.components.WifiIcon
 import com.powersync.demos.powersync.ListItem
+import com.powersync.sync.SyncStatusData
 
 @Composable
 internal fun HomeScreen(
     modifier: Modifier = Modifier,
     items: List<ListItem>,
     inputText: String,
-    isConnected: Boolean,
-    hasSynced: Boolean?,
+    syncStatus: SyncStatusData,
     onSignOutSelected: () -> Unit,
     onItemClicked: (item: ListItem) -> Unit,
     onItemDeleteClicked: (item: ListItem) -> Unit,
@@ -40,46 +40,49 @@ internal fun HomeScreen(
         TopAppBar(
             title = {
                 Text(
-                "Todo Lists",
-                textAlign = TextAlign.Center,
-                modifier = Modifier.fillMaxWidth().padding(end = 36.dp)
-            ) },
-            navigationIcon = { Menu(
-                true,
-                onSignOutSelected
-            ) },
+                    "Todo Lists",
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth().padding(end = 36.dp),
+                )
+            },
+            navigationIcon = {
+                Menu(
+                    true,
+                    onSignOutSelected,
+                )
+            },
             actions = {
-                WifiIcon(isConnected)
+                WifiIcon(syncStatus)
                 Spacer(modifier = Modifier.width(16.dp))
-            }
+            },
         )
 
         when {
-                hasSynced == null || hasSynced == false -> {
-                    Box(
-                        modifier = Modifier.fillMaxSize().background(MaterialTheme.colors.background),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        Text(
-                            text = "Busy with initial sync...",
-                            style = MaterialTheme.typography.h6
-                        )
-                    }
+            syncStatus.hasSynced == null || syncStatus.hasSynced == false -> {
+                Box(
+                    modifier = Modifier.fillMaxSize().background(MaterialTheme.colors.background),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = "Busy with initial sync...",
+                        style = MaterialTheme.typography.h6,
+                    )
                 }
-            else -> {
+            }
 
+            else -> {
                 Input(
                     text = inputText,
                     onAddClicked = onAddItemClicked,
                     onTextChanged = onInputTextChanged,
-                    screen = Screen.Home
+                    screen = Screen.Home,
                 )
 
                 Box(Modifier.weight(1F)) {
                     ListContent(
                         items = items,
                         onItemClicked = onItemClicked,
-                        onItemDeleteClicked = onItemDeleteClicked
+                        onItemDeleteClicked = onItemDeleteClicked,
                     )
                 }
             }

--- a/demos/supabase-todolist/shared/src/commonMain/kotlin/com/powersync/demos/screens/TodosScreen.kt
+++ b/demos/supabase-todolist/shared/src/commonMain/kotlin/com/powersync/demos/screens/TodosScreen.kt
@@ -12,19 +12,17 @@ import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.powersync.demos.NavController
 import com.powersync.demos.Screen
 import com.powersync.demos.components.Input
-import com.powersync.demos.components.Menu
 import com.powersync.demos.components.TodoList
 import com.powersync.demos.components.WifiIcon
 import com.powersync.demos.powersync.TodoItem
+import com.powersync.sync.SyncStatusData
 
 @Composable
 internal fun TodosScreen(
@@ -32,7 +30,7 @@ internal fun TodosScreen(
     navController: NavController,
     items: List<TodoItem>,
     inputText: String,
-    isConnected: Boolean,
+    syncStatus: SyncStatusData,
     onItemClicked: (item: TodoItem) -> Unit,
     onItemDoneChanged: (item: TodoItem, isDone: Boolean) -> Unit,
     onItemDeleteClicked: (item: TodoItem) -> Unit,
@@ -45,24 +43,25 @@ internal fun TodosScreen(
                 Text(
                     "Todo List",
                     textAlign = TextAlign.Center,
-                    modifier = Modifier.fillMaxWidth().padding(end = 36.dp)
-                ) },
+                    modifier = Modifier.fillMaxWidth().padding(end = 36.dp),
+                )
+            },
             navigationIcon = {
                 IconButton(onClick = { navController.navigate(Screen.Home) }) {
                     Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Go back")
                 }
             },
             actions = {
-                WifiIcon(isConnected)
+                WifiIcon(syncStatus)
                 Spacer(modifier = Modifier.width(16.dp))
-            }
+            },
         )
 
         Input(
             text = inputText,
             onAddClicked = onAddItemClicked,
             onTextChanged = onInputTextChanged,
-            screen = Screen.Todos
+            screen = Screen.Todos,
         )
 
         Box(Modifier.weight(1F)) {
@@ -70,7 +69,7 @@ internal fun TodosScreen(
                 items = items,
                 onItemClicked = onItemClicked,
                 onItemDoneChanged = onItemDoneChanged,
-                onItemDeleteClicked = onItemDeleteClicked
+                onItemDeleteClicked = onItemDeleteClicked,
             )
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ development=true
 RELEASE_SIGNING_ENABLED=true
 # Library config
 GROUP=com.powersync
-LIBRARY_VERSION=1.0.0-BETA26
+LIBRARY_VERSION=1.0.0-BETA27
 GITHUB_REPO=https://github.com/powersync-ja/powersync-kotlin.git
 # POM
 POM_URL=https://github.com/powersync-ja/powersync-kotlin/


### PR DESCRIPTION
# Overview

This fixes the sync status indicator which did not emit any updates for `uploading` or `downloading`. 

Sync status updates for uploading or downloading can be quite fast. The demo has been updated to debounce the flow. A nicer UI might be to trigger some animation based off uploading/downloading. 


https://github.com/user-attachments/assets/a271d2fd-dddb-4750-91ef-332cbdc5796e



