### PR TITLE
Add unique constraint support for tables and automatic upserts in Supabase connector

### DIFF
--- a/connectors/supabase/src/commonMain/kotlin/com/powersync/connector/supabase/SupabaseConnectorExtensions.kt
+++ b/connectors/supabase/src/commonMain/kotlin/com/powersync/connector/supabase/SupabaseConnectorExtensions.kt
@@ -1,0 +1,69 @@
+package com.powersync.connector.supabase
+
+import com.powersync.PowerSyncDatabase
+import com.powersync.db.schema.Schema
+
+/**
+ * Extension function to configure a SupabaseConnector with a PowerSync database schema.
+ * This enables automatic conflict resolution for upsert operations based on unique constraints
+ * defined in the schema.
+ * 
+ * Example:
+ * ```
+ * val connector = SupabaseConnector(supabaseUrl, supabaseKey, powerSyncUrl)
+ * connector.configureWithDatabase(database)
+ * ```
+ */
+public fun SupabaseConnector.configureWithDatabase(database: PowerSyncDatabase) {
+    val schema = database.schema
+    this.setSchema(schema)
+}
+
+/**
+ * Create a SupabaseConnector with schema configuration.
+ * 
+ * Example:
+ * ```
+ * val schema = Schema(
+ *     Table(
+ *         name = "users",
+ *         columns = listOf(
+ *             Column.text("email"),
+ *             Column.text("username")
+ *         ),
+ *         indexes = listOf(
+ *             Index.unique("idx_email", "email")
+ *         )
+ *     )
+ * )
+ * 
+ * val connector = SupabaseConnector.withSchema(
+ *     supabaseUrl = "https://example.supabase.co",
+ *     supabaseKey = "your-key",
+ *     powerSyncEndpoint = "https://example.powersync.com",
+ *     schema = schema
+ * )
+ * ```
+ */
+public fun SupabaseConnector.Companion.withSchema(
+    supabaseUrl: String,
+    supabaseKey: String,
+    powerSyncEndpoint: String,
+    storageBucket: String? = null,
+    schema: Schema
+): SupabaseConnector {
+    val connector = SupabaseConnector(
+        supabaseUrl = supabaseUrl,
+        supabaseKey = supabaseKey,
+        powerSyncEndpoint = powerSyncEndpoint,
+        storageBucket = storageBucket
+    )
+    connector.setSchema(schema)
+    return connector
+}
+
+// Add companion object to SupabaseConnector for the extension function
+public val SupabaseConnector.Companion: SupabaseConnectorCompanion
+    get() = SupabaseConnectorCompanion
+
+public object SupabaseConnectorCompanion

--- a/core/src/commonMain/kotlin/com/powersync/db/crud/UpsertOptions.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/crud/UpsertOptions.kt
@@ -1,0 +1,30 @@
+package com.powersync.db.crud
+
+/**
+ * Options for configuring upsert behavior when handling conflicts.
+ * 
+ * @property onConflict Comma-separated column name(s) to specify how duplicate rows are determined.
+ *                      Two rows are duplicates if all the onConflict columns are equal.
+ *                      If null, the primary key is used.
+ * @property ignoreDuplicates If true, duplicate rows are ignored. If false, duplicate rows are merged with existing rows.
+ */
+public data class UpsertOptions(
+    val onConflict: String? = null,
+    val ignoreDuplicates: Boolean = false
+) {
+    public companion object {
+        /**
+         * Default upsert options that merge duplicates based on primary key.
+         */
+        public val DEFAULT: UpsertOptions = UpsertOptions()
+        
+        /**
+         * Create upsert options from a list of conflict columns.
+         */
+        public fun fromColumns(columns: List<String>, ignoreDuplicates: Boolean = false): UpsertOptions =
+            UpsertOptions(
+                onConflict = columns.joinToString(","),
+                ignoreDuplicates = ignoreDuplicates
+            )
+    }
+}

--- a/core/src/commonMain/kotlin/com/powersync/db/schema/SchemaExtensions.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/schema/SchemaExtensions.kt
@@ -1,0 +1,67 @@
+package com.powersync.db.schema
+
+/**
+ * Extension functions for working with schemas and unique constraints.
+ */
+
+/**
+ * Find a table by name in the schema.
+ */
+public fun Schema.getTable(name: String): Table? = tables.find { it.name == name }
+
+/**
+ * Get all tables that have at least one unique constraint.
+ */
+public fun Schema.getTablesWithUniqueConstraints(): List<Table> = 
+    tables.filter { table -> table.indexes.any { it.unique } }
+
+/**
+ * Check if a table has any unique constraints.
+ */
+public fun Table.hasUniqueConstraints(): Boolean = indexes.any { it.unique }
+
+/**
+ * Get all unique indexes for a table.
+ */
+public fun Table.getUniqueIndexes(): List<Index> = indexes.filter { it.unique }
+
+/**
+ * Create a table builder with a unique constraint.
+ * 
+ * Example:
+ * ```
+ * val userTable = Table(
+ *     name = "users",
+ *     columns = listOf(
+ *         Column.text("email"),
+ *         Column.text("username"),
+ *         Column.text("name")
+ *     ),
+ *     indexes = listOf(
+ *         Index.unique("idx_email", "email"),
+ *         Index.unique("idx_username", "username")
+ *     )
+ * )
+ * ```
+ */
+public fun Table.Companion.withUnique(
+    name: String,
+    columns: List<Column>,
+    uniqueColumns: List<String>,
+    additionalIndexes: List<Index> = emptyList()
+): Table {
+    val uniqueIndex = Index.unique("${name}_unique", uniqueColumns)
+    return Table(
+        name = name,
+        columns = columns,
+        indexes = listOf(uniqueIndex) + additionalIndexes
+    )
+}
+
+/**
+ * Check if a column participates in any unique constraint.
+ */
+public fun Table.isColumnUnique(columnName: String): Boolean =
+    indexes.any { index ->
+        index.unique && index.columns.any { it.column == columnName }
+    }

--- a/core/src/commonMain/kotlin/com/powersync/db/schema/Table.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/schema/Table.kt
@@ -216,6 +216,25 @@ public data class Table(
      */
     public val viewName: String
         get() = viewNameOverride ?: name
+    
+    /**
+     * Get all unique column names from unique indexes.
+     * This returns a list of all columns that participate in unique constraints.
+     */
+    public fun getUniqueColumns(): List<String> {
+        return indexes
+            .filter { it.unique }
+            .flatMap { index -> index.columns.map { it.column } }
+            .distinct()
+    }
+    
+    /**
+     * Get the first unique index if any exists.
+     * This is useful for determining conflict resolution columns for upsert operations.
+     */
+    public fun getFirstUniqueIndex(): Index? {
+        return indexes.firstOrNull { it.unique }
+    }
 }
 
 /**

--- a/core/src/commonMain/kotlin/com/powersync/db/schema/UniqueConstraintsExample.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/schema/UniqueConstraintsExample.kt
@@ -1,0 +1,66 @@
+package com.powersync.db.schema
+
+/**
+ * Example demonstrating how to define tables with unique constraints
+ * and use them with the Supabase connector for proper upsert behavior.
+ * 
+ * ```kotlin
+ * // Define a schema with unique constraints
+ * val schema = Schema(
+ *     Table(
+ *         name = "users",
+ *         columns = listOf(
+ *             Column.text("email"),
+ *             Column.text("username"),
+ *             Column.text("full_name"),
+ *             Column.integer("age")
+ *         ),
+ *         indexes = listOf(
+ *             // Single column unique constraint
+ *             Index.unique("idx_email", "email"),
+ *             // Another single column unique constraint
+ *             Index.unique("idx_username", "username"),
+ *             // Regular non-unique index for performance
+ *             Index.ascending("idx_age", listOf("age"))
+ *         )
+ *     ),
+ *     Table(
+ *         name = "products",
+ *         columns = listOf(
+ *             Column.text("sku"),
+ *             Column.text("name"),
+ *             Column.real("price"),
+ *             Column.text("category")
+ *         ),
+ *         indexes = listOf(
+ *             // Composite unique constraint on multiple columns
+ *             Index.unique("idx_sku_category", listOf("sku", "category"))
+ *         )
+ *     )
+ * )
+ * 
+ * // Initialize PowerSync database with the schema
+ * val database = PowerSyncDatabase(
+ *     schema = schema,
+ *     // ... other configuration
+ * )
+ * 
+ * // Configure Supabase connector with the schema
+ * val connector = SupabaseConnector(
+ *     supabaseUrl = "https://your-project.supabase.co",
+ *     supabaseKey = "your-anon-key",
+ *     powerSyncEndpoint = "https://your-instance.powersync.com"
+ * )
+ * connector.setSchema(schema)
+ * 
+ * // When the connector uploads data with PUT operations:
+ * // - For the "users" table, conflicts will be resolved on the "email" column
+ * //   (using the first unique index found)
+ * // - For the "products" table, conflicts will be resolved on "sku,category"
+ * // - Tables without unique constraints will use the default "id" column
+ * 
+ * // The Supabase connector automatically generates the appropriate
+ * // upsert query with onConflict parameter based on your schema
+ * ```
+ */
+internal object UniqueConstraintsExample


### PR DESCRIPTION
- Add `unique` property to Index class to define unique constraints
- Update Table class with methods to retrieve unique columns and indexes
- Create UpsertOptions data class for configuring upsert behavior
- Enhance SupabaseConnector to automatically handle upserts based on schema
  - Detects unique constraints from table schema
  - Sets appropriate onConflict columns for Supabase upsert operations
  - Falls back to primary key conflict resolution when no unique indexes exist
- Add extension functions and examples for working with unique constraints

This allows developers to define unique constraints in their PowerSync schema and have the Supabase connector automatically handle upserts with proper conflict resolution without manual configuration.

#196 