### PR TITLE
WIP: Try enabling configuration cache

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,12 +35,12 @@ jobs:
       - uses: actions/checkout@v4
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v1
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ~/.konan
           key: ${{ runner.os }}-${{ hashFiles('**/.lock') }}
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -49,6 +49,7 @@ jobs:
       - name: Gradle publish
         run: |
           ./gradlew \
+            --no-configuration-cache \
             -PGITHUB_PUBLISH_TOKEN="${{ secrets.GITHUB_TOKEN }}" \
             -PsigningInMemoryKey="${{ secrets.SIGNING_KEY }}" \
             -PsigningInMemoryKeyId="${{ secrets.SIGNING_KEY_ID }}" \
@@ -66,12 +67,12 @@ jobs:
       - uses: actions/checkout@v4
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v1
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ~/.konan
           key: ${{ runner.os }}-${{ hashFiles('**/.lock') }}
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/demos/supabase-todolist/gradle.properties
+++ b/demos/supabase-todolist/gradle.properties
@@ -2,6 +2,7 @@ kotlin.code.style=official
 xcodeproj=./iosApp
 android.useAndroidX=true
 org.gradle.caching=true
+org.gradle.configuration-cache=true
 org.gradle.jvmargs=-Xmx3g
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 org.jetbrains.compose.experimental.macos.enabled=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,7 @@ kotlin.code.style=official
 # Gradle
 org.gradle.jvmargs=-Xmx2048M -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options\="-Xmx2048M"
 org.gradle.caching=true
+org.gradle.configuration-cache=true
 # Compose
 org.jetbrains.compose.experimental.uikit.enabled=true
 # Android


### PR DESCRIPTION
Using the [configuration cache](https://docs.gradle.org/current/userguide/configuration_cache.html) can speed up builds by caching results of the configuration phase, which means that Gradle doesn't have to evaluate buildscripts multiple times.

An even bigger impact is that enabling this allows tasks in the same project to run in parallel, which is particularly helpful when working on the SDK: The steps to compile SQLite for `:static-sqlite-driver` are sped up a lot by running them in parallel (by default, we'd compile SQLite one ABI at a time).

I've heard that the configuration cache doesn't work too well with some publishing plugins, so I've disabled it for the publishing CI. Apart from that, this should hopefully speed up our builds. We could cache the results of the configuration cche between CI runs too by [setting a key to encrypt them](https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#saving-configuration-cache-data) with (it's not cached by default because the data may be sensitive). But I think the benefits of multi-threading alone could justify this and we don't necessarily need to worry about that.