### PR TITLE
Rename `oldData` in CRUD entries to `previousValues`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## unreleased
+## 1.1.0
 
-* Add `trackPreviousValues` option on `Table` which sets `CrudEntry.oldData` to previous values on updates.
+* Add `trackPreviousValues` option on `Table` which sets `CrudEntry.previousValues` to previous values on updates.
 * Add `trackMetadata` option on `Table` which adds a `_metadata` column that can be used for updates.
   The configured metadata is available through `CrudEntry.metadata`.
 * Add `ignoreEmptyUpdates` option which skips creating CRUD entries for updates that don't change any values.

--- a/core/src/commonIntegrationTest/kotlin/com/powersync/CrudTest.kt
+++ b/core/src/commonIntegrationTest/kotlin/com/powersync/CrudTest.kt
@@ -33,7 +33,7 @@ class CrudTest {
             database.execute("UPDATE lists SET name = ?", listOf("new name"))
 
             val batch = database.getNextCrudTransaction()
-            batch!!.crud[0].oldData shouldBe mapOf("name" to "entry", "content" to "content")
+            batch!!.crud[0].previousValues shouldBe mapOf("name" to "entry", "content" to "content")
         }
 
     @Test
@@ -54,7 +54,7 @@ class CrudTest {
             database.execute("UPDATE lists SET name = ?, content = ?", listOf("new name", "new content"))
 
             val batch = database.getNextCrudTransaction()
-            batch!!.crud[0].oldData shouldBe mapOf("name" to "entry")
+            batch!!.crud[0].previousValues shouldBe mapOf("name" to "entry")
         }
 
     @Test
@@ -75,7 +75,7 @@ class CrudTest {
             database.execute("UPDATE lists SET name = ?", listOf("new name"))
 
             val batch = database.getNextCrudTransaction()
-            batch!!.crud[0].oldData shouldBe mapOf("name" to "entry")
+            batch!!.crud[0].previousValues shouldBe mapOf("name" to "entry")
         }
 
     @Test

--- a/core/src/commonMain/kotlin/com/powersync/db/crud/CrudEntry.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/crud/CrudEntry.kt
@@ -64,7 +64,7 @@ public data class CrudEntry(
      * These values can be tracked for `UPDATE` statements when [Table.trackPreviousValues] is
      * enabled.
      */
-    val oldData: Map<String, String?>? = null,
+    val previousValues: Map<String, String?>? = null,
 ) {
     public companion object {
         public fun fromRow(row: CrudRow): CrudEntry {
@@ -80,7 +80,7 @@ public data class CrudEntry(
                 table = data["type"]!!.jsonPrimitive.content,
                 transactionId = row.txId,
                 metadata = data["metadata"]?.jsonPrimitive?.content,
-                oldData =
+                previousValues =
                     data["old"]?.jsonObject?.mapValues { (_, value) ->
                         value.jsonPrimitive.contentOrNull
                     },

--- a/core/src/commonMain/kotlin/com/powersync/db/schema/Table.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/schema/Table.kt
@@ -43,7 +43,7 @@ public data class Table(
      */
     val trackMetadata: Boolean = false,
     /**
-     * When set to a non-null value, track old values of columns for [CrudEntry.oldData].
+     * When set to a non-null value, track old values of columns for [CrudEntry.previousValue].
      *
      * See [TrackPreviousValuesOptions] for details.
      */
@@ -219,7 +219,7 @@ public data class Table(
 }
 
 /**
- * Options to include old values in [CrudEntry.oldData] for update statements.
+ * Options to include old values in [CrudEntry.previousValue] for update statements.
  *
  * These options are enabled by passing them to a non-local [Table] constructor.
  */
@@ -228,7 +228,7 @@ public data class TrackPreviousValuesOptions(
      * A filter of column names for which updates should be tracked.
      *
      * When set to a non-null value, columns not included in this list will not appear in
-     * [CrudEntry.oldData]. By default, all columns are included.
+     * [CrudEntry.previousValues]. By default, all columns are included.
      */
     val columnFilter: List<String>? = null,
     /**

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,11 +17,11 @@ development=true
 RELEASE_SIGNING_ENABLED=true
 # Library config
 GROUP=com.powersync
-LIBRARY_VERSION=1.0.1
+LIBRARY_VERSION=1.1.0
 # The Swift KMM bridge artifacts are published to SPM via a unique tag version
 # The version is the same as the LIBRARY_VERSION, but with a suffix of +SWIFT
 # Please update this when updating the LIBRARY_VERSION
-SWIFT_LIBRARY_VERSION=1.0.1+SWIFT
+SWIFT_LIBRARY_VERSION=1.1.0+SWIFT
 GITHUB_REPO=https://github.com/powersync-ja/powersync-kotlin.git
 # POM
 POM_URL=https://github.com/powersync-ja/powersync-kotlin/


### PR DESCRIPTION
Benita pointed out that the `oldData` field in `CrudEntry` is inconsistent with the `trackPreviousValues` option. So, this renames it to `previousValues` for clarity.

This also bumps the version to `1.1.0`, I think we can start a release once this is merged.