### PR TITLE
Enable `org.gradle.parallel` option

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,7 @@
 kotlin.code.style=official
 # Gradle
 org.gradle.jvmargs=-Xmx2048M -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options\="-Xmx2048M"
+org.gradle.parallel=true
 # Compose
 org.jetbrains.compose.experimental.uikit.enabled=true
 # Android


### PR DESCRIPTION
Enabling parallel builds will execute tasks from different projects in parallel. This is a safe optimization to enable and makes our builds a bit faster (it's also a [recommended performance optimization](https://docs.gradle.org/current/userguide/performance.html#parallel_execution)).

Tasks within a single project are still running sequentially (which means that the tasks to compile SQLite can still slow things down quite a bit), but it's a quick win. Enabling the [configuration cache](https://docs.gradle.org/current/userguide/performance.html#enable_configuration_cache) would likely speed things up a lot more more, but many Gradle plugins are not compatible with that yet so I think that may be too risky.