### PR TITLE
Update dependencies

### DIFF
--- a/PowerSyncKotlin/build.gradle.kts
+++ b/PowerSyncKotlin/build.gradle.kts
@@ -1,8 +1,6 @@
 import co.touchlab.faktory.artifactmanager.ArtifactManager
 import co.touchlab.faktory.capitalized
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
-import org.jetbrains.kotlin.ir.backend.js.compile
-import java.net.URL
 import java.security.MessageDigest
 
 plugins {
@@ -170,7 +168,7 @@ abstract class UpdatePackageSwiftChecksumTask : DefaultTask() {
 
         // Download the zip file
         zipFile.parentFile.mkdirs()
-        URL(zipUrl.get()).openStream().use { input ->
+        project.uri(zipUrl.get()).toURL().openStream().use { input ->
             zipFile.outputStream().use { output ->
                 input.copyTo(output)
             }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,16 +15,7 @@ plugins {
     alias(libs.plugins.downloadPlugin) apply false
     alias(libs.plugins.kotlinter) apply false
     alias(libs.plugins.keeper) apply false
-}
-
-// Having different versions of this lead to the issue mentioned here
-// https://stackoverflow.com/questions/76479563/could-not-found-kotlinx-atomicfu-compose-multiplatform-ios
-// This and the `apply(plugin = "kotlinx-atomicfu")` in allprojects below solve the issue but can be deleted in future when
-// the issue is resolved https://github.com/Kotlin/kotlinx-atomicfu/issues/469
-buildscript {
-    dependencies {
-        classpath("org.jetbrains.kotlinx:atomicfu-gradle-plugin:0.23.1")
-    }
+    alias(libs.plugins.kotlin.atomicfu) apply false
 }
 
 allprojects {
@@ -57,9 +48,6 @@ allprojects {
         // We have a transitive dependency on this due to Kermit, but need the fixed version to support Java 8
         resolutionStrategy.force("co.touchlab:stately-collections:${libs.versions.stately.get()}")
     }
-
-    //
-    apply(plugin = "kotlinx-atomicfu")
 }
 subprojects {
     val GROUP: String by project

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -18,6 +18,7 @@ plugins {
     alias(libs.plugins.kotlinter)
     id("com.powersync.plugins.sonatype")
     alias(libs.plugins.mokkery)
+    alias(libs.plugins.kotlin.atomicfu)
 }
 
 val sqliteVersion = "3450200"

--- a/core/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
@@ -34,9 +34,9 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toInstant
-import kotlinx.datetime.toLocalDateTime
 import kotlinx.serialization.encodeToString
 
 /**
@@ -316,7 +316,7 @@ internal class PowerSyncDatabaseImpl(
 
                 SyncedAt(
                     priority = BucketPriority(it.getLong(0)!!.toInt()),
-                    syncedAt = rawTime.replace(" ", "T").toLocalDateTime().toInstant(TimeZone.UTC),
+                    syncedAt = LocalDateTime.parse(rawTime.replace(" ", "T")).toInstant(TimeZone.UTC),
                 )
             }
 

--- a/core/src/commonMain/kotlin/com/powersync/sync/SyncStatus.kt
+++ b/core/src/commonMain/kotlin/com/powersync/sync/SyncStatus.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.datetime.Instant
 
+@ConsistentCopyVisibility
 public data class PriorityStatusEntry internal constructor(
     val priority: BucketPriority,
     val lastSyncedAt: Instant?,

--- a/demos/android-supabase-todolist/app/build.gradle.kts
+++ b/demos/android-supabase-todolist/app/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.jetbrains.kotlin.android)
     alias(libs.plugins.sqldelight)
+    alias(libs.plugins.compose.compiler)
 }
 
 val localProperties = Properties()
@@ -18,7 +19,7 @@ fun getLocalProperty(key: String, defaultValue: String): String {
 
 android {
     namespace = "com.powersync.androidexample"
-    compileSdk = 34
+    compileSdk = 35
 
     buildFeatures {
         buildConfig = true
@@ -27,7 +28,7 @@ android {
     defaultConfig {
         applicationId = "com.powersync.androidexample"
         minSdk = 24
-        targetSdk = 34
+        targetSdk = 35
         versionCode = 1
         versionName = "1.0"
 

--- a/demos/android-supabase-todolist/build.gradle.kts
+++ b/demos/android-supabase-todolist/build.gradle.kts
@@ -2,4 +2,5 @@
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.jetbrains.kotlin.android) apply false
+    alias(libs.plugins.compose.compiler) apply false
 }

--- a/demos/android-supabase-todolist/gradle/libs.versions.toml
+++ b/demos/android-supabase-todolist/gradle/libs.versions.toml
@@ -1,17 +1,17 @@
 [versions]
-agp = "8.5.1"
+agp = "8.9.0"
 coreSplashscreen = "1.0.1"
-kotlin = "1.9.0"
-coreKtx = "1.13.1"
+kotlin = "2.1.10"
+coreKtx = "1.15.0"
 junit = "4.13.2"
 junitVersion = "1.2.1"
 espressoCore = "3.6.1"
-lifecycleRuntimeKtx = "2.6.1"
-activityCompose = "1.9.2"
-composeBom = "2024.04.01"
-materialIconsExtended = "1.7.2"
+lifecycleRuntimeKtx = "2.8.7"
+activityCompose = "1.10.1"
+composeBom = "2025.02.00"
+materialIconsExtended = "1.7.8"
 uuid = "0.8.2"
-kermit = "2.0.4"
+kermit = "2.0.5"
 sqldelight= "2.0.2"
 
 [libraries]
@@ -38,3 +38,4 @@ kermit = { module = "co.touchlab:kermit", version.ref = "kermit" }
 android-application = { id = "com.android.application", version.ref = "agp" }
 jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 sqldelight = { id = "app.cash.sqldelight", version.ref = "sqldelight" }
+compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }

--- a/demos/android-supabase-todolist/gradle/wrapper/gradle-wrapper.properties
+++ b/demos/android-supabase-todolist/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Sep 19 13:08:23 SAST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/demos/supabase-todolist/gradle/libs.versions.toml
+++ b/demos/supabase-todolist/gradle/libs.versions.toml
@@ -1,14 +1,14 @@
 [versions]
 ## SDK Versions
 android-minSdk = "24"
-android-targetSdk = "34"
-android-compileSdk = "34"
+android-targetSdk = "35"
+android-compileSdk = "35"
 java = "17"
 
 # Dependencies
-kotlin = "2.0.20"
+kotlin = "2.1.10"
 coroutines = "1.8.1"
-kotlinx-datetime = "0.5.0"
+kotlinx-datetime = "0.6.2"
 kotlinx-io = "0.5.4"
 ktor = "3.0.1"
 uuid = "0.8.2"
@@ -17,15 +17,15 @@ buildKonfig = "0.15.1"
 junit = "4.13.2"
 
 compose = "1.6.11"
-compose-preview = "1.7.2"
-lifecycle = "2.8.2"
+compose-preview = "1.7.8"
+lifecycle = "2.8.4"
 
 # plugins
-android-gradle-plugin = "8.5.1"
+android-gradle-plugin = "8.9.0"
 
 # Sample - Android
-androidx-core = "1.13.1"
-androidx-activity-compose = "1.9.2"
+androidx-core = "1.15.0"
+androidx-activity-compose = "1.10.1"
 
 androidx-appcompat = "1.7.0"
 androidx-espresso-core = "3.6.1"

--- a/demos/supabase-todolist/gradle/wrapper/gradle-wrapper.properties
+++ b/demos/supabase-todolist/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/demos/supabase-todolist/shared/src/androidMain/kotlin/com/powersync/demos/main.android.kt
+++ b/demos/supabase-todolist/shared/src/androidMain/kotlin/com/powersync/demos/main.android.kt
@@ -1,9 +1,15 @@
 package com.powersync.demos
 
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.powersync.DatabaseDriverFactory
 
 @Composable
-fun MainView(factory: DatabaseDriverFactory) = App(factory, Modifier.fillMaxSize())
+fun MainView(factory: DatabaseDriverFactory) = App(
+    factory,
+    Modifier.fillMaxSize().windowInsetsPadding(WindowInsets.systemBars)
+)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,15 +3,15 @@
 android-minSdk = "24"
 android-targetSdk = "34"
 android-compileSdk = "34"
-configurationAnnotations = "0.9.3"
+configurationAnnotations = "0.9.5"
 java = "17"
-idea = "222.4459.24" # Flamingo | 2022.2.1 (see https://plugins.jetbrains.com/docs/intellij/android-studio-releases-list.html)
+idea = "243.22562.218" # Meerkat | 2024.3.1 (see https://plugins.jetbrains.com/docs/intellij/android-studio-releases-list.html)
 
 # Dependencies
 kermit = "2.0.5"
-kotlin = "2.0.20"
+kotlin = "2.1.10"
 coroutines = "1.8.1"
-kotlinx-datetime = "0.5.0"
+kotlinx-datetime = "0.6.2"
 kotlinx-io = "0.5.4"
 ktor = "3.0.1"
 uuid = "0.8.2"
@@ -26,23 +26,24 @@ supabase = "3.0.1"
 junit = "4.13.2"
 
 compose = "1.6.11"
-compose-preview = "1.7.2"
+compose-preview = "1.7.8"
 androidxSqlite = "2.4.0"
 
 # plugins
-android-gradle-plugin = "8.5.1"
+android-gradle-plugin = "8.9.0"
 kmmBridge = "0.5.7"
-skie = "0.9.5"
+skie = "0.10.1"
 maven-publish = "0.27.0"
 download-plugin = "5.5.0"
-grammerKit = "0.1.12"
-mokkery = "2.4.0"
-kotlinter = "4.4.1"
+grammarkit-composer = "0.1.12"
+mokkery = "2.7.1"
+kotlinter = "5.0.1"
 keeper = "0.16.1"
+atomicfu = "0.27.0"
 
 # Sample - Android
-androidx-core = "1.13.1"
-androidx-activity-compose = "1.9.2"
+androidx-core = "1.15.0"
+androidx-activity-compose = "1.10.1"
 
 androidx-appcompat = "1.7.0"
 androidx-espresso-core = "3.6.1"
@@ -119,13 +120,14 @@ kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", versio
 skie = { id = "co.touchlab.skie", version.ref = "skie" }
 kmmbridge = { id = "co.touchlab.kmmbridge", version.ref = "kmmBridge" }
 sqldelight = { id = "app.cash.sqldelight", version.ref = "sqlDelight" }
-grammarKitComposer = { id = "com.alecstrong.grammar.kit.composer", version.ref = "grammerKit" }
+grammarKitComposer = { id = "com.alecstrong.grammar.kit.composer", version.ref = "grammarkit-composer" }
 mavenPublishPlugin = { id = "com.vanniktech.maven.publish", version.ref = "maven-publish" }
 downloadPlugin = { id = "de.undercouch.download", version.ref = "download-plugin" }
 mokkery = { id = "dev.mokkery", version.ref = "mokkery" }
 kotlinter = { id = "org.jmailen.kotlinter", version.ref = "kotlinter" }
 keeper = { id = "com.slack.keeper", version.ref = "keeper" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+kotlin-atomicfu = { id = "org.jetbrains.kotlinx.atomicfu", version.ref = "atomicfu" }
 
 [bundles]
 sqldelight = [

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
 ## SDK Versions
 android-minSdk = "24"
-android-targetSdk = "34"
-android-compileSdk = "34"
+android-targetSdk = "35"
+android-compileSdk = "35"
 configurationAnnotations = "0.9.5"
 java = "17"
 idea = "243.22562.218" # Meerkat | 2024.3.1 (see https://plugins.jetbrains.com/docs/intellij/android-studio-releases-list.html)

--- a/plugins/sonatype/src/main/kotlin/com/powersync/plugins/sonatype/SonatypeCentralExtension.kt
+++ b/plugins/sonatype/src/main/kotlin/com/powersync/plugins/sonatype/SonatypeCentralExtension.kt
@@ -41,7 +41,7 @@ public abstract class SonatypeCentralExtension(
         val sonatypeCentralUploadDir =
             project.file(project.layout.buildDirectory.dir(REPO_DIR))
 
-        project.tasks.create(COMPONENT_BUNDLE_TASK_NAME, Zip::class.java) {
+        val bundle = project.tasks.register(COMPONENT_BUNDLE_TASK_NAME, Zip::class.java) {
             it.group = GROUP
             it.description = "Creates a bundle for Sonatype Central Portal publishing."
             it.archiveClassifier.set("bundle")
@@ -55,10 +55,10 @@ public abstract class SonatypeCentralExtension(
         }
 
         log.info("Setting up the `:${PUBLISH_TASK_NAME}` task")
-        project.tasks.create(PUBLISH_TASK_NAME, PublishToCentralPortalTask::class.java) {
+        project.tasks.register(PUBLISH_TASK_NAME, PublishToCentralPortalTask::class.java) {
             it.group = GROUP
             it.description = "Publishes the bundle to Sonatype Central Portal"
-            it.dependsOn(project.tasks.named(COMPONENT_BUNDLE_TASK_NAME))
+            it.dependsOn(bundle)
         }
     }
 }


### PR DESCRIPTION
For the background sync investigation, I'll need to make some changes to the example app (in particular, restructuring dependency injection in the example to allow a database to be used within and outside of the compose UI). Some of these new dependencies don't work that well together with our old Gradle version and Android plugins.

So, as a first step, this updates our build dependencies. The most notable changes are the Gradle update, the Kotlin upgrade to 2.1 and the Android Gradle plugin update. I've also removed some build script workarounds that don't appear to be necessary anymore and fixed a few deprecation warnings.

I have tested the core android integration tests, the supabase-todolist demo on the JVM and Android, the android todolist demo and the unit tests in our Swift SDK after a local build.
