### PR TITLE
Set temp_store_directory on Android

### DIFF
--- a/core-tests-android/src/androidTest/java/com/powersync/AndroidDatabaseTest.kt
+++ b/core-tests-android/src/androidTest/java/com/powersync/AndroidDatabaseTest.kt
@@ -227,5 +227,8 @@ class AndroidDatabaseTest {
     fun canCreateTemporaryTable() = runTest {
         database.execute("PRAGMA temp_store = 1;") // Store temporary data as files
         database.execute("CREATE TEMP TABLE my_tbl (content ANY) STRICT;")
+        for (i in 0..128) {
+            database.execute("INSERT INTO my_tbl VALUES (randomblob(1024 * 1024))")
+        }
     }
 }

--- a/core-tests-android/src/androidTest/java/com/powersync/AndroidDatabaseTest.kt
+++ b/core-tests-android/src/androidTest/java/com/powersync/AndroidDatabaseTest.kt
@@ -222,4 +222,10 @@ class AndroidDatabaseTest {
             // The exception messages differ slightly between drivers
             assertEquals(exception.message!!.contains("write a readonly database"), true)
         }
+
+    @Test
+    fun canCreateTemporaryTable() = runTest {
+        database.execute("PRAGMA temp_store = 1;") // Store temporary data as files
+        database.execute("CREATE TEMP TABLE my_tbl (content ANY) STRICT;")
+    }
 }

--- a/core-tests-android/src/androidTest/java/com/powersync/AndroidDatabaseTest.kt
+++ b/core-tests-android/src/androidTest/java/com/powersync/AndroidDatabaseTest.kt
@@ -224,11 +224,12 @@ class AndroidDatabaseTest {
         }
 
     @Test
-    fun canCreateTemporaryTable() = runTest {
+    fun canUseTempStore() = runTest {
         database.execute("PRAGMA temp_store = 1;") // Store temporary data as files
-        database.execute("CREATE TEMP TABLE my_tbl (content ANY) STRICT;")
-        for (i in 0..128) {
-            database.execute("INSERT INTO my_tbl VALUES (randomblob(1024 * 1024))")
+        database.execute("CREATE TEMP TABLE foo (bar TEXT);")
+        val data = "new row".repeat(100);
+        for (i in 0..10000) {
+            database.execute("INSERT INTO foo VALUES (?)", parameters = listOf(data))
         }
     }
 }

--- a/core/src/androidMain/kotlin/com/powersync/DatabaseDriverFactory.android.kt
+++ b/core/src/androidMain/kotlin/com/powersync/DatabaseDriverFactory.android.kt
@@ -7,6 +7,7 @@ import com.powersync.db.internal.InternalSchema
 import com.powersync.db.migrateDriver
 import kotlinx.coroutines.CoroutineScope
 import org.sqlite.SQLiteCommitListener
+import java.util.concurrent.atomic.AtomicBoolean
 
 @Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
 public actual class DatabaseDriverFactory(
@@ -27,10 +28,22 @@ public actual class DatabaseDriverFactory(
                 context.getDatabasePath(dbFilename)
             }
 
+        val properties = buildDefaultWalProperties(readOnly = readOnly)
+        val isFirst = IS_FIRST_CONNECTION.getAndSet(false)
+        if (isFirst) {
+            // Make sure the temp_store_directory points towards a temporary directory we actually
+            // have access to. Due to sandboxing, the default /tmp/ is inaccessible.
+            // The temp_store_directory pragma is deprecated and not thread-safe, so we only set it
+            // on the first connection (it sets a global field and will affect every connection
+            // opened).
+            val escapedPath = context.cacheDir.absolutePath.replace("\"", "\"\"")
+            properties.setProperty("temp_store_directory", "\"$escapedPath\"")
+        }
+
         val driver =
             JdbcSqliteDriver(
                 url = "jdbc:sqlite:$dbPath",
-                properties = buildDefaultWalProperties(readOnly = readOnly),
+                properties = properties,
             )
 
         migrateDriver(driver, schema)
@@ -58,5 +71,9 @@ public actual class DatabaseDriverFactory(
         )
 
         return mappedDriver
+    }
+
+    private companion object {
+        val IS_FIRST_CONNECTION = AtomicBoolean(true)
     }
 }


### PR DESCRIPTION
SQLite tries to write some temporary data, such as large intermediate materialized views or indexes, to the file system. For this, it attempts to use paths in `/tmp` or the current working directory. Due to sandboxing, both directories are unavailable on Android though. This can cause [errors that users were running into](https://discord.com/channels/1138230179878154300/1357681026939486369/1362417181802893482).

As a workaround, this overwrites the temporary directory to point to the cache directory from the app's `Context`.