### PR TITLE
Allow running demos with released dependencies

### DIFF
--- a/demos/android-supabase-todolist/app/build.gradle.kts
+++ b/demos/android-supabase-todolist/app/build.gradle.kts
@@ -87,9 +87,11 @@ dependencies {
     androidTestImplementation(libs.androidx.ui.test.junit4)
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)
-    implementation("com.powersync:core")
-    implementation("com.powersync:connector-supabase")
-    implementation("com.powersync:compose")
+    // To use a fixed version, replace "latest.release" with the latest version available at
+    // https://central.sonatype.com/artifact/com.powersync/core
+    implementation("com.powersync:core:latest.release")
+    implementation("com.powersync:connector-supabase:latest.release")
+    implementation("com.powersync:compose:latest.release")
     implementation(libs.uuid)
     implementation(libs.kermit)
     implementation(libs.androidx.material.icons.extended)

--- a/demos/android-supabase-todolist/local.properties.example
+++ b/demos/android-supabase-todolist/local.properties.example
@@ -12,3 +12,5 @@ sdk.dir=/Users/dominic/Library/Android/sdk
 SUPABASE_URL=https://foo.supabase.co
 SUPABASE_ANON_KEY=foo
 POWERSYNC_URL=https://foo.powersync.journeyapps.com
+# Set to true to use released PowerSync packages instead of the ones built locally.
+USE_RELEASED_POWERSYNC_VERSIONS=false

--- a/demos/android-supabase-todolist/settings.gradle.kts
+++ b/demos/android-supabase-todolist/settings.gradle.kts
@@ -1,3 +1,5 @@
+import java.util.Properties
+
 pluginManagement {
     repositories {
         google {
@@ -15,7 +17,9 @@ dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
         google()
-        maven("https://jitpack.io")
+        maven("https://jitpack.io") {
+            content { includeGroup("com.github.requery") }
+        }
         mavenCentral()
     }
 }
@@ -23,15 +27,26 @@ dependencyResolutionManagement {
 rootProject.name = "PowersyncAndroidExample"
 include(":app")
 
-includeBuild("../..") {
-    dependencySubstitution {
-        substitute(module("com.powersync:core"))
-            .using(project(":core")).because("we want to auto-wire up sample dependency")
-        substitute(module("com.powersync:connector-supabase"))
-            .using(project(":connectors:supabase"))
-            .because("we want to auto-wire up sample dependency")
-        substitute(module("com.powersync:compose"))
-            .using(project(":compose"))
-            .because("we want to auto-wire up sample dependency")
+val localProperties = Properties().apply {
+    try {
+        load(file("local.properties").reader())
+    } catch (ignored: java.io.IOException) {
+        // ignore
+    }
+}
+val useReleasedVersions = localProperties.getProperty("USE_RELEASED_POWERSYNC_VERSIONS") == "true"
+
+if (!useReleasedVersions) {
+    includeBuild("../..") {
+        dependencySubstitution {
+            substitute(module("com.powersync:core"))
+                .using(project(":core")).because("we want to auto-wire up sample dependency")
+            substitute(module("com.powersync:connector-supabase"))
+                .using(project(":connectors:supabase"))
+                .because("we want to auto-wire up sample dependency")
+            substitute(module("com.powersync:compose"))
+                .using(project(":compose"))
+                .because("we want to auto-wire up sample dependency")
+        }
     }
 }

--- a/demos/supabase-todolist/settings.gradle.kts
+++ b/demos/supabase-todolist/settings.gradle.kts
@@ -1,5 +1,7 @@
 import java.util.Properties
 
+enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
+
 pluginManagement {
     repositories {
         maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
@@ -25,13 +27,6 @@ dependencyResolutionManagement {
         maven("https://jitpack.io") {
             content { includeGroup("com.github.requery") }
         }
-        maven {
-            url = uri("https://maven.pkg.github.com/powersync-ja/powersync-kotlin")
-            credentials {
-                username = localProperties.getProperty("GITHUB_USERNAME", "")
-                password = localProperties.getProperty("GITHUB_TOKEN", "")
-            }
-        }
     }
 }
 
@@ -45,12 +40,18 @@ include(":androidApp")
 include(":shared")
 include(":desktopApp")
 
-includeBuild("../..") {
-    dependencySubstitution {
-        substitute(module("com.powersync:core"))
-            .using(project(":core")).because("we want to auto-wire up sample dependency")
-        substitute(module("com.powersync:connector-supabase"))
-            .using(project(":connectors:supabase"))
-            .because("we want to auto-wire up sample dependency")
+val useReleasedVersions = localProperties.getProperty("USE_RELEASED_POWERSYNC_VERSIONS") == "true"
+
+if (!useReleasedVersions) {
+    includeBuild("../..") {
+        dependencySubstitution {
+            substitute(module("com.powersync:core"))
+                .using(project(":core")).because("we want to auto-wire up sample dependency")
+            substitute(module("com.powersync:persistence"))
+                .using(project(":persistence")).because("we want to auto-wire up sample dependency")
+            substitute(module("com.powersync:connector-supabase"))
+                .using(project(":connectors:supabase"))
+                .because("we want to auto-wire up sample dependency")
+        }
     }
 }

--- a/demos/supabase-todolist/shared/build.gradle.kts
+++ b/demos/supabase-todolist/shared/build.gradle.kts
@@ -40,8 +40,10 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             // Need to use api here otherwise Database driver can't be accessed
-            api("com.powersync:core")
-            implementation("com.powersync:connector-supabase")
+            // When copying this example, replace "latest.release" with the current version available
+            // at: https://central.sonatype.com/artifact/com.powersync/core
+            api("com.powersync:core:latest.release")
+            implementation("com.powersync:connector-supabase:latest.release")
             implementation(libs.uuid)
             implementation(compose.runtime)
             implementation(compose.foundation)


### PR DESCRIPTION
Our examples in `demos/` are set up to compile our SDK as part of their build. That's useful for us to quickly test local changes in example apps, but not too helpful for users who need to fix these dependencies when copying from our examples.

This changes the builds of the `android-supabase-todolist` and `supabase-todolist` apps to optionally use released packages instead of the local ones. This behavior is enabled by setting `USE_RELEASED_POWERSYNC_VERSIONS=true` in `local.properties` in the respective demo.
I've also had to add an version selector to the dependencies - `latest.release` seems to work. There's a comment instructing users to pick an actual stable dependency.