### PR TITLE
Prepare static-sqlite-driver for publishing

### DIFF
--- a/static-sqlite-driver/build.gradle.kts
+++ b/static-sqlite-driver/build.gradle.kts
@@ -12,13 +12,12 @@ import org.jetbrains.kotlin.konan.target.PlatformManager
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.downloadPlugin)
+    alias(libs.plugins.kotlinter)
     id("com.powersync.plugins.sonatype")
 }
 
 val sqliteVersion = "3490100"
 val sqliteReleaseYear = "2025"
-
-setupGithubRepository()
 
 val downloads = layout.buildDirectory.dir("downloads")
 val sqliteSrcFolder = downloads.map { it.dir("sqlite3") }
@@ -155,6 +154,7 @@ kotlin {
     iosSimulatorArm64()
 
     applyDefaultHierarchyTemplate()
+    explicitApi()
 
     sourceSets {
         all {
@@ -187,3 +187,5 @@ kotlin {
         }
     }
 }
+
+setupGithubRepository()

--- a/static-sqlite-driver/gradle.properties
+++ b/static-sqlite-driver/gradle.properties
@@ -1,0 +1,3 @@
+POM_ARTIFACT_ID=static-sqlite-driver
+POM_NAME=Statically linked SQLite
+POM_DESCRIPTION=A Kotlin-multiplatform bundle containing a static library for SQLite without Kotlin code.

--- a/static-sqlite-driver/src/commonMain/kotlin/com/powersync/sqlite3/StaticSqliteDriver.kt
+++ b/static-sqlite-driver/src/commonMain/kotlin/com/powersync/sqlite3/StaticSqliteDriver.kt
@@ -1,0 +1,9 @@
+package com.powersync.sqlite3
+
+/**
+ * An empty Kotlin object.
+ *
+ * This package needs to provide a source to be published correctly. The only purpose of this package is to provide
+ * build scripts linking SQLite statically however, so this empty object is defined for publishing only.
+ */
+public object StaticSqliteDriver

--- a/static-sqlite-driver/src/nativeTest/kotlin/SmokeTest.kt
+++ b/static-sqlite-driver/src/nativeTest/kotlin/SmokeTest.kt
@@ -6,12 +6,15 @@ import kotlin.test.assertEquals
 class SmokeTest {
     @Test
     fun canUseSqlite() {
-        val manager = createDatabaseManager(DatabaseConfiguration(
-            name = "test",
-            version = 1,
-            create = {},
-            inMemory = true,
-        ))
+        val manager =
+            createDatabaseManager(
+                DatabaseConfiguration(
+                    name = "test",
+                    version = 1,
+                    create = {},
+                    inMemory = true,
+                ),
+            )
         val db = manager.createSingleThreadedConnection()
         val stmt = db.createStatement("SELECT sqlite_version();")
         val cursor = stmt.query()


### PR DESCRIPTION
It looks like we need to have some Kotlin sources for the package to get uploaded, otherwise we're missing some klibs. So, to fix the publishing step, this adds a bogus declaration.

I've also copied and adapted a `gradle.properties` file (not sure if that actually gets used though), enabled kotlinter and generally made some minor adjustments to the gradle file for that project to be closer to the others.