### PR TITLE
Fix checkpoints during uploads not being applied

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,3 +45,13 @@ jobs:
           -PGITHUB_PUBLISH_TOKEN=${{ secrets.GITHUB_TOKEN }} \
           ${{ matrix.targets }}
       shell: bash
+
+    # Credit: https://github.com/gradle/actions/issues/76#issuecomment-2007584323
+    - name: Upload reports on failure
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: report-for-${{ matrix.os }}
+        path: |
+          **/build/reports/
+          **/build/test-results/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.0.0-BETA29 (unreleased)
 
 * Fix potential race condition between jobs in `connect()` and `disconnect()`.
+* Fix race condition causing data received during uploads not to be applied.
 
 ## 1.0.0-BETA28
 

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -345,6 +345,7 @@ tasks.withType<KotlinTest> {
     testLogging {
         events("PASSED", "FAILED", "SKIPPED")
         exceptionFormat = TestExceptionFormat.FULL
+        showCauses = true
         showStandardStreams = true
         showStackTraces = true
     }

--- a/core/src/commonIntegrationTest/kotlin/com/powersync/DatabaseTest.kt
+++ b/core/src/commonIntegrationTest/kotlin/com/powersync/DatabaseTest.kt
@@ -69,6 +69,7 @@ class DatabaseTest {
         runBlocking {
             if (!database.closed) {
                 database.disconnectAndClear(true)
+                database.close()
             }
         }
         com.powersync.testutils.cleanup("testdb")

--- a/core/src/commonIntegrationTest/kotlin/com/powersync/SyncIntegrationTest.kt
+++ b/core/src/commonIntegrationTest/kotlin/com/powersync/SyncIntegrationTest.kt
@@ -626,9 +626,8 @@ class SyncIntegrationTest {
             val requestedCheckpoint = CompletableDeferred<Unit>()
             checkpointResponse = {
                 requestedCheckpoint.complete(Unit)
-                WriteCheckpointResponse(WriteCheckpointData(""))
+                WriteCheckpointResponse(WriteCheckpointData("1"))
             }
-            println("marking update as completed")
             completeUpload.complete(Unit)
             requestedCheckpoint.await()
 

--- a/core/src/commonIntegrationTest/kotlin/com/powersync/SyncIntegrationTest.kt
+++ b/core/src/commonIntegrationTest/kotlin/com/powersync/SyncIntegrationTest.kt
@@ -553,7 +553,6 @@ class SyncIntegrationTest {
             val completeUpload = CompletableDeferred<Unit>()
             val uploadStarted = CompletableDeferred<Unit>()
             testConnector.uploadDataCallback = { db ->
-                println("upload data callback called")
                 db.getCrudBatch()?.let { batch ->
                     uploadStarted.complete(Unit)
                     completeUpload.await()

--- a/core/src/commonIntegrationTest/kotlin/com/powersync/SyncIntegrationTest.kt
+++ b/core/src/commonIntegrationTest/kotlin/com/powersync/SyncIntegrationTest.kt
@@ -139,7 +139,7 @@ class SyncIntegrationTest {
 
                 database.close()
                 turbine.waitFor { !it.connected }
-                turbine.cancel()
+                turbine.cancelAndIgnoreRemainingEvents()
             }
 
             // Closing the database should have closed the channel
@@ -159,7 +159,7 @@ class SyncIntegrationTest {
 
                 database.disconnect()
                 turbine.waitFor { !it.connected }
-                turbine.cancel()
+                turbine.cancelAndIgnoreRemainingEvents()
             }
 
             // Disconnecting should have closed the channel
@@ -178,7 +178,7 @@ class SyncIntegrationTest {
             turbineScope(timeout = 10.0.seconds) {
                 val turbine = database.currentStatus.asFlow().testIn(this)
                 turbine.waitFor { it.connected }
-                turbine.cancel()
+                turbine.cancelAndIgnoreRemainingEvents()
             }
 
             assertFailsWith<PowerSyncException>("Cannot update schema while connected") {
@@ -276,7 +276,7 @@ class SyncIntegrationTest {
                 turbine.waitFor { it.hasSynced == true }
                 expectUserCount(4)
 
-                turbine.cancel()
+                turbine.cancelAndIgnoreRemainingEvents()
             }
 
             syncLines.close()
@@ -349,7 +349,7 @@ class SyncIntegrationTest {
 
                 syncLines.send(SyncLine.CheckpointComplete(lastOpId = "1"))
                 turbine.waitFor { !it.downloading }
-                turbine.cancel()
+                turbine.cancelAndIgnoreRemainingEvents()
             }
 
             database.close()
@@ -369,7 +369,7 @@ class SyncIntegrationTest {
                 database.disconnect()
 
                 turbine.waitFor { !it.connecting && !it.connected }
-                turbine.cancel()
+                turbine.cancelAndIgnoreRemainingEvents()
             }
 
             database.close()
@@ -414,7 +414,7 @@ class SyncIntegrationTest {
                     assertEquals(1, rows.size)
                 }
 
-                turbine.cancel()
+                turbine.cancelAndIgnoreRemainingEvents()
             }
 
             database.close()
@@ -486,8 +486,8 @@ class SyncIntegrationTest {
                 db2.disconnect()
                 turbine2.waitFor { !it.connecting }
 
-                turbine1.cancel()
-                turbine2.cancel()
+                turbine1.cancelAndIgnoreRemainingEvents()
+                turbine2.cancelAndIgnoreRemainingEvents()
             }
 
             db2.close()
@@ -512,7 +512,7 @@ class SyncIntegrationTest {
                 database.disconnect()
                 turbine.waitFor { !it.connecting }
 
-                turbine.cancel()
+                turbine.cancelAndIgnoreRemainingEvents()
             }
 
             database.close()
@@ -531,7 +531,7 @@ class SyncIntegrationTest {
                 database.connect(connector, 1000L, retryDelayMs = 5000)
                 turbine.waitFor { it.connecting }
 
-                turbine.cancel()
+                turbine.cancelAndIgnoreRemainingEvents()
             }
 
             database.close()
@@ -580,7 +580,7 @@ class SyncIntegrationTest {
             turbineScope {
                 val turbine = database.currentStatus.asFlow().testIn(this)
                 turbine.waitFor { it.downloading }
-                turbine.cancel()
+                turbine.cancelAndIgnoreRemainingEvents()
             }
 
             syncLines.send(
@@ -635,7 +635,7 @@ class SyncIntegrationTest {
             turbineScope {
                 val turbine = database.currentStatus.asFlow().testIn(this)
                 turbine.waitFor { !it.downloading }
-                turbine.cancel()
+                turbine.cancelAndIgnoreRemainingEvents()
             }
 
             // Meaning that the two rows are now visible

--- a/core/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
@@ -150,6 +150,7 @@ internal class PowerSyncDatabaseImpl(
                 retryDelayMs = retryDelayMs,
                 logger = logger,
                 params = params.toJsonObject(),
+                scope = scope,
             ),
             crudThrottleMs,
         )
@@ -222,7 +223,7 @@ internal class PowerSyncDatabaseImpl(
                     .filter { it.contains(InternalTable.CRUD.toString()) }
                     .throttle(crudThrottleMs)
                     .collect {
-                        stream.triggerCrudUpload()
+                        stream.triggerCrudUploadAsync().join()
                     }
             }
         }

--- a/core/src/commonMain/kotlin/com/powersync/sync/SyncStream.kt
+++ b/core/src/commonMain/kotlin/com/powersync/sync/SyncStream.kt
@@ -121,19 +121,20 @@ internal class SyncStream(
         }
     }
 
-    fun triggerCrudUploadAsync(): Job = scope.launch {
-        val thisIteration = PendingCrudUpload(CompletableDeferred())
-        try {
-            if (!status.connected || !isUploadingCrud.compareAndSet(null, thisIteration)) {
-                return@launch
-            }
+    fun triggerCrudUploadAsync(): Job =
+        scope.launch {
+            val thisIteration = PendingCrudUpload(CompletableDeferred())
+            try {
+                if (!status.connected || !isUploadingCrud.compareAndSet(null, thisIteration)) {
+                    return@launch
+                }
 
-            uploadAllCrud()
-        } finally {
-            isUploadingCrud.set(null)
-            thisIteration.done.complete(Unit)
+                uploadAllCrud()
+            } finally {
+                isUploadingCrud.set(null)
+                thisIteration.done.complete(Unit)
+            }
         }
-    }
 
     private suspend fun uploadAllCrud() {
         var checkedCrudItem: CrudEntry? = null
@@ -484,7 +485,9 @@ internal data class SyncStreamState(
     var validatedCheckpoint: Checkpoint?,
     var appliedCheckpoint: Checkpoint?,
     var bucketSet: MutableSet<String>?,
-    var abortIteration: Boolean = false
+    var abortIteration: Boolean = false,
 )
 
-private class PendingCrudUpload(val done: CompletableDeferred<Unit>)
+private class PendingCrudUpload(
+    val done: CompletableDeferred<Unit>,
+)

--- a/core/src/commonTest/kotlin/com/powersync/TestConnector.kt
+++ b/core/src/commonTest/kotlin/com/powersync/TestConnector.kt
@@ -3,7 +3,7 @@ package com.powersync
 import com.powersync.connectors.PowerSyncBackendConnector
 import com.powersync.connectors.PowerSyncCredentials
 
-class TestConnector: PowerSyncBackendConnector() {
+class TestConnector : PowerSyncBackendConnector() {
     var fetchCredentialsCallback: suspend () -> PowerSyncCredentials? = {
         PowerSyncCredentials(
             token = "test-token",
@@ -16,9 +16,7 @@ class TestConnector: PowerSyncBackendConnector() {
         tx?.complete(null)
     }
 
-    override suspend fun fetchCredentials(): PowerSyncCredentials? {
-        return fetchCredentialsCallback()
-    }
+    override suspend fun fetchCredentials(): PowerSyncCredentials? = fetchCredentialsCallback()
 
     override suspend fun uploadData(database: PowerSyncDatabase) {
         uploadDataCallback(database)

--- a/core/src/commonTest/kotlin/com/powersync/TestConnector.kt
+++ b/core/src/commonTest/kotlin/com/powersync/TestConnector.kt
@@ -1,0 +1,26 @@
+package com.powersync
+
+import com.powersync.connectors.PowerSyncBackendConnector
+import com.powersync.connectors.PowerSyncCredentials
+
+class TestConnector: PowerSyncBackendConnector() {
+    var fetchCredentialsCallback: suspend () -> PowerSyncCredentials? = {
+        PowerSyncCredentials(
+            token = "test-token",
+            userId = "test-user",
+            endpoint = "https://test.com",
+        )
+    }
+    var uploadDataCallback: suspend (PowerSyncDatabase) -> Unit = {
+        val tx = it.getNextCrudTransaction()
+        tx?.complete(null)
+    }
+
+    override suspend fun fetchCredentials(): PowerSyncCredentials? {
+        return fetchCredentialsCallback()
+    }
+
+    override suspend fun uploadData(database: PowerSyncDatabase) {
+        uploadDataCallback(database)
+    }
+}

--- a/core/src/commonTest/kotlin/com/powersync/sync/SyncStreamTest.kt
+++ b/core/src/commonTest/kotlin/com/powersync/sync/SyncStreamTest.kt
@@ -30,10 +30,7 @@ import dev.mokkery.verify.VerifyMode.Companion.order
 import dev.mokkery.verifyNoMoreCalls
 import dev.mokkery.verifySuspend
 import io.ktor.client.engine.mock.MockEngine
-import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest

--- a/core/src/commonTest/kotlin/com/powersync/testutils/MockSyncService.kt
+++ b/core/src/commonTest/kotlin/com/powersync/testutils/MockSyncService.kt
@@ -1,6 +1,7 @@
 package com.powersync.testutils
 
 import app.cash.turbine.ReceiveTurbine
+import com.powersync.bucket.WriteCheckpointResponse
 import com.powersync.sync.SyncLine
 import com.powersync.sync.SyncStatusData
 import com.powersync.utils.JsonUtil
@@ -33,6 +34,7 @@ import kotlinx.serialization.encodeToString
  */
 internal class MockSyncService(
     private val lines: ReceiveChannel<SyncLine>,
+    private val generateCheckpoint: () -> WriteCheckpointResponse,
 ) : HttpClientEngineBase("sync-service") {
     override val config: HttpClientEngineConfig
         get() = Config
@@ -68,6 +70,15 @@ internal class MockSyncService(
                 headersOf(),
                 HttpProtocolVersion.HTTP_1_1,
                 job.channel,
+                context,
+            )
+        } else if (data.url.encodedPath == "/write-checkpoint2.json") {
+            HttpResponseData(
+                HttpStatusCode.OK,
+                GMTDate(),
+                headersOf(),
+                HttpProtocolVersion.HTTP_1_1,
+                JsonUtil.json.encodeToString(generateCheckpoint()),
                 context,
             )
         } else {


### PR DESCRIPTION
This is the Kotlin port of https://github.com/powersync-ja/powersync-js/pull/558, see that PR for a more complete description.

I also had to fix some other quirks in the sync implementation here, notably:

1. The `triggerCrudUpload()` call when receiving keep-alive messages used to block the entire sync stream from receiving subsequent lines until the upload was completed. This changes that to spawn an async job that is not awaited (the trigger listening on `ps_crud` will still await this though).
2. There was no way to abort sync iterations (used e.g. for checkpoints with a checksum mismatch). This adds that functionality.