### PR TITLE
Fix symlinks in generated XCFramework

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,8 @@ let packageName = "PowerSyncKotlin"
 let package = Package(
     name: packageName,
     platforms: [
-        .iOS(.v13)
+        .iOS(.v13),
+        .macOS(.v10_15)
     ],
     products: [
         .library(


### PR DESCRIPTION
The kmmbridge Gradle plugin uses a Gradle `Zip` task to create a `.zip` archive of an XCFramework directory for the compiled Kotlin code.

On macOS, the layout of an XCFramework typically looks like this:

```
PowerSyncKotlin.xcframework/
├─ macos-arm64_x86_64/
│  ├─ Versions/
│  │  ├─ A/
│  │  │  ├─ .../
│  │  ├─ Current/    (symlink to ./A)
```

However, the Gradle `Zip` task does not support preserving symlinks when creating zip files. Instead, these files are copied into the uploaded archive. It looks like XCode is not consistently fine with this, sometimes attempting to `readlink` the `Current/` directory in the xcframework even when it is a regular directory. This fails, breaking macOS builds.

This PR applies a hack to the publishing logic for the `:PowerSyncKotlin` project that will delete the archive created by Gradle only to re-create it with a `zip` invocation (we can't replace the task because it's created by the KMMBridge plugin). That allows using this project in macOS apps built with Swift.

I've tested this by changing `Package.swift` here, replacing the path for the binary target with the created archive:

```Swift
.binaryTarget(
    name: packageName,
    path: "PowerSyncKotlin/build/faktory/zip/frameworkarchive.zip"
)
```

(run `./gradlew PowerSyncKotlin:zipXCFramework` to create it). Pointing our Swift SDK at that package allows building macOS apps. See: https://github.com/powersync-ja/powersync-swift/pull/44