### PR TITLE
Fix deadlock when connecting after opening database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.0-BETA30
+
+* Fix a deadlock when calling `connect()` immediately after opening a database.
+  The issue has been introduced in version `1.0.0-BETA29`.
+
 ## 1.0.0-BETA29
 
 * Fix potential race condition between jobs in `connect()` and `disconnect()`.

--- a/core/src/commonIntegrationTest/kotlin/com/powersync/testutils/TestUtils.kt
+++ b/core/src/commonIntegrationTest/kotlin/com/powersync/testutils/TestUtils.kt
@@ -7,23 +7,23 @@ import co.touchlab.kermit.Severity
 import co.touchlab.kermit.TestConfig
 import co.touchlab.kermit.TestLogWriter
 import com.powersync.DatabaseDriverFactory
-import com.powersync.PowerSyncDatabase
 import com.powersync.bucket.WriteCheckpointData
 import com.powersync.bucket.WriteCheckpointResponse
 import com.powersync.connectors.PowerSyncBackendConnector
 import com.powersync.connectors.PowerSyncCredentials
+import com.powersync.createPowerSyncDatabaseImpl
 import com.powersync.db.PowerSyncDatabaseImpl
 import com.powersync.db.schema.Schema
 import com.powersync.sync.SyncLine
-import com.powersync.sync.SyncStream
 import dev.mokkery.answering.returns
 import dev.mokkery.everySuspend
 import dev.mokkery.mock
+import io.ktor.client.HttpClient
+import io.ktor.client.HttpClientConfig
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import kotlinx.io.files.Path
-import kotlinx.serialization.json.JsonObject
 
 expect val factory: DatabaseDriverFactory
 
@@ -43,18 +43,22 @@ fun generatePrintLogWriter() =
         }
     }
 
-internal fun databaseTest(testBody: suspend ActiveDatabaseTest.() -> Unit) =
-    runTest {
-        val running = ActiveDatabaseTest(this)
+internal fun databaseTest(
+    createInitialDatabase: Boolean = true,
+    testBody: suspend ActiveDatabaseTest.() -> Unit,
+) = runTest {
+    val running = ActiveDatabaseTest(this)
+    if (createInitialDatabase) {
         // Make sure the database is initialized, we're using internal APIs that expect initialization.
         running.database = running.openDatabaseAndInitialize()
-
-        try {
-            running.testBody()
-        } finally {
-            running.cleanup()
-        }
     }
+
+    try {
+        running.testBody()
+    } finally {
+        running.cleanup()
+    }
+}
 
 @OptIn(ExperimentalKermitApi::class)
 internal class ActiveDatabaseTest(
@@ -104,32 +108,27 @@ internal class ActiveDatabaseTest(
     fun openDatabase(): PowerSyncDatabaseImpl {
         logger.d { "Opening database $databaseName in directory $testDirectory" }
         val db =
-            PowerSyncDatabase(
+            createPowerSyncDatabaseImpl(
                 factory = factory,
                 schema = Schema(UserRow.table),
                 dbFilename = databaseName,
                 dbDirectory = testDirectory,
                 logger = logger,
                 scope = scope,
+                createClient = ::createClient,
             )
         doOnCleanup { db.close() }
-        return db as PowerSyncDatabaseImpl
+        return db
     }
 
     suspend fun openDatabaseAndInitialize(): PowerSyncDatabaseImpl = openDatabase().also { it.readLock { } }
 
-    fun PowerSyncDatabase.syncStream(): SyncStream {
-        val client = MockSyncService(syncLines) { checkpointResponse() }
-        return SyncStream(
-            bucketStorage = database.bucketStorage,
-            connector = connector,
-            httpEngine = client,
-            uploadCrud = { connector.uploadData(this) },
-            retryDelayMs = 10,
-            logger = logger,
-            params = JsonObject(emptyMap()),
-            scope = scope,
-        )
+    private fun createClient(config: HttpClientConfig<*>.() -> Unit): HttpClient {
+        val engine = MockSyncService(syncLines) { checkpointResponse() }
+
+        return HttpClient(engine) {
+            config()
+        }
     }
 
     fun doOnCleanup(action: suspend () -> Unit) {

--- a/core/src/commonMain/kotlin/com/powersync/PowerSyncDatabaseFactory.kt
+++ b/core/src/commonMain/kotlin/com/powersync/PowerSyncDatabaseFactory.kt
@@ -4,7 +4,10 @@ import co.touchlab.kermit.Logger
 import co.touchlab.skie.configuration.annotations.DefaultArgumentInterop
 import com.powersync.db.PowerSyncDatabaseImpl
 import com.powersync.db.schema.Schema
+import com.powersync.sync.SyncStream
 import com.powersync.utils.generateLogger
+import io.ktor.client.HttpClient
+import io.ktor.client.HttpClientConfig
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
@@ -30,7 +33,7 @@ public fun PowerSyncDatabase(
 ): PowerSyncDatabase {
     val generatedLogger: Logger = generateLogger(logger)
 
-    return PowerSyncDatabaseImpl(
+    return createPowerSyncDatabaseImpl(
         schema = schema,
         factory = factory,
         dbFilename = dbFilename,
@@ -39,3 +42,22 @@ public fun PowerSyncDatabase(
         dbDirectory = dbDirectory,
     )
 }
+
+internal fun createPowerSyncDatabaseImpl(
+    factory: DatabaseDriverFactory,
+    schema: Schema,
+    dbFilename: String,
+    scope: CoroutineScope,
+    logger: Logger,
+    dbDirectory: String?,
+    createClient: (HttpClientConfig<*>.() -> Unit) -> HttpClient = SyncStream::defaultHttpClient,
+): PowerSyncDatabaseImpl =
+    PowerSyncDatabaseImpl(
+        schema = schema,
+        factory = factory,
+        dbFilename = dbFilename,
+        scope = scope,
+        logger = logger,
+        dbDirectory = dbDirectory,
+        createClient = createClient,
+    )

--- a/core/src/commonTest/kotlin/com/powersync/sync/SyncStreamTest.kt
+++ b/core/src/commonTest/kotlin/com/powersync/sync/SyncStreamTest.kt
@@ -29,6 +29,7 @@ import dev.mokkery.verify
 import dev.mokkery.verify.VerifyMode.Companion.order
 import dev.mokkery.verifyNoMoreCalls
 import dev.mokkery.verifySuspend
+import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
@@ -103,7 +104,7 @@ class SyncStreamTest {
                 SyncStream(
                     bucketStorage = bucketStorage,
                     connector = connector,
-                    httpEngine = assertNoHttpEngine,
+                    createClient = { config -> HttpClient(assertNoHttpEngine, config) },
                     uploadCrud = {},
                     logger = logger,
                     params = JsonObject(emptyMap()),
@@ -139,7 +140,7 @@ class SyncStreamTest {
                 SyncStream(
                     bucketStorage = bucketStorage,
                     connector = connector,
-                    httpEngine = assertNoHttpEngine,
+                    createClient = { config -> HttpClient(assertNoHttpEngine, config) },
                     uploadCrud = { },
                     retryDelayMs = 10,
                     logger = logger,
@@ -179,7 +180,7 @@ class SyncStreamTest {
                 SyncStream(
                     bucketStorage = bucketStorage,
                     connector = connector,
-                    httpEngine = assertNoHttpEngine,
+                    createClient = { config -> HttpClient(assertNoHttpEngine, config) },
                     uploadCrud = { },
                     retryDelayMs = 10,
                     logger = logger,
@@ -220,7 +221,7 @@ class SyncStreamTest {
                 SyncStream(
                     bucketStorage = bucketStorage,
                     connector = connector,
-                    httpEngine = client,
+                    createClient = { config -> HttpClient(client, config) },
                     uploadCrud = { },
                     retryDelayMs = 10,
                     logger = logger,

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ development=true
 RELEASE_SIGNING_ENABLED=true
 # Library config
 GROUP=com.powersync
-LIBRARY_VERSION=1.0.0-BETA29
+LIBRARY_VERSION=1.0.0-BETA30
 GITHUB_REPO=https://github.com/powersync-ja/powersync-kotlin.git
 # POM
 POM_URL=https://github.com/powersync-ja/powersync-kotlin/


### PR DESCRIPTION
`PowerSyncDatabaseImpl.connect` used to call `waitReady()` inside of `mutex.withLock`. That's unfortunate, because `initialize` also acquires the mutex in `updateSchemaInternal`. So, when calling `connect()` immediately after creating a database, there's a potential for a deadlock. The mutex must only be acquired after waiting for the database to be initialized.

To validate the fix, I've migrated the sync tests to stop calling `connectInternal` and instead use the public `connect` method. This requires customizing the HTTP client engine passed to the sync engine, for which I've created an (internal) method next to the `PowerSyncDatabase` factory method. 

Closes https://github.com/powersync-ja/powersync-kotlin/issues/169.