### PR TITLE
CrudBatch hasMore + onChange improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.0.0-BETA33
+## unreleased
 
 * Fixed `CrudBatch` `hasMore` always returning false.
 * Added `triggerImmediately` to `onChange` method.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.0-BETA33
+
+* Fixed `CrudBatch` `hasMore` always returning false.
+* Added `triggerImmediately` to `onChange` method.
+
 ## 1.0.0-BETA32
 
 * Added `onChange` method to the PowerSync client. This allows for observing table changes.

--- a/core/src/commonIntegrationTest/kotlin/com/powersync/DatabaseTest.kt
+++ b/core/src/commonIntegrationTest/kotlin/com/powersync/DatabaseTest.kt
@@ -187,14 +187,22 @@ class DatabaseTest {
     fun testTableChangesUpdates() =
         databaseTest {
             turbineScope {
-                val query = database.onChange(tables = setOf("users")).testIn(this)
+                val query =
+                    database
+                        .onChange(
+                            tables = setOf("users"),
+                        ).testIn(this)
 
                 database.execute(
                     "INSERT INTO users (id, name, email) VALUES (uuid(), ?, ?)",
                     listOf("Test", "test@example.org"),
                 )
 
-                val changeSet = query.awaitItem()
+                var changeSet = query.awaitItem()
+                // The initial result
+                changeSet.count() shouldBe 0
+
+                changeSet = query.awaitItem()
                 changeSet.count() shouldBe 1
                 changeSet.contains("users") shouldBe true
 

--- a/core/src/commonIntegrationTest/kotlin/com/powersync/DatabaseTest.kt
+++ b/core/src/commonIntegrationTest/kotlin/com/powersync/DatabaseTest.kt
@@ -454,6 +454,7 @@ class DatabaseTest {
 
             batch = database.getCrudBatch(1000) ?: error("Batch should not be null")
             batch.crud shouldHaveSize 1
+            batch.hasMore shouldBe false
             batch.complete(null)
 
             database.getCrudBatch() shouldBe null

--- a/core/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
@@ -258,10 +258,10 @@ internal class PowerSyncDatabaseImpl(
             return null
         }
 
-        val entries =
+        var entries =
             internalDb.getAll(
                 "SELECT id, tx_id, data FROM ps_crud ORDER BY id ASC LIMIT ?",
-                listOf(limit.toLong()),
+                listOf(limit.toLong() + 1),
             ) {
                 CrudEntry.fromRow(
                     CrudRow(
@@ -278,7 +278,7 @@ internal class PowerSyncDatabaseImpl(
 
         val hasMore = entries.size > limit
         if (hasMore) {
-            entries.dropLast(entries.size - limit)
+            entries = entries.dropLast(1)
         }
 
         return CrudBatch(entries, hasMore, complete = { writeCheckpoint ->
@@ -351,11 +351,12 @@ internal class PowerSyncDatabaseImpl(
     override fun onChange(
         tables: Set<String>,
         throttleMs: Long,
+        triggerImmediately: Boolean,
     ): Flow<Set<String>> =
         flow {
             waitReady()
             emitAll(
-                internalDb.onChange(tables, throttleMs),
+                internalDb.onChange(tables, throttleMs, triggerImmediately),
             )
         }
 

--- a/core/src/commonMain/kotlin/com/powersync/db/Queries.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/Queries.kt
@@ -97,6 +97,7 @@ public interface Queries {
      *
      * @param tables The set of tables to monitor for changes.
      * @param throttleMs The minimum interval, in milliseconds, between emissions. Defaults to [DEFAULT_THROTTLE]. Table changes are accumulated while throttling is active. The accumulated set of tables will be emitted on the trailing edge of the throttle.
+     * @param triggerImmediately If true (default), the flow will immediately emit an empty set of tables when the flow is first collected. This can be useful for ensuring that the flow emits at least once, even if no changes occur to the monitored tables.
      * @return A [Flow] emitting the set of modified tables.
      * @throws PowerSyncException If a database error occurs.
      * @throws CancellationException If the operation is cancelled.
@@ -105,6 +106,7 @@ public interface Queries {
     public fun onChange(
         tables: Set<String>,
         throttleMs: Long = DEFAULT_THROTTLE.inWholeMilliseconds,
+        triggerImmediately: Boolean = true,
     ): Flow<Set<String>>
 
     /**


### PR DESCRIPTION
# Overview

## CrudBatch

This fixes a bug where the `hasMore` value of `CrudBatch` was always false.


## onChange

This adds a `triggerImmediately` parameter to the `onChange` API similar to the [Dart API](https://github.com/powersync-ja/sqlite_async.dart/blob/6d85217e30c61c3e51372b2304aec6ae1f1660b6/packages/sqlite_async/lib/src/sqlite_queries.dart#L86). Adding this makes it easy to avoid race conditions in consumers such as the Swift SDK. 
