### PR TITLE
Disable dokka javadoc jars for publishing

### DIFF
--- a/plugins/sonatype/src/main/kotlin/com/powersync/plugins/sonatype/SonatypeCentralUploadPlugin.kt
+++ b/plugins/sonatype/src/main/kotlin/com/powersync/plugins/sonatype/SonatypeCentralUploadPlugin.kt
@@ -3,6 +3,9 @@ package com.powersync.plugins.sonatype
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import com.vanniktech.maven.publish.MavenPublishPlugin
+import com.vanniktech.maven.publish.KotlinMultiplatform
+import com.vanniktech.maven.publish.JavadocJar
+import com.vanniktech.maven.publish.MavenPublishBaseExtension
 
 internal class SonatypeCentralUploadPlugin : Plugin<Project> {
     override fun apply(project: Project) {
@@ -14,6 +17,14 @@ internal class SonatypeCentralUploadPlugin : Plugin<Project> {
             SonatypeCentralExtension::class.java,
             project
         )
+
+        // The publishing plugin would apply Dokka to upload docs by default, but we only really apply Dokka on the root
+        // project, so this breaks the release flow.
+        @Suppress("UnstableApiUsage")
+        project.extensions.getByType(MavenPublishBaseExtension::class.java).configure(KotlinMultiplatform(
+            javadocJar = JavadocJar.Empty(),
+        ))
+
         extension.apply()
     }
 }


### PR DESCRIPTION
The Gradle plugin we use for publishing will automatically depend on `dokkaHtml` to include the outputs of that task as a javadoc jar. That's generally nice, but not helpful for us because our subprojects apply Dokka without building independent documentation sites (we apply Dokka on the root project to build a single site for everything).

So, disable that and use an empty javadoc jar instead.