### PR TITLE
[Chore] Update KMM deploy action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,7 +47,7 @@ jobs:
     uses: touchlab/KMMBridgeGithubWorkflow/.github/workflows/faktorybuildautoversion.yml@v1.2
     with:
       jvmVersion: 17
-      versionBaseProperty: LIBRARY_VERSION
+      versionBaseProperty: SWIFT_LIBRARY_VERSION
       publishTask: kmmBridgePublish
     secrets:
       gradle_params: -PsigningInMemoryKey="${{ secrets.SIGNING_KEY }}" -PsigningInMemoryKeyId="${{ secrets.SIGNING_KEY_ID }}" -PsigningInMemoryKeyPassword="${{ secrets.SIGNING_PASSWORD }}"

--- a/docs/Release.md
+++ b/docs/Release.md
@@ -2,7 +2,7 @@
 
 ## How to make a release
 
-1. Update `LIBRARY_VERSION` in `gradle.properties` in the root.
+1. Update `LIBRARY_VERSION` and `SWIFT_LIBRARY_VERSION` in `gradle.properties` in the root.
 2. Add an entry to the `CHANGELOG.md`.
 3. Make a PR and merge it.
 4. Once the PR is merged and in the `main` branch then manually run the Github action `Deploy to Sonatype`. This will create a release to Maven Central and will also update the version of the `powersync-kotlin` SPM package used in the Swift SDK. If the release contains changes pertaining to the Swift SDK you will need to update the `powersync-kotlin` SPM package version in that repo and make a release there as well.

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,7 +21,7 @@ LIBRARY_VERSION=1.0.0
 # The Swift KMM bridge artifacts are published to SPM via a unique tag version
 # The version is the same as the LIBRARY_VERSION, but with a suffix of -SWIFT
 # Please update this when updating the LIBRARY_VERSION
-SWIFT_LIBRARY_VERSION=1.0.0-SWIFT
+SWIFT_LIBRARY_VERSION=1.0.0+SWIFT
 GITHUB_REPO=https://github.com/powersync-ja/powersync-kotlin.git
 # POM
 POM_URL=https://github.com/powersync-ja/powersync-kotlin/

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ RELEASE_SIGNING_ENABLED=true
 GROUP=com.powersync
 LIBRARY_VERSION=1.0.0
 # The Swift KMM bridge artifacts are published to SPM via a unique tag version
-# The version is the same as the LIBRARY_VERSION, but with a suffix of -SWIFT
+# The version is the same as the LIBRARY_VERSION, but with a suffix of +SWIFT
 # Please update this when updating the LIBRARY_VERSION
 SWIFT_LIBRARY_VERSION=1.0.0+SWIFT
 GITHUB_REPO=https://github.com/powersync-ja/powersync-kotlin.git

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,6 +18,10 @@ RELEASE_SIGNING_ENABLED=true
 # Library config
 GROUP=com.powersync
 LIBRARY_VERSION=1.0.0
+# The Swift KMM bridge artifacts are published to SPM via a unique tag version
+# The version is the same as the LIBRARY_VERSION, but with a suffix of -SWIFT
+# Please update this when updating the LIBRARY_VERSION
+SWIFT_LIBRARY_VERSION=1.0.0-SWIFT
 GITHUB_REPO=https://github.com/powersync-ja/powersync-kotlin.git
 # POM
 POM_URL=https://github.com/powersync-ja/powersync-kotlin/


### PR DESCRIPTION
# Overview

The `KMMBridgeGithubWorkflow` action builds and publishes the artifacts required by the Swift SDK. 

On a high level the workflow:
- Builds the binary artifacts and uploads them to Maven
- Updates the committed `Package.swift` file to point to these `binaryTarget`s.
- Pushes the updated changes to a temporary branch and tags the commit with a computed version tag. Swift consumers can then use SPM to checkout the repo at this tag to obtain the core frameworks.

The workflow automatically adds a patch suffix to the provided version string. This distinguishes the KMM release from other releases. This causes version mappings such as `1.0.0-BETA21` -> `1.0.0-BETA21.0`.

The workflow [broke](https://github.com/powersync-ja/powersync-kotlin/actions/runs/14756037385) when we updated the Kotlin SDK version to `1.0.0`. The corresponding Swift version, `1.0.0.0` is not a valid SemVer version.

This PR adds a `+SWIFT` prelease suffix to the version provided to the `KMMBridgeGithubWorkflow` workflow. This will cause Swift releases to follow the version format `1.x.x+SWIFT.0`. The Swift SDK can use a version range of `^1.0.0` which will allow for automatic updates e.g. if we release `1.1.2+SWIFT.0`.

