### PR TITLE
Do not upload empty updates to Supabase

### DIFF
--- a/connectors/supabase/src/commonMain/kotlin/com/powersync/connector/supabase/SupabaseConnector.kt
+++ b/connectors/supabase/src/commonMain/kotlin/com/powersync/connector/supabase/SupabaseConnector.kt
@@ -176,9 +176,11 @@ public class SupabaseConnector(
                         }
 
                         UpdateType.PATCH -> {
-                            table.update(entry.opData!!) {
-                                filter {
-                                    eq("id", entry.id)
+                            if (!entry.opData.isNullOrEmpty()) {
+                                table.update(entry.opData) {
+                                    filter {
+                                        eq("id", entry.id)
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
If a local table has been updated and the update resulted in no change for particular rows, then the corresponding `CrudEntry`s have empty `opData`. It doesn't seem to make sense to execute such updates. Skipping them speeds up sync.