### PR TITLE
Prepare 1.1.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.1.1
+
+* Fix reported progress around compactions / defrags on the sync service.
+* [Android] Set `temp_store_directory`, avoiding crashes for large materialized views.
+
 ## 1.1.0
 
 * Add `trackPreviousValues` option on `Table` which sets `CrudEntry.previousValues` to previous values on updates.

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ development=true
 RELEASE_SIGNING_ENABLED=true
 # Library config
 GROUP=com.powersync
-LIBRARY_VERSION=1.1.0
+LIBRARY_VERSION=1.1.1
 GITHUB_REPO=https://github.com/powersync-ja/powersync-kotlin.git
 # POM
 POM_URL=https://github.com/powersync-ja/powersync-kotlin/


### PR DESCRIPTION
Raise the version to `1.1.1` and add changelog entries for changes since `1.1.0`.