### PR TITLE
Link SQLite statically on native platforms

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -179,8 +179,7 @@ kotlin {
 
         if (konanTarget.family == Family.IOS && konanTarget.name.contains("simulator")) {
             binaries.withType<TestExecutable>().configureEach {
-                /*
-                linkTaskProvider.dependsOn(unzipPowersyncFramework)
+                linkTaskProvider.configure { dependsOn(unzipPowersyncFramework) }
                 linkerOpts("-framework", "powersync-sqlite-core")
                 val frameworkRoot =
                     binariesFolder
@@ -189,7 +188,7 @@ kotlin {
                         .asFile.path
 
                 linkerOpts("-F", frameworkRoot)
-                linkerOpts("-rpath", frameworkRoot)*/
+                linkerOpts("-rpath", frameworkRoot)
             }
         }
         /*

--- a/core/src/iosMain/kotlin/com/powersync/DatabaseDriverFactory.ios.kt
+++ b/core/src/iosMain/kotlin/com/powersync/DatabaseDriverFactory.ios.kt
@@ -5,15 +5,14 @@ import co.touchlab.sqliter.DatabaseConfiguration.Logging
 import co.touchlab.sqliter.DatabaseConnection
 import co.touchlab.sqliter.interop.Logger
 import co.touchlab.sqliter.interop.SqliteErrorType
+import co.touchlab.sqliter.sqlite3.sqlite3_commit_hook
+import co.touchlab.sqliter.sqlite3.sqlite3_enable_load_extension
+import co.touchlab.sqliter.sqlite3.sqlite3_load_extension
+import co.touchlab.sqliter.sqlite3.sqlite3_rollback_hook
+import co.touchlab.sqliter.sqlite3.sqlite3_update_hook
 import com.powersync.db.internal.InternalSchema
 import com.powersync.persistence.driver.NativeSqliteDriver
 import com.powersync.persistence.driver.wrapConnection
-import com.powersync.sqlite3.sqlite3
-import com.powersync.sqlite3.sqlite3_commit_hook
-import com.powersync.sqlite3.sqlite3_enable_load_extension
-import com.powersync.sqlite3.sqlite3_load_extension
-import com.powersync.sqlite3.sqlite3_rollback_hook
-import com.powersync.sqlite3.sqlite3_update_hook
 import kotlinx.cinterop.ByteVar
 import kotlinx.cinterop.CPointerVar
 import kotlinx.cinterop.ExperimentalForeignApi
@@ -103,7 +102,7 @@ public actual class DatabaseDriverFactory {
         connection: DatabaseConnection,
         driver: DeferredDriver,
     ) {
-        val basePointer = connection.getDbPointer().getPointer(MemScope())
+        val ptr = connection.getDbPointer().getPointer(MemScope())
         // Try and find the bundle path for the SQLite core extension.
         val bundlePath =
             NSBundle.bundleWithIdentifier("co.powersync.sqlitecore")?.bundlePath
@@ -116,10 +115,6 @@ public actual class DatabaseDriverFactory {
         // Construct full path to the shared library inside the bundle
         val extensionPath = bundlePath.let { "$it/powersync-sqlite-core" }
 
-        // We have a mix of SQLite operations. The SQliteR lib links to the system SQLite with `-lsqlite3`
-        // However we also include our own build of SQLite which is statically linked.
-        // Loading of extensions is only available using our version of SQLite's API
-        val ptr = basePointer.reinterpret<sqlite3>()
         // Enable extension loading
         // We don't disable this after the fact, this should allow users to load their own extensions
         // in future.
@@ -183,13 +178,8 @@ public actual class DatabaseDriverFactory {
     private fun deregisterSqliteBinding(connection: DatabaseConnection) {
         val basePtr = connection.getDbPointer().getPointer(MemScope())
 
-        // We have a mix of SQLite operations. The SQliteR lib links to the system SQLite with `-lsqlite3`
-        // However we also include our own build of SQLite which is statically linked.
-        // Loading of extensions is only available using our version of SQLite's API
-        val ptr = basePtr.reinterpret<sqlite3>()
-
         sqlite3_update_hook(
-            ptr,
+            basePtr.reinterpret(),
             null,
             null,
         )

--- a/core/src/iosMain/kotlin/com/powersync/DatabaseDriverFactory.ios.kt
+++ b/core/src/iosMain/kotlin/com/powersync/DatabaseDriverFactory.ios.kt
@@ -22,7 +22,6 @@ import kotlinx.cinterop.alloc
 import kotlinx.cinterop.asStableRef
 import kotlinx.cinterop.nativeHeap
 import kotlinx.cinterop.ptr
-import kotlinx.cinterop.reinterpret
 import kotlinx.cinterop.staticCFunction
 import kotlinx.cinterop.toKString
 import kotlinx.cinterop.value
@@ -179,7 +178,7 @@ public actual class DatabaseDriverFactory {
         val basePtr = connection.getDbPointer().getPointer(MemScope())
 
         sqlite3_update_hook(
-            basePtr.reinterpret(),
+            basePtr,
             null,
             null,
         )

--- a/demos/supabase-todolist/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/demos/supabase-todolist/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -397,10 +397,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-lsqlite3",
-				);
+				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "${BUNDLE_ID}${TEAM_ID}";
 				PRODUCT_NAME = "${APP_NAME}";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -425,10 +422,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-lsqlite3",
-				);
+				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "${BUNDLE_ID}${TEAM_ID}";
 				PRODUCT_NAME = "${APP_NAME}";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ uuid = "0.8.2"
 powersync-core = "0.3.12"
 sqlite-android = "3.45.0"
 sqlite-jdbc = "3.45.2.0"
+sqliter = "1.3.1"
 turbine = "1.2.0"
 
 sqlDelight = "2.0.2"
@@ -81,7 +82,6 @@ ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
 ktor-serialization-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 
-sqldelight-driver-ios = { module = "app.cash.sqldelight:native-driver", version.ref = "sqlDelight" }
 sqldelight-driver-android = { module = "app.cash.sqldelight:android-driver", version.ref = "sqlDelight" }
 sqldelight-driver-jdbc = { module = "app.cash.sqldelight:sqlite-driver", version.ref = "sqlDelight" }
 requery-sqlite-android = { module = "com.github.requery:sqlite-android", version.ref = "sqlite-android" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -82,6 +82,8 @@ ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
 ktor-serialization-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 
+sqldelight-driver-native = { module = "app.cash.sqldelight:native-driver", version.ref = "sqlDelight" }
+sqliter = { module = "co.touchlab:sqliter-driver", version.ref = "sqliter" }
 sqldelight-driver-android = { module = "app.cash.sqldelight:android-driver", version.ref = "sqlDelight" }
 sqldelight-driver-jdbc = { module = "app.cash.sqldelight:sqlite-driver", version.ref = "sqlDelight" }
 requery-sqlite-android = { module = "com.github.requery:sqlite-android", version.ref = "sqlite-android" }

--- a/persistence/build.gradle.kts
+++ b/persistence/build.gradle.kts
@@ -90,6 +90,8 @@ android {
 }
 
 sqldelight {
+    linkSqlite = false
+
     databases {
         create("PsDatabase") {
             packageName.set("com.powersync.persistence")

--- a/persistence/build.gradle.kts
+++ b/persistence/build.gradle.kts
@@ -52,6 +52,7 @@ kotlin {
         }
 
         iosMain.dependencies {
+            api(libs.sqldelight.driver.native)
             api(projects.staticSqliteDriver)
         }
     }

--- a/persistence/build.gradle.kts
+++ b/persistence/build.gradle.kts
@@ -36,7 +36,6 @@ kotlin {
     explicitApi()
 
     sourceSets {
-
         commonMain.dependencies {
             api(libs.bundles.sqldelight)
         }
@@ -53,7 +52,7 @@ kotlin {
         }
 
         iosMain.dependencies {
-            api(libs.sqldelight.driver.ios)
+            api(projects.staticSqliteDriver)
         }
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -23,6 +23,7 @@ rootProject.name = "powersync-root"
 include(":core")
 include(":core-tests-android")
 include(":connectors:supabase")
+include("static-sqlite-driver")
 
 include(":dialect")
 include(":persistence")

--- a/static-sqlite-driver/README.md
+++ b/static-sqlite-driver/README.md
@@ -1,4 +1,1 @@
-This builds [SQLiter](https://github.com/touchlab/SQLiter) and the [SQlDelight native driver](https://github.com/sqldelight/sqldelight/tree/master/drivers/native-driver)
-as an independent project.
-
-We use unchanged source code, but change the buil logic to link SQLite statically.
+This project builds a `.klib` linking sqlite3 statically, without containing other Kotlin sources.

--- a/static-sqlite-driver/README.md
+++ b/static-sqlite-driver/README.md
@@ -1,0 +1,4 @@
+This builds [SQLiter](https://github.com/touchlab/SQLiter) and the [SQlDelight native driver](https://github.com/sqldelight/sqldelight/tree/master/drivers/native-driver)
+as an independent project.
+
+We use unchanged source code, but change the buil logic to link SQLite statically.

--- a/static-sqlite-driver/build.gradle.kts
+++ b/static-sqlite-driver/build.gradle.kts
@@ -1,0 +1,183 @@
+import java.io.File
+import com.powersync.plugins.sonatype.setupGithubRepository
+import de.undercouch.gradle.tasks.download.Download
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
+import org.jetbrains.kotlin.gradle.utils.NativeCompilerDownloader
+import org.jetbrains.kotlin.konan.target.HostManager
+import org.jetbrains.kotlin.konan.target.PlatformManager
+
+plugins {
+    alias(libs.plugins.kotlinMultiplatform)
+    alias(libs.plugins.downloadPlugin)
+    id("com.powersync.plugins.sonatype")
+}
+
+val sqliteVersion = "3450200"
+val sqliteReleaseYear = "2024"
+
+setupGithubRepository()
+
+val downloads = layout.buildDirectory.dir("downloads")
+val sqliteSrcFolder = downloads.map { it.dir("sqlite3") }
+
+val downloadSQLiteSources by tasks.registering(Download::class) {
+    val zipFileName = "sqlite-amalgamation-$sqliteVersion.zip"
+    src("https://www.sqlite.org/$sqliteReleaseYear/$zipFileName")
+    dest(downloads.map { it.file(zipFileName) })
+    onlyIfNewer(true)
+    overwrite(false)
+}
+
+val unzipSQLiteSources by tasks.registering(Copy::class) {
+    dependsOn(downloadSQLiteSources)
+
+    from(
+        zipTree(downloadSQLiteSources.get().dest).matching {
+            include("*/sqlite3.*")
+            exclude {
+                it.isDirectory
+            }
+            eachFile {
+                this.path = this.name
+            }
+        },
+    )
+    into(sqliteSrcFolder)
+}
+
+// Obtain host and platform manager from Kotlin multiplatform plugin. They're supposed to be
+// internal, but it's very convenient to have them because they expose the necessary toolchains we
+// use to compile SQLite for the platforms we need.
+val hostManager = HostManager()
+val platformManager: PlatformManager get() {
+    val distribution = org.jetbrains.kotlin.konan.target.Distribution(
+        konanHome = NativeCompilerDownloader(project).compilerDirectory.absolutePath
+    )
+    return PlatformManager(distribution = distribution)
+}
+
+fun compileSqlite(target: KotlinNativeTarget): TaskProvider<Task> {
+    val name = target.targetName
+    val outputDir = layout.buildDirectory.dir("c/$name")
+
+    val compileSqlite = tasks.register("${name}CompileSqlite") {
+        dependsOn(unzipSQLiteSources)
+        val targetDirectory = outputDir.get()
+        val sqliteSource = sqliteSrcFolder.map { it.file("sqlite3.c") }.get()
+        val output = targetDirectory.file("sqlite3.o")
+
+        inputs.file(sqliteSource)
+        outputs.file(output)
+
+        doFirst {
+            targetDirectory.asFile.mkdirs()
+            output.asFile.delete()
+        }
+
+        doLast {
+            val platform = platformManager.platform(target.konanTarget)
+
+            providers.exec {
+                commandLine = platform.clang.clangC(
+                    "--compile",
+                    "-I${sqliteSrcFolder.get().asFile.absolutePath}",
+                    sqliteSource.asFile.absolutePath,
+                    "-DHAVE_GETHOSTUUID=0",
+                    "-DSQLITE_ENABLE_DBSTAT_VTAB",
+                    "-DSQLITE_ENABLE_FTS5",
+                    "-DSQLITE_ENABLE_RTREE",
+                    "-O3",
+                    "-o",
+                    "sqlite3.o",
+                )
+
+                workingDir = targetDirectory.asFile
+            }.result.get()
+        }
+    }
+
+    val createStaticLibrary = tasks.register("${name}ArchiveSqlite") {
+        dependsOn(compileSqlite)
+        val targetDirectory = outputDir.get()
+        inputs.file(targetDirectory.file("sqlite3.o"))
+        outputs.file(targetDirectory.file("libsqlite3.a"))
+
+        doLast {
+            val platform = platformManager.platform(target.konanTarget)
+            providers.exec {
+                commandLine = platform.clang.llvmAr(
+                    "rc",
+                    "libsqlite3.a",
+                    "sqlite3.o",
+                )
+
+                workingDir = targetDirectory.asFile
+            }.result.get()
+        }
+    }
+
+    val buildCInteropDef = tasks.register("${name}CinteropSqlite") {
+        dependsOn(createStaticLibrary)
+
+        val archive = createStaticLibrary.get().outputs.files.singleFile
+        inputs.file(archive)
+
+        val parent = archive.parentFile
+        val defFile = File(parent, "sqlite3.def")
+        outputs.file(defFile)
+
+        doFirst {
+            defFile.writeText(
+                """
+            package = com.powersync.sqlite3
+            
+            linkerOpts.linux_x64 = -lpthread -ldl
+            linkerOpts.macos_x64 = -lpthread -ldl
+            staticLibraries=${archive.name}
+            libraryPaths=${parent.relativeTo(project.layout.projectDirectory.asFile.canonicalFile)}
+            """.trimIndent(),
+            )
+        }
+    }
+
+    return buildCInteropDef
+}
+
+kotlin {
+    iosX64()
+    iosArm64()
+    iosSimulatorArm64()
+
+    applyDefaultHierarchyTemplate()
+
+    sourceSets {
+        all {
+            languageSettings.apply {
+                optIn("kotlin.experimental.ExperimentalNativeApi")
+                optIn("kotlinx.cinterop.ExperimentalForeignApi")
+                optIn("kotlinx.cinterop.BetaInteropApi")
+            }
+        }
+
+        nativeTest {
+            dependencies {
+                implementation(libs.sqliter)
+            }
+        }
+    }
+
+    targets.withType<KotlinNativeTarget> {
+        if (hostManager.isEnabled(konanTarget)) {
+            val compileSqlite3 = compileSqlite(this)
+
+            compilations.named("main") {
+                cinterops.create("sqlite3") {
+                    val cInteropTask = tasks[interopProcessingTaskName]
+                    cInteropTask.dependsOn(compileSqlite3)
+                    definitionFile = compileSqlite3.get().outputs.files.singleFile
+                    includeDirs(sqliteSrcFolder.get())
+                }
+            }
+        }
+    }
+}

--- a/static-sqlite-driver/src/nativeTest/kotlin/SmokeTest.kt
+++ b/static-sqlite-driver/src/nativeTest/kotlin/SmokeTest.kt
@@ -1,0 +1,22 @@
+import co.touchlab.sqliter.DatabaseConfiguration
+import co.touchlab.sqliter.createDatabaseManager
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SmokeTest {
+    @Test
+    fun canUseSqlite() {
+        val manager = createDatabaseManager(DatabaseConfiguration(
+            name = "test",
+            version = 1,
+            create = {},
+            inMemory = true,
+        ))
+        val db = manager.createSingleThreadedConnection()
+        val stmt = db.createStatement("SELECT sqlite_version();")
+        val cursor = stmt.query()
+
+        assertEquals(true, cursor.next())
+        db.close()
+    }
+}


### PR DESCRIPTION
All our client SDKs need the PowerSync core extension to be loaded to work. On Apple platforms however, SQLite extension loading is disabled. This means that our SDK must not link the SQLite library from the platform, and instead link a custom version compiled with extension support.

This:

1. Removes the last remnants of native builds in the `:core` project. We don't need it for Android since we're now using sqlite-jdbc. We also don't need it for iOS since we can call the cinterop methods exposed from the SQLiter dependency.
2. Disables linking SQLite with the option provided by SQLDelight (since that one uses the one from the system).
3. Adds a new project whose only purpose is to compile `sqlite3` into a static archive. This archive is then included on a cinterop definition. This makes the Kotlin compiler bundle the archive with the klib, dependents will automatically link it. 
4. Depend on the new project from `:persistence`. This means that we now link SQLite statically.