### PR TITLE
Refactor SQLite compilation tasks

### DIFF
--- a/core/src/commonIntegrationTest/kotlin/com/powersync/sync/SyncProgressTest.kt
+++ b/core/src/commonIntegrationTest/kotlin/com/powersync/sync/SyncProgressTest.kt
@@ -83,14 +83,19 @@ class SyncProgressTest {
         val progress = item.downloadProgress ?: error("Expected download progress on $item")
 
         assertTrue { item.downloading }
-        assertEquals(total.first, progress.downloadedOperations)
-        assertEquals(total.second, progress.totalOperations)
+        run {
+            val message = "Expected total progress to be ${total.first}/${total.second}, but it is ${progress.downloadedOperations}/${progress.totalOperations}"
+            assertEquals(total.first, progress.downloadedOperations, message)
+            assertEquals(total.second, progress.totalOperations, message)
+        }
 
         priorities.forEach { (priority, expected) ->
             val (expectedDownloaded, expectedTotal) = expected
-            val progress = progress.untilPriority(priority)
-            assertEquals(expectedDownloaded, progress.downloadedOperations)
-            assertEquals(expectedTotal, progress.totalOperations)
+            val actualProgress = progress.untilPriority(priority)
+            val message = "Expected progress at prio $priority to be ${expectedDownloaded}/${expectedTotal}, but it is ${actualProgress.downloadedOperations}/${actualProgress.totalOperations}"
+
+            assertEquals(expectedDownloaded, actualProgress.downloadedOperations, message)
+            assertEquals(expectedTotal, actualProgress.totalOperations, message)
         }
     }
 

--- a/core/src/commonMain/kotlin/com/powersync/sync/SyncStream.kt
+++ b/core/src/commonMain/kotlin/com/powersync/sync/SyncStream.kt
@@ -436,8 +436,8 @@ internal class SyncStream(
         state: SyncStreamState,
     ): SyncStreamState {
         val batch = SyncDataBatch(listOf(data))
-        status.update { copy(downloading = true, downloadProgress = downloadProgress?.incrementDownloaded(batch)) }
         bucketStorage.saveSyncData(batch)
+        status.update { copy(downloading = true, downloadProgress = downloadProgress?.incrementDownloaded(batch)) }
         return state
     }
 

--- a/demos/supabase-todolist/gradle.properties
+++ b/demos/supabase-todolist/gradle.properties
@@ -1,6 +1,7 @@
 kotlin.code.style=official
 xcodeproj=./iosApp
 android.useAndroidX=true
+org.gradle.caching=true
 org.gradle.jvmargs=-Xmx3g
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 org.jetbrains.compose.experimental.macos.enabled=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,7 @@
 kotlin.code.style=official
 # Gradle
 org.gradle.jvmargs=-Xmx2048M -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options\="-Xmx2048M"
+org.gradle.caching=true
 # Compose
 org.jetbrains.compose.experimental.uikit.enabled=true
 # Android

--- a/plugins/build-plugin/src/main/kotlin/com/powersync/compile/ClangCompile.kt
+++ b/plugins/build-plugin/src/main/kotlin/com/powersync/compile/ClangCompile.kt
@@ -1,0 +1,92 @@
+package com.powersync.compile
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.ProviderFactory
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import org.jetbrains.kotlin.konan.target.KonanTarget
+import javax.inject.Inject
+import kotlin.io.path.name
+
+@CacheableTask
+abstract class ClangCompile: DefaultTask() {
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.NONE)
+    abstract val inputFile: RegularFileProperty
+
+    @get:Input
+    abstract val konanTarget: Property<String>
+
+    @get:InputDirectory
+    @get:PathSensitive(PathSensitivity.NONE)
+    abstract val include: DirectoryProperty
+
+    @get:OutputFile
+    abstract val objectFile: RegularFileProperty
+
+    @get:Inject
+    protected abstract val providers: ProviderFactory
+
+    @TaskAction
+    fun run() {
+        val target = requireNotNull(KonanTarget.predefinedTargets[konanTarget.get()])
+
+        val (llvmTarget, sysRoot) = when (target) {
+            KonanTarget.IOS_X64 -> "x86_64-apple-ios12.0-simulator" to IOS_SIMULATOR_SDK
+            KonanTarget.IOS_ARM64 -> "arm64-apple-ios12.0" to IOS_SDK
+            KonanTarget.IOS_SIMULATOR_ARM64 -> "arm64-apple-ios14.0-simulator" to IOS_SIMULATOR_SDK
+            KonanTarget.MACOS_ARM64 -> "aarch64-apple-macos" to MACOS_SDK
+            KonanTarget.MACOS_X64 -> "x86_64-apple-macos" to MACOS_SDK
+            KonanTarget.WATCHOS_DEVICE_ARM64 -> "aarch64-apple-watchos" to WATCHOS_SDK
+            KonanTarget.WATCHOS_ARM32 -> "armv7k-apple-watchos" to WATCHOS_SDK
+            KonanTarget.WATCHOS_ARM64 -> "arm64_32-apple-watchos" to WATCHOS_SDK
+            KonanTarget.WATCHOS_SIMULATOR_ARM64 -> "aarch64-apple-watchos-simulator" to WATCHOS_SIMULATOR_SDK
+            KonanTarget.WATCHOS_X64 -> "x86_64-apple-watchos-simulator" to WATCHOS_SIMULATOR_SDK
+            else -> error("Unexpected target $target")
+        }
+
+        val output = objectFile.get()
+
+        providers.exec {
+            executable = "clang"
+            args(
+                "-B/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin",
+                "-fno-stack-protector",
+                "-target",
+                llvmTarget,
+                "-isysroot",
+                sysRoot,
+                "-fPIC",
+                "--compile",
+                "-I${include.get().asFile.absolutePath}",
+                inputFile.get().asFile.absolutePath,
+                "-DHAVE_GETHOSTUUID=0",
+                "-DSQLITE_ENABLE_DBSTAT_VTAB",
+                "-DSQLITE_ENABLE_FTS5",
+                "-DSQLITE_ENABLE_RTREE",
+                "-O3",
+                "-o",
+                output.asFile.toPath().name,
+            )
+
+            workingDir = output.asFile.parentFile
+        }.result.get()
+    }
+
+    companion object {
+        const val WATCHOS_SDK = "/Applications/Xcode.app/Contents/Developer/Platforms/WatchOS.platform/Developer/SDKs/WatchOS.sdk"
+        const val WATCHOS_SIMULATOR_SDK = "/Applications/Xcode.app/Contents/Developer/Platforms/WatchSimulator.platform/Developer/SDKs/WatchSimulator.sdk/"
+        const val IOS_SDK = "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk"
+        const val IOS_SIMULATOR_SDK = "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk"
+        const val MACOS_SDK = "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/"
+    }
+}

--- a/plugins/build-plugin/src/main/kotlin/com/powersync/compile/CreateSqliteCInterop.kt
+++ b/plugins/build-plugin/src/main/kotlin/com/powersync/compile/CreateSqliteCInterop.kt
@@ -1,0 +1,33 @@
+package com.powersync.compile
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
+
+@DisableCachingByDefault(because = "not worth caching")
+abstract class CreateSqliteCInterop: DefaultTask() {
+    @get:InputFile
+    abstract val archiveFile: RegularFileProperty
+
+    @get:OutputFile
+    abstract val definitionFile: RegularFileProperty
+
+    @TaskAction
+    fun run() {
+        val archive = archiveFile.get().asFile
+        val parent = archive.parentFile
+
+        definitionFile.get().asFile.writeText("""
+            package = com.powersync.sqlite3
+            
+            linkerOpts.linux_x64 = -lpthread -ldl
+            linkerOpts.macos_x64 = -lpthread -ldl
+            staticLibraries=${archive.name}
+            libraryPaths=${parent.relativeTo(project.layout.projectDirectory.asFile.canonicalFile)}
+            """.trimIndent(),
+        )
+    }
+}

--- a/plugins/build-plugin/src/main/kotlin/com/powersync/compile/CreateStaticLibrary.kt
+++ b/plugins/build-plugin/src/main/kotlin/com/powersync/compile/CreateStaticLibrary.kt
@@ -1,0 +1,37 @@
+package com.powersync.compile
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ProviderFactory
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import javax.inject.Inject
+
+@CacheableTask
+abstract class CreateStaticLibrary: DefaultTask() {
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val objects: ConfigurableFileCollection
+
+    @get:OutputFile
+    abstract val staticLibrary: RegularFileProperty
+
+    @get:Inject
+    abstract val providers: ProviderFactory
+
+    @TaskAction
+    fun run() {
+        providers.exec {
+            executable = "ar"
+            args("rc", staticLibrary.get().asFile.absolutePath)
+            for (file in objects.files) {
+                args(file.absolutePath)
+            }
+        }.result.get()
+    }
+}

--- a/plugins/build-plugin/src/main/kotlin/com/powersync/compile/UnzipSqlite.kt
+++ b/plugins/build-plugin/src/main/kotlin/com/powersync/compile/UnzipSqlite.kt
@@ -1,0 +1,23 @@
+package com.powersync.compile
+
+import org.gradle.api.file.Directory
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Copy
+import org.gradle.api.tasks.OutputDirectory
+
+/**
+ * A cacheable [Copy] task providing typed providers for the emitted [sqlite3C] and [sqlite3H]
+ * files, making them easier to access in other tasks.
+ */
+@CacheableTask
+abstract class UnzipSqlite: Copy() {
+    @get:OutputDirectory
+    abstract val destination: DirectoryProperty
+
+    fun intoDirectory(dir: Provider<Directory>) {
+        into(dir)
+        destination.set(dir)
+    }
+}

--- a/plugins/build-plugin/src/main/kotlin/com/powersync/compile/UnzipSqlite.kt
+++ b/plugins/build-plugin/src/main/kotlin/com/powersync/compile/UnzipSqlite.kt
@@ -2,21 +2,33 @@ package com.powersync.compile
 
 import org.gradle.api.file.Directory
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.FileTree
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.OutputDirectory
 
 /**
- * A cacheable [Copy] task providing typed providers for the emitted [sqlite3C] and [sqlite3H]
- * files, making them easier to access in other tasks.
+ * A cacheable [Copy] task providing a typed provider for the output directory.
  */
 @CacheableTask
 abstract class UnzipSqlite: Copy() {
     @get:OutputDirectory
     abstract val destination: DirectoryProperty
 
-    fun intoDirectory(dir: Provider<Directory>) {
+    fun unzipSqlite(src: FileTree, dir: Provider<Directory>) {
+        from(
+            src.matching {
+                include("*/sqlite3.*")
+                exclude {
+                    it.isDirectory
+                }
+                eachFile {
+                    this.path = this.name
+                }
+            },
+        )
+
         into(dir)
         destination.set(dir)
     }

--- a/static-sqlite-driver/build.gradle.kts
+++ b/static-sqlite-driver/build.gradle.kts
@@ -28,18 +28,13 @@ val downloadSQLiteSources by tasks.registering(Download::class) {
 }
 
 val unzipSQLiteSources by tasks.registering(UnzipSqlite::class) {
-    from(
-        zipTree(downloadSQLiteSources.map { it.outputs.files.singleFile }).matching {
-            include("*/sqlite3.*")
-            exclude {
-                it.isDirectory
-            }
-            eachFile {
-                this.path = this.name
-            }
-        },
+    val zip = downloadSQLiteSources.map { it.outputs.files.singleFile }
+    inputs.file(zip)
+
+    unzipSqlite(
+        src = zipTree(zip),
+        dir = layout.buildDirectory.dir("downloads/sqlite3")
     )
-    intoDirectory(layout.buildDirectory.dir("downloads/sqlite3"))
 }
 
 // Obtain host and platform manager from Kotlin multiplatform plugin. They're supposed to be

--- a/static-sqlite-driver/build.gradle.kts
+++ b/static-sqlite-driver/build.gradle.kts
@@ -1,14 +1,13 @@
+import com.powersync.compile.ClangCompile
+import com.powersync.compile.CreateSqliteCInterop
+import com.powersync.compile.CreateStaticLibrary
+import com.powersync.compile.UnzipSqlite
 import java.io.File
-import java.io.FileInputStream
 import com.powersync.plugins.sonatype.setupGithubRepository
 import com.powersync.plugins.utils.powersyncTargets
 import de.undercouch.gradle.tasks.download.Download
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
-import org.jetbrains.kotlin.gradle.utils.NativeCompilerDownloader
-import org.jetbrains.kotlin.konan.properties.Properties
 import org.jetbrains.kotlin.konan.target.HostManager
-import org.jetbrains.kotlin.konan.target.KonanTarget
-import org.jetbrains.kotlin.konan.target.PlatformManager
 
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
@@ -20,22 +19,17 @@ plugins {
 val sqliteVersion = "3490100"
 val sqliteReleaseYear = "2025"
 
-val downloads = layout.buildDirectory.dir("downloads")
-val sqliteSrcFolder = downloads.map { it.dir("sqlite3") }
-
 val downloadSQLiteSources by tasks.registering(Download::class) {
     val zipFileName = "sqlite-amalgamation-$sqliteVersion.zip"
     src("https://www.sqlite.org/$sqliteReleaseYear/$zipFileName")
-    dest(downloads.map { it.file(zipFileName) })
+    dest(layout.buildDirectory.dir("downloads").map { it.file(zipFileName) })
     onlyIfNewer(true)
     overwrite(false)
 }
 
-val unzipSQLiteSources by tasks.registering(Copy::class) {
-    dependsOn(downloadSQLiteSources)
-
+val unzipSQLiteSources by tasks.registering(UnzipSqlite::class) {
     from(
-        zipTree(downloadSQLiteSources.get().dest).matching {
+        zipTree(downloadSQLiteSources.map { it.outputs.files.singleFile }).matching {
             include("*/sqlite3.*")
             exclude {
                 it.isDirectory
@@ -45,7 +39,7 @@ val unzipSQLiteSources by tasks.registering(Copy::class) {
             }
         },
     )
-    into(sqliteSrcFolder)
+    intoDirectory(layout.buildDirectory.dir("downloads/sqlite3"))
 }
 
 // Obtain host and platform manager from Kotlin multiplatform plugin. They're supposed to be
@@ -53,99 +47,33 @@ val unzipSQLiteSources by tasks.registering(Copy::class) {
 // use to compile SQLite for the platforms we need.
 val hostManager = HostManager()
 
-fun compileSqlite(target: KotlinNativeTarget): TaskProvider<Task> {
+fun compileSqlite(target: KotlinNativeTarget): TaskProvider<CreateSqliteCInterop> {
     val name = target.targetName
     val outputDir = layout.buildDirectory.dir("c/$name")
 
-    val compileSqlite = tasks.register("${name}CompileSqlite") {
-        dependsOn(unzipSQLiteSources)
-        val targetDirectory = outputDir.get()
-        val sqliteSource = sqliteSrcFolder.map { it.file("sqlite3.c") }.get()
-        val output = targetDirectory.file("sqlite3.o")
+    val sqlite3Obj = outputDir.map { it.file("sqlite3.o") }
+    val archive = outputDir.map { it.file("libsqlite3.a") }
 
-        inputs.file(sqliteSource)
-        outputs.file(output)
+    val compileSqlite = tasks.register("${name}CompileSqlite", ClangCompile::class) {
+        inputs.dir(unzipSQLiteSources.map { it.destination })
 
-        doFirst {
-            targetDirectory.asFile.mkdirs()
-            output.asFile.delete()
-        }
-
-        doLast {
-            val (llvmTarget, sysRoot) = when (target.konanTarget) {
-                KonanTarget.IOS_X64 -> "x86_64-apple-ios12.0-simulator" to "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk"
-                KonanTarget.IOS_ARM64 -> "arm64-apple-ios12.0" to "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk"
-                KonanTarget.IOS_SIMULATOR_ARM64 -> "arm64-apple-ios14.0-simulator" to "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk"
-                KonanTarget.MACOS_ARM64 -> "aarch64-apple-macos" to "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/"
-                KonanTarget.MACOS_X64 -> "x86_64-apple-macos" to "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/"
-                else -> error("Unexpected target $target")
-            }
-
-            providers.exec {
-                executable = "clang"
-                args(
-                    "-B/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin",
-                    "-fno-stack-protector",
-                    "-target",
-                    llvmTarget,
-                    "-isysroot",
-                    sysRoot,
-                    "-fPIC",
-                    "--compile",
-                    "-I${sqliteSrcFolder.get().asFile.absolutePath}",
-                    sqliteSource.asFile.absolutePath,
-                    "-DHAVE_GETHOSTUUID=0",
-                    "-DSQLITE_ENABLE_DBSTAT_VTAB",
-                    "-DSQLITE_ENABLE_FTS5",
-                    "-DSQLITE_ENABLE_RTREE",
-                    "-O3",
-                    "-o",
-                    "sqlite3.o",
-                )
-
-                workingDir = targetDirectory.asFile
-            }.result.get()
-        }
+        inputFile.set(unzipSQLiteSources.flatMap { it.destination.file("sqlite3.c") })
+        konanTarget.set(target.konanTarget.name)
+        include.set(unzipSQLiteSources.flatMap { it.destination })
+        objectFile.set(sqlite3Obj)
     }
 
-    val createStaticLibrary = tasks.register("${name}ArchiveSqlite") {
-        dependsOn(compileSqlite)
-        val targetDirectory = outputDir.get()
-        inputs.file(targetDirectory.file("sqlite3.o"))
-        outputs.file(targetDirectory.file("libsqlite3.a"))
-
-        doLast {
-            providers.exec {
-                executable = "ar"
-                args("rc", "libsqlite3.a", "sqlite3.o")
-
-                workingDir = targetDirectory.asFile
-            }.result.get()
-        }
+    val createStaticLibrary = tasks.register("${name}ArchiveSqlite", CreateStaticLibrary::class) {
+        inputs.file(compileSqlite.map { it.objectFile })
+        objects.from(sqlite3Obj)
+        staticLibrary.set(archive)
     }
 
-    val buildCInteropDef = tasks.register("${name}CinteropSqlite") {
-        dependsOn(createStaticLibrary)
+    val buildCInteropDef = tasks.register("${name}CinteropSqlite", CreateSqliteCInterop::class) {
+        inputs.file(createStaticLibrary.map { it.staticLibrary })
 
-        val archive = createStaticLibrary.get().outputs.files.singleFile
-        inputs.file(archive)
-
-        val parent = archive.parentFile
-        val defFile = File(parent, "sqlite3.def")
-        outputs.file(defFile)
-
-        doFirst {
-            defFile.writeText(
-                """
-            package = com.powersync.sqlite3
-            
-            linkerOpts.linux_x64 = -lpthread -ldl
-            linkerOpts.macos_x64 = -lpthread -ldl
-            staticLibraries=${archive.name}
-            libraryPaths=${parent.relativeTo(project.layout.projectDirectory.asFile.canonicalFile)}
-            """.trimIndent(),
-            )
-        }
+        archiveFile.set(archive)
+        definitionFile.fileProvider(archive.map { File(it.asFile.parentFile, "sqlite3.def") })
     }
 
     return buildCInteropDef
@@ -180,10 +108,7 @@ kotlin {
 
             compilations.named("main") {
                 cinterops.create("sqlite3") {
-                    val cInteropTask = tasks[interopProcessingTaskName]
-                    cInteropTask.dependsOn(compileSqlite3)
-                    definitionFile = compileSqlite3.get().outputs.files.singleFile
-                    includeDirs(sqliteSrcFolder.get())
+                    definitionFile.set(compileSqlite3.flatMap { it.definitionFile })
                 }
             }
         }


### PR DESCRIPTION
On all native platforms we currently support, we compile and link a copy of SQLite statically (through the `:static-sqlite-driver` project).

The way the compilation is currently set up is a suboptimal, as it doesn't allow Gradle to cache outputs effectively:

1. We're using `dependsOn` to specify task dependencies, which is [not recommended](https://docs.gradle.org/current/userguide/best_practices_tasks.html#avoid_depends_on). We should specify file dependencies instead, as that allows Gradle to understand the dependencies better and allows for fine-grained build invalidation.
2. A lot of the compilation tasks we written using `Exec`, which does not support caching. To make the build easier to understand while also improving cache invalidation, I've extracted the tasks into independent files.

Finally, I've enabled the [build cache](https://docs.gradle.org/current/userguide/build_cache.html), which should allow us to cache outputs (including the compiled sqlite libraries) across CI runs, avoiding a recompilation on every run.