### PR TITLE
Revert "Enable `org.gradle.parallel` option"

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,6 @@
 kotlin.code.style=official
 # Gradle
 org.gradle.jvmargs=-Xmx2048M -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options\="-Xmx2048M"
-org.gradle.parallel=true
 # Compose
 org.jetbrains.compose.experimental.uikit.enabled=true
 # Android


### PR DESCRIPTION
Reverts powersync-ja/powersync-kotlin#152

Looking at the CI failure, the option may be less safe than I thought. Definitely something to investigate at some point, reverting that sounds like the easiest option for now.