### PR TITLE
Use structured concurrency for sync jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.0-BETA29 (unreleased)
+
+* Fix potential race condition between jobs in `connect()` and `disconnect()`.
+
 ## 1.0.0-BETA28
 
 * Update PowerSync SQLite core extension to 0.3.12.

--- a/core/src/commonIntegrationTest/kotlin/com/powersync/SyncIntegrationTest.kt
+++ b/core/src/commonIntegrationTest/kotlin/com/powersync/SyncIntegrationTest.kt
@@ -27,7 +27,7 @@ import com.powersync.utils.JsonUtil
 import dev.mokkery.answering.returns
 import dev.mokkery.everySuspend
 import dev.mokkery.mock
-import kotlinx.coroutines.CompletableDeferred
+import dev.mokkery.verify
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.runBlocking
@@ -38,6 +38,7 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
@@ -119,7 +120,7 @@ class SyncIntegrationTest {
 
     @Test
     @OptIn(DelicateCoroutinesApi::class)
-    fun closesResponseStreamOnDisconnect() = runTest {
+    fun closesResponseStreamOnDatabaseClose() = runTest {
         val syncStream = syncStream()
         database.connectInternal(syncStream, 1000L)
 
@@ -132,10 +133,48 @@ class SyncIntegrationTest {
             turbine.cancel()
         }
 
-        // Closing the database should close the channel
-        val channelClose = CompletableDeferred<Unit>()
-        syncLines.invokeOnClose { channelClose.complete(Unit) }
-        channelClose.await()
+        // Closing the database should have closed the channel
+        assertTrue { syncLines.isClosedForSend }
+    }
+
+    @Test
+    @OptIn(DelicateCoroutinesApi::class)
+    fun cleansResourcesOnDisconnect() = runTest {
+        val syncStream = syncStream()
+        database.connectInternal(syncStream, 1000L)
+
+        turbineScope(timeout = 10.0.seconds) {
+            val turbine = database.currentStatus.asFlow().testIn(this)
+            turbine.waitFor { it.connected }
+
+            database.disconnect()
+            turbine.waitFor { !it.connected }
+            turbine.cancel()
+        }
+
+        // Disconnecting should have closed the channel
+        assertTrue { syncLines.isClosedForSend }
+
+        // And called invalidateCredentials on the connector
+        verify { connector.invalidateCredentials() }
+    }
+
+    @Test
+    fun cannotUpdateSchemaWhileConnected() = runTest {
+        val syncStream = syncStream()
+        database.connectInternal(syncStream, 1000L)
+
+        turbineScope(timeout = 10.0.seconds) {
+            val turbine = database.currentStatus.asFlow().testIn(this)
+            turbine.waitFor { it.connected }
+            turbine.cancel()
+        }
+
+        assertFailsWith<PowerSyncException>("Cannot update schema while connected") {
+            database.updateSchema(Schema())
+        }
+
+        database.close()
     }
 
     @Test

--- a/core/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
@@ -488,4 +488,4 @@ internal class PowerSyncDatabaseImpl(
     }
 }
 
-internal object DisconnectRequestedException: CancellationException("disconnect() called")
+internal object DisconnectRequestedException : CancellationException("disconnect() called")

--- a/core/src/commonMain/kotlin/com/powersync/sync/SyncStatus.kt
+++ b/core/src/commonMain/kotlin/com/powersync/sync/SyncStatus.kt
@@ -5,6 +5,7 @@ import com.powersync.connectors.PowerSyncBackendConnector
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.cancel
 import kotlinx.datetime.Instant
 
 @ConsistentCopyVisibility

--- a/core/src/commonMain/kotlin/com/powersync/sync/SyncStatus.kt
+++ b/core/src/commonMain/kotlin/com/powersync/sync/SyncStatus.kt
@@ -5,7 +5,6 @@ import com.powersync.connectors.PowerSyncBackendConnector
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
-import kotlinx.coroutines.flow.cancel
 import kotlinx.datetime.Instant
 
 @ConsistentCopyVisibility

--- a/core/src/commonTest/kotlin/com/powersync/sync/SyncStreamTest.kt
+++ b/core/src/commonTest/kotlin/com/powersync/sync/SyncStreamTest.kt
@@ -210,7 +210,7 @@ class SyncStreamTest {
             // TODO: It would be neat if we could use in-memory sqlite instances instead of mocking everything
             // Revisit https://github.com/powersync-ja/powersync-kotlin/pull/117/files at some point
             val syncLines = Channel<SyncLine>()
-            val client = MockSyncService.client(this, syncLines.receiveAsFlow())
+            val client = MockSyncService(syncLines)
 
             syncStream =
                 SyncStream(

--- a/core/src/commonTest/kotlin/com/powersync/sync/SyncStreamTest.kt
+++ b/core/src/commonTest/kotlin/com/powersync/sync/SyncStreamTest.kt
@@ -30,7 +30,6 @@ import dev.mokkery.verifySuspend
 import io.ktor.client.engine.mock.MockEngine
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeout

--- a/core/src/commonTest/kotlin/com/powersync/testutils/MockSyncService.kt
+++ b/core/src/commonTest/kotlin/com/powersync/testutils/MockSyncService.kt
@@ -4,53 +4,77 @@ import app.cash.turbine.ReceiveTurbine
 import com.powersync.sync.SyncLine
 import com.powersync.sync.SyncStatusData
 import com.powersync.utils.JsonUtil
-import io.ktor.client.engine.HttpClientEngine
-import io.ktor.client.engine.mock.MockEngine
-import io.ktor.client.engine.mock.MockRequestHandleScope
-import io.ktor.client.engine.mock.respond
-import io.ktor.client.engine.mock.respondBadRequest
+import io.ktor.client.engine.HttpClientEngineBase
+import io.ktor.client.engine.HttpClientEngineCapability
+import io.ktor.client.engine.HttpClientEngineConfig
+import io.ktor.client.engine.callContext
+import io.ktor.client.plugins.HttpTimeoutCapability
 import io.ktor.client.request.HttpRequestData
 import io.ktor.client.request.HttpResponseData
-import io.ktor.utils.io.ByteChannel
+import io.ktor.http.HttpProtocolVersion
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.util.date.GMTDate
+import io.ktor.utils.io.InternalAPI
 import io.ktor.utils.io.writeStringUtf8
+import io.ktor.utils.io.writer
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.channels.ReceiveChannel
+import kotlinx.coroutines.channels.consumeEach
 import kotlinx.serialization.encodeToString
 
-internal class MockSyncService private constructor(
-    private val scope: CoroutineScope,
-    private val lines: Flow<SyncLine>,
-) {
-    private fun handleRequest(
-        scope: MockRequestHandleScope,
-        request: HttpRequestData,
-    ): HttpResponseData =
-        if (request.url.encodedPath == "/sync/stream") {
-            val channel = ByteChannel(autoFlush = true)
-            this.scope.launch {
-                lines.collect {
+/**
+ * A mock HTTP engine providing sync lines read from a coroutines [ReceiveChannel].
+ *
+ * Note that we can't trivially use ktor's `MockEngine` here because that engine requires a non-suspending handler
+ * function which makes it very hard to cancel the channel when the sync client closes the request stream. That is
+ * precisely what we may want to test though.
+ */
+internal class MockSyncService(
+    private val lines: ReceiveChannel<SyncLine>,
+) : HttpClientEngineBase("sync-service") {
+
+    override val config: HttpClientEngineConfig
+        get() = Config
+
+    override val supportedCapabilities: Set<HttpClientEngineCapability<out Any>> = setOf(
+        HttpTimeoutCapability,
+    )
+
+    @OptIn(InternalAPI::class)
+    override suspend fun execute(data: HttpRequestData): HttpResponseData {
+        val context = callContext()
+        val scope = CoroutineScope(context)
+
+        return if (data.url.encodedPath == "/sync/stream") {
+            val job = scope.writer(autoFlush = true) {
+                lines.consumeEach {
                     val serializedLine = JsonUtil.json.encodeToString(it)
                     channel.writeStringUtf8("$serializedLine\n")
                 }
             }
 
-            scope.respond(channel)
+            HttpResponseData(
+                HttpStatusCode.OK,
+                GMTDate(),
+                headersOf(),
+                HttpProtocolVersion.HTTP_1_1,
+                job.channel,
+                context,
+            )
         } else {
-            scope.respondBadRequest()
-        }
-
-    companion object {
-        fun client(
-            scope: CoroutineScope,
-            lines: Flow<SyncLine>,
-        ): HttpClientEngine {
-            val service = MockSyncService(scope, lines)
-            return MockEngine { request ->
-                service.handleRequest(this, request)
-            }
+            HttpResponseData(
+                HttpStatusCode.BadRequest,
+                GMTDate(),
+                headersOf(),
+                HttpProtocolVersion.HTTP_1_1,
+                "",
+                context,
+            )
         }
     }
+
+    private object Config : HttpClientEngineConfig()
 }
 
 suspend inline fun ReceiveTurbine<SyncStatusData>.waitFor(matcher: (SyncStatusData) -> Boolean) {

--- a/core/src/commonTest/kotlin/com/powersync/testutils/MockSyncService.kt
+++ b/core/src/commonTest/kotlin/com/powersync/testutils/MockSyncService.kt
@@ -22,7 +22,6 @@ import io.ktor.utils.io.writer
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.consume
-import kotlinx.coroutines.channels.consumeEach
 import kotlinx.serialization.encodeToString
 
 /**

--- a/core/src/commonTest/kotlin/com/powersync/testutils/MockSyncService.kt
+++ b/core/src/commonTest/kotlin/com/powersync/testutils/MockSyncService.kt
@@ -33,13 +33,13 @@ import kotlinx.serialization.encodeToString
 internal class MockSyncService(
     private val lines: ReceiveChannel<SyncLine>,
 ) : HttpClientEngineBase("sync-service") {
-
     override val config: HttpClientEngineConfig
         get() = Config
 
-    override val supportedCapabilities: Set<HttpClientEngineCapability<out Any>> = setOf(
-        HttpTimeoutCapability,
-    )
+    override val supportedCapabilities: Set<HttpClientEngineCapability<out Any>> =
+        setOf(
+            HttpTimeoutCapability,
+        )
 
     @OptIn(InternalAPI::class)
     override suspend fun execute(data: HttpRequestData): HttpResponseData {
@@ -47,13 +47,14 @@ internal class MockSyncService(
         val scope = CoroutineScope(context)
 
         return if (data.url.encodedPath == "/sync/stream") {
-            val job = scope.writer {
-                lines.consumeEach {
-                    val serializedLine = JsonUtil.json.encodeToString(it)
-                    channel.writeStringUtf8("$serializedLine\n")
-                    channel.flush()
+            val job =
+                scope.writer {
+                    lines.consumeEach {
+                        val serializedLine = JsonUtil.json.encodeToString(it)
+                        channel.writeStringUtf8("$serializedLine\n")
+                        channel.flush()
+                    }
                 }
-            }
 
             HttpResponseData(
                 HttpStatusCode.OK,

--- a/core/src/commonTest/kotlin/com/powersync/testutils/MockSyncService.kt
+++ b/core/src/commonTest/kotlin/com/powersync/testutils/MockSyncService.kt
@@ -47,10 +47,11 @@ internal class MockSyncService(
         val scope = CoroutineScope(context)
 
         return if (data.url.encodedPath == "/sync/stream") {
-            val job = scope.writer(autoFlush = true) {
+            val job = scope.writer {
                 lines.consumeEach {
                     val serializedLine = JsonUtil.json.encodeToString(it)
                     channel.writeStringUtf8("$serializedLine\n")
+                    channel.flush()
                 }
             }
 


### PR DESCRIPTION
The jobs to download and upload data (as well as the one forwarding sync status changes) are all operating independently from each other, which can potentially cause issues stopping these jobs as once.

This adopts a `SupervisorJob` for the three, allowing us to cancel just one job in `disconnect` that's guaranteed to get them all.

I've also slightly refactored our test client so that it properly forwards cancellations (when we cancel the sync jobs, that propagates to `SyncStream.streamingSyncRequest` in the `request.execute` block). With the mock HTTP engine from ktor we unfortunately have no access to that scope, but by implementing a fairly trivial custom engine we can implement the same functionality while also reporting downstream listeners being cancelled.
This then allows testing that calling `disconnect()` or `close()` on a database does indeed close the underlying HTTP response stream.