### PR TITLE
Remove User Id header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.0.0-BETA32
 
 * Added `onChange` method to the PowerSync client. This allows for observing table changes.
+* Removed unnecessary `User-Id` header from internal PowerSync service requests.
 
 ## 1.0.0-BETA31
 

--- a/README.md
+++ b/README.md
@@ -47,9 +47,6 @@ Current limitations:
 
 - Integration with SQLDelight schema and API generation (ORM) is not yet supported.
 
-Future work/ideas:
-- Attachments helper package.
-
 ## Installation
 
 Add the PowerSync Kotlin Multiplatform SDK to your project by adding the following to your `build.gradle.kts` file:

--- a/connectors/supabase/src/commonMain/kotlin/com/powersync/connector/supabase/SupabaseConnector.kt
+++ b/connectors/supabase/src/commonMain/kotlin/com/powersync/connector/supabase/SupabaseConnector.kt
@@ -164,7 +164,6 @@ public class SupabaseConnector(
 
             check(session.user != null) { "No user data" }
 
-            // userId is for debugging purposes only
             PowerSyncCredentials(
                 endpoint = powerSyncEndpoint,
                 token = session.accessToken, // Use the access token to authenticate against PowerSync

--- a/connectors/supabase/src/commonMain/kotlin/com/powersync/connector/supabase/SupabaseConnector.kt
+++ b/connectors/supabase/src/commonMain/kotlin/com/powersync/connector/supabase/SupabaseConnector.kt
@@ -168,7 +168,6 @@ public class SupabaseConnector(
             PowerSyncCredentials(
                 endpoint = powerSyncEndpoint,
                 token = session.accessToken, // Use the access token to authenticate against PowerSync
-                userId = session.user!!.id,
             )
         }
 

--- a/core/src/commonIntegrationTest/kotlin/com/powersync/testutils/TestUtils.kt
+++ b/core/src/commonIntegrationTest/kotlin/com/powersync/testutils/TestUtils.kt
@@ -100,7 +100,6 @@ internal class ActiveDatabaseTest(
             everySuspend { getCredentialsCached() } returns
                 PowerSyncCredentials(
                     token = "test-token",
-                    userId = "test-user",
                     endpoint = "https://test.com",
                 )
 

--- a/core/src/commonMain/kotlin/com/powersync/connectors/PowerSyncCredentials.kt
+++ b/core/src/commonMain/kotlin/com/powersync/connectors/PowerSyncCredentials.kt
@@ -18,6 +18,7 @@ public data class PowerSyncCredentials(
     val token: String,
     /**
      * User ID.
+     * @deprecated This is no longer used.
      */
     @SerialName("user_id") val userId: String?,
 ) {

--- a/core/src/commonMain/kotlin/com/powersync/connectors/PowerSyncCredentials.kt
+++ b/core/src/commonMain/kotlin/com/powersync/connectors/PowerSyncCredentials.kt
@@ -22,7 +22,7 @@ public data class PowerSyncCredentials(
     @Deprecated(
         message = "This property is no longer used.",
         replaceWith = ReplaceWith(""),
-        level = DeprecationLevel.WARNING
+        level = DeprecationLevel.WARNING,
     )
     @SerialName("user_id")
     val userId: String?,

--- a/core/src/commonMain/kotlin/com/powersync/connectors/PowerSyncCredentials.kt
+++ b/core/src/commonMain/kotlin/com/powersync/connectors/PowerSyncCredentials.kt
@@ -18,9 +18,14 @@ public data class PowerSyncCredentials(
     val token: String,
     /**
      * User ID.
-     * @deprecated This is no longer used.
      */
-    @SerialName("user_id") val userId: String?,
+    @Deprecated(
+        message = "This property is no longer used.",
+        replaceWith = ReplaceWith(""),
+        level = DeprecationLevel.WARNING
+    )
+    @SerialName("user_id")
+    val userId: String?,
 ) {
     override fun toString(): String = "PowerSyncCredentials<endpoint: $endpoint userId: $userId>"
 

--- a/core/src/commonMain/kotlin/com/powersync/connectors/PowerSyncCredentials.kt
+++ b/core/src/commonMain/kotlin/com/powersync/connectors/PowerSyncCredentials.kt
@@ -20,8 +20,7 @@ public data class PowerSyncCredentials(
      * User ID.
      */
     @Deprecated(
-        message = "This property is no longer used.",
-        replaceWith = ReplaceWith(""),
+        message = "This property is no longer used and should be removed.",
         level = DeprecationLevel.WARNING,
     )
     @SerialName("user_id")

--- a/core/src/commonMain/kotlin/com/powersync/connectors/PowerSyncCredentials.kt
+++ b/core/src/commonMain/kotlin/com/powersync/connectors/PowerSyncCredentials.kt
@@ -24,7 +24,7 @@ public data class PowerSyncCredentials(
         level = DeprecationLevel.WARNING,
     )
     @SerialName("user_id")
-    val userId: String?,
+    val userId: String? = null,
 ) {
     override fun toString(): String = "PowerSyncCredentials<endpoint: $endpoint userId: $userId>"
 

--- a/core/src/commonMain/kotlin/com/powersync/sync/SyncStream.kt
+++ b/core/src/commonMain/kotlin/com/powersync/sync/SyncStream.kt
@@ -174,7 +174,6 @@ internal class SyncStream(
                 contentType(ContentType.Application.Json)
                 headers {
                     append(HttpHeaders.Authorization, "Token ${credentials.token}")
-                    append("User-Id", credentials.userId ?: "")
                 }
             }
         if (response.status.value == 401) {
@@ -202,7 +201,6 @@ internal class SyncStream(
                     contentType(ContentType.Application.Json)
                     headers {
                         append(HttpHeaders.Authorization, "Token ${credentials.token}")
-                        append("User-Id", credentials.userId ?: "")
                     }
                     timeout { socketTimeoutMillis = Long.MAX_VALUE }
                     setBody(bodyJson)

--- a/core/src/commonTest/kotlin/com/powersync/TestConnector.kt
+++ b/core/src/commonTest/kotlin/com/powersync/TestConnector.kt
@@ -7,7 +7,6 @@ class TestConnector : PowerSyncBackendConnector() {
     var fetchCredentialsCallback: suspend () -> PowerSyncCredentials? = {
         PowerSyncCredentials(
             token = "test-token",
-            userId = "test-user",
             endpoint = "https://test.com",
         )
     }

--- a/core/src/commonTest/kotlin/com/powersync/sync/SyncStreamTest.kt
+++ b/core/src/commonTest/kotlin/com/powersync/sync/SyncStreamTest.kt
@@ -86,7 +86,6 @@ class SyncStreamTest {
                 everySuspend { getCredentialsCached() } returns
                     PowerSyncCredentials(
                         token = "test-token",
-                        userId = "test-user",
                         endpoint = "https://test.com",
                     )
             }


### PR DESCRIPTION
# Overview

This removes an unnecessary `User-Id` header which is currently being added to PowerSync service requests. 

This header has not been used by the service for a long time. 

The parameter in `PowerSyncCredentials` has been deprecated. 