### PR TITLE
Fix extracting PowerSync library from JAR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.0.0-BETA31
 
 * Added helpers for Attachment syncing.
+* Fix loading native PowerSync extension for Java targets.
 
 ## 1.0.0-BETA30
 


### PR DESCRIPTION
As a workaround for a Windows-specific issue, `R::class.java.getResource(path)` was used to obtain a path to `libpowersync.dylib`.
While this works during development, it fails for builds we distribute to users because `libpowersync.dylib` is inside a JAR, so the path can't be `dlopen`ed by SQLite.

This reverts the implementation to extract the library into a temporary file again. I couldn't test this on Windows to debug any potentially regressions there (which was the motivation for the change). I'm using `deleteOnClose` instead of a custom shutdown hook, I'm not sure if that makes a difference?