### PR TITLE
Prepare 1.0.0-BETA29 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.0.0-BETA29 (unreleased)
+## 1.0.0-BETA29
 
 * Fix potential race condition between jobs in `connect()` and `disconnect()`.
 * [JVM Windows] Fixed PowerSync Extension temporary file deletion error on process shutdown.

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ development=true
 RELEASE_SIGNING_ENABLED=true
 # Library config
 GROUP=com.powersync
-LIBRARY_VERSION=1.0.0-BETA28
+LIBRARY_VERSION=1.0.0-BETA29
 GITHUB_REPO=https://github.com/powersync-ja/powersync-kotlin.git
 # POM
 POM_URL=https://github.com/powersync-ja/powersync-kotlin/


### PR DESCRIPTION
This adopts the changelog and the version in `gradle.properties` to prepare for a release run.