### PR TITLE
chore: bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.1
+
+* [Internal] Version bump for broken Swift release pipeline
+
 ## 1.0.0
 
 * Bump SDK to V1/Stable feature status

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,11 +17,11 @@ development=true
 RELEASE_SIGNING_ENABLED=true
 # Library config
 GROUP=com.powersync
-LIBRARY_VERSION=1.0.0
+LIBRARY_VERSION=1.0.1
 # The Swift KMM bridge artifacts are published to SPM via a unique tag version
 # The version is the same as the LIBRARY_VERSION, but with a suffix of +SWIFT
 # Please update this when updating the LIBRARY_VERSION
-SWIFT_LIBRARY_VERSION=1.0.0+SWIFT
+SWIFT_LIBRARY_VERSION=1.0.1+SWIFT
 GITHUB_REPO=https://github.com/powersync-ja/powersync-kotlin.git
 # POM
 POM_URL=https://github.com/powersync-ja/powersync-kotlin/


### PR DESCRIPTION
# Overview

The previous failed KMM [publish](https://github.com/powersync-ja/powersync-kotlin/actions/runs/14756037385/job/41427039008) job already published some artifacts before it failed. This causes a new publish to [fail](https://github.com/powersync-ja/powersync-kotlin/actions/runs/14792437919/job/41534823355).

This bumps the package version in order to avoid package publishing conflicts. 