### PR TITLE
[Fix] IOS Migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## 1.0.0-BETA29 (unreleased)
 
 * Fix potential race condition between jobs in `connect()` and `disconnect()`.
+* [iOS] Fixed issue where automatic driver migrations would fail with the error:
+```
+Sqlite operation failure database is locked attempted to run migration and failed. closing connection
+```
 
 ## 1.0.0-BETA28
 

--- a/core/src/iosMain/kotlin/com/powersync/DatabaseDriverFactory.ios.kt
+++ b/core/src/iosMain/kotlin/com/powersync/DatabaseDriverFactory.ios.kt
@@ -1,5 +1,6 @@
 package com.powersync
 
+import app.cash.sqldelight.db.QueryResult
 import co.touchlab.sqliter.DatabaseConfiguration
 import co.touchlab.sqliter.DatabaseConfiguration.Logging
 import co.touchlab.sqliter.DatabaseConnection
@@ -112,6 +113,15 @@ public actual class DatabaseDriverFactory {
         if (readOnly) {
             driver.execute("PRAGMA query_only=true")
         }
+
+        // Ensure internal read pool has created a connection at this point. This makes connection
+        // initialization a bit more deterministic.
+        driver.executeQuery(
+            identifier = null,
+            sql = "SELECT 1",
+            mapper = { QueryResult.Value(it.getLong(0)) },
+            parameters = 0,
+        )
 
         deferredDriver.setDriver(driver)
 

--- a/core/src/iosMain/kotlin/com/powersync/DatabaseDriverFactory.ios.kt
+++ b/core/src/iosMain/kotlin/com/powersync/DatabaseDriverFactory.ios.kt
@@ -3,6 +3,7 @@ package com.powersync
 import co.touchlab.sqliter.DatabaseConfiguration
 import co.touchlab.sqliter.DatabaseConfiguration.Logging
 import co.touchlab.sqliter.DatabaseConnection
+import co.touchlab.sqliter.NO_VERSION_CHECK
 import co.touchlab.sqliter.interop.Logger
 import co.touchlab.sqliter.interop.SqliteErrorType
 import co.touchlab.sqliter.sqlite3.sqlite3_commit_hook
@@ -68,7 +69,13 @@ public actual class DatabaseDriverFactory {
                         configuration =
                             DatabaseConfiguration(
                                 name = dbFilename,
-                                version = schema.version.toInt(),
+                                version =
+                                    if (!readOnly) {
+                                        schema.version.toInt()
+                                    } else {
+                                        // Don't do migrations on read only connections
+                                        NO_VERSION_CHECK
+                                    },
                                 create = { connection ->
                                     wrapConnection(connection) {
                                         schema.create(


### PR DESCRIPTION
# Overview

We currently create multiple readonly connections via the iOS driver. The iOS driver attempts to run schema migrations whenever a driver is created. It looks like these migrations are not synchronized internally. This causes errors of the form

```
Sqlite operation failure database is locked attempted to run migration and failed. closing connection
```

See example failed [test](https://github.com/powersync-ja/powersync-kotlin/actions/runs/14302972547/job/40081077924?pr=162)

This changeset avoids attempting to run migrations on read only drivers. 