### PR TITLE
[JVM Windows] Process shutdown bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.0.0-BETA29 (unreleased)
 
 * Fix potential race condition between jobs in `connect()` and `disconnect()`.
+* [JVM Windows] Fixed PowerSync Extension temporary file deletion error on process shutdown.
 
 ## 1.0.0-BETA28
 

--- a/core/src/jvmMain/kotlin/com/powersync/DatabaseDriverFactory.jvm.kt
+++ b/core/src/jvmMain/kotlin/com/powersync/DatabaseDriverFactory.jvm.kt
@@ -57,6 +57,6 @@ public actual class DatabaseDriverFactory {
     }
 
     public companion object {
-        private val powersyncExtension: String = extractLib("powersync").toString()
+        private val powersyncExtension: String = extractLib("powersync")
     }
 }

--- a/core/src/jvmMain/kotlin/com/powersync/ExtractLib.kt
+++ b/core/src/jvmMain/kotlin/com/powersync/ExtractLib.kt
@@ -30,6 +30,5 @@ internal fun extractLib(fileName: String): String {
      * Wrapping in a File handle resolves the URI to a path usable by SQLite.
      * This is particularly relevant on Windows.
      */
-    val result = File(resourceURI.path).path.toString()
-    return result
+    return File(resourceURI.path).path.toString()
 }

--- a/core/src/jvmMain/kotlin/com/powersync/ExtractLib.kt
+++ b/core/src/jvmMain/kotlin/com/powersync/ExtractLib.kt
@@ -26,9 +26,9 @@ internal fun extractLib(fileName: String): String {
     val resourceURI =
         (R::class.java.getResource(path) ?: error("Resource $path not found"))
 
-    /**
-     * Wrapping in a File handle resolves the URI to a path usable by SQLite.
-     * This is particularly relevant on Windows.
-     */
+    // Wrapping the above in a File handle resolves the URI to a path usable by SQLite.
+    // This is particularly relevant on Windows.
+    // On Windows [resourceURI.path] starts with a `/`, e.g. `/c:/...`. SQLite does not load this path correctly.
+    // The wrapping here transforms the path to `c:/...` which does load correctly.
     return File(resourceURI.path).path.toString()
 }

--- a/core/src/jvmMain/kotlin/com/powersync/ExtractLib.kt
+++ b/core/src/jvmMain/kotlin/com/powersync/ExtractLib.kt
@@ -1,13 +1,10 @@
 package com.powersync
 
-import java.nio.file.Path
-import kotlin.io.path.createTempFile
-import kotlin.io.path.deleteIfExists
-import kotlin.io.path.outputStream
+import java.io.File
 
 private class R
 
-internal fun extractLib(fileName: String): Path {
+internal fun extractLib(fileName: String): String {
     val os = System.getProperty("os.name").lowercase()
     val (prefix, extension) =
         when {
@@ -26,14 +23,13 @@ internal fun extractLib(fileName: String): Path {
 
     val path = "/$prefix${fileName}_$arch.$extension"
 
-    val tmpPath = createTempFile("$prefix$fileName", ".$extension")
-    Runtime.getRuntime().addShutdownHook(Thread { tmpPath.deleteIfExists() })
+    val resourceURI =
+        (R::class.java.getResource(path) ?: error("Resource $path not found"))
 
-    (R::class.java.getResourceAsStream(path) ?: error("Resource $path not found")).use { input ->
-        tmpPath.outputStream().use { output ->
-            input.copyTo(output)
-        }
-    }
-
-    return tmpPath
+    /**
+     * Wrapping in a File handle resolves the URI to a path usable by SQLite.
+     * This is particularly relevant on Windows.
+     */
+    val result = File(resourceURI.path).path.toString()
+    return result
 }


### PR DESCRIPTION
# Overview

For JVM we currently find the PowerSync SQLite core resource's path then copy it to a temporary file. The temporary file is used when loading the extension in SQLite. The temporary file is deleted on process shutdown. 

https://github.com/powersync-ja/powersync-kotlin/issues/161 raised that on Windows an issue occurs when deleting the temporary file.

It looks like this method, of using a temporary file, was used in order to resolve the extension's path in a format compatible with Windows. Typically the `R::class.java.getResource(path)` result is of the format `/c:/...` which does not seem to work as an extension path in SQLite.

The logic has been updated to avoid the use of temporary files altogether. The binary resource file path is now used to load the SQLite extension.