### PR TITLE
Include version number in user agent, prepare release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.2.0 (pending)
+## 1.2.0
 
 * Add a new sync client implementation written in Rust instead of Kotlin. While this client is still
   experimental, we intend to make it the default in the future. The main benefit of this client is

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -6,7 +6,9 @@ import org.gradle.internal.os.OperatingSystem
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 import org.jetbrains.kotlin.gradle.targets.jvm.tasks.KotlinJvmTest
 import org.jetbrains.kotlin.gradle.tasks.KotlinTest
-
+import java.nio.file.Path
+import kotlin.io.path.createDirectories
+import kotlin.io.path.writeText
 
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
@@ -128,23 +130,24 @@ val moveJDBCJNIFiles by tasks.registering(Copy::class) {
 kotlin {
     powersyncTargets()
 
-    targets.withType<KotlinNativeTarget> {
-        compilations.named("main") {
-            compileTaskProvider {
-                compilerOptions.freeCompilerArgs.add("-Xexport-kdoc")
+    targets.configureEach {
+        compilations.configureEach {
+            compileTaskProvider.configure {
+                dependsOn(generateVersionConstant)
             }
         }
 
-        /*
-        If we ever need macOS support:
-        {
-            binaries.withType<TestExecutable>().configureEach {
-                linkTaskProvider.dependsOn(downloadPowersyncDesktopBinaries)
-                linkerOpts("-lpowersync")
-                linkerOpts("-L", binariesFolder.map { it.dir("powersync") }.get().asFile.path)
+        if (this is KotlinNativeTarget) {
+            compilations.named("main") {
+                compileTaskProvider.configure {
+                    compilerOptions.freeCompilerArgs.add("-Xexport-kdoc")
+                }
             }
         }
-         */
+    }
+
+    targets.withType<KotlinNativeTarget> {
+
     }
 
     explicitApi()
@@ -168,21 +171,27 @@ kotlin {
             }
         }
 
-        commonMain.dependencies {
-            implementation(libs.uuid)
-            implementation(libs.kotlin.stdlib)
-            implementation(libs.ktor.client.core)
-            implementation(libs.ktor.client.contentnegotiation)
-            implementation(libs.ktor.serialization.json)
-            implementation(libs.kotlinx.io)
-            implementation(libs.rsocket.core)
-            implementation(libs.rsocket.transport.websocket)
-            implementation(libs.kotlinx.coroutines.core)
-            implementation(libs.kotlinx.datetime)
-            implementation(libs.stately.concurrency)
-            implementation(libs.configuration.annotations)
-            api(projects.persistence)
-            api(libs.kermit)
+        commonMain.configure {
+            kotlin {
+                srcDir(layout.buildDirectory.dir("generated/constants"))
+            }
+
+            dependencies {
+                implementation(libs.uuid)
+                implementation(libs.kotlin.stdlib)
+                implementation(libs.ktor.client.core)
+                implementation(libs.ktor.client.contentnegotiation)
+                implementation(libs.ktor.serialization.json)
+                implementation(libs.kotlinx.io)
+                implementation(libs.rsocket.core)
+                implementation(libs.rsocket.transport.websocket)
+                implementation(libs.kotlinx.coroutines.core)
+                implementation(libs.kotlinx.datetime)
+                implementation(libs.stately.concurrency)
+                implementation(libs.configuration.annotations)
+                api(projects.persistence)
+                api(libs.kermit)
+            }
         }
 
         androidMain {
@@ -301,4 +310,30 @@ setupGithubRepository()
 
 dokka {
     moduleName.set("PowerSync Core")
+}
+
+val generateVersionConstant by tasks.registering {
+    val target = project.layout.buildDirectory.dir("generated/constants")
+    val packageName = "com.powersync.build"
+
+    outputs.dir(target)
+    val currentVersion = version.toString()
+
+    doLast {
+        val dir = target.get().asFile
+        dir.mkdir()
+        val rootPath = dir.toPath()
+
+        val source = """
+            package $packageName
+            
+            internal const val LIBRARY_VERSION: String = "$currentVersion"
+
+        """.trimIndent()
+
+        val packageRoot = packageName.split('.').fold(rootPath, Path::resolve)
+        packageRoot.createDirectories()
+
+        packageRoot.resolve("BuildConstants.kt").writeText(source)
+    }
 }

--- a/core/src/androidMain/kotlin/com/powersync/sync/UserAgent.android.kt
+++ b/core/src/androidMain/kotlin/com/powersync/sync/UserAgent.android.kt
@@ -1,5 +1,6 @@
 package com.powersync.sync
 
 import android.os.Build
+import com.powersync.build.LIBRARY_VERSION
 
-internal actual fun userAgent(): String = "PowerSync Kotlin SDK (Android ${Build.VERSION.SDK_INT})"
+internal actual fun userAgent(): String = "PowerSync Kotlin SDK v$LIBRARY_VERSION (Android ${Build.VERSION.SDK_INT})"

--- a/core/src/jvmMain/kotlin/com/powersync/sync/UserAgent.jvm.kt
+++ b/core/src/jvmMain/kotlin/com/powersync/sync/UserAgent.jvm.kt
@@ -1,9 +1,11 @@
 package com.powersync.sync
 
+import com.powersync.build.LIBRARY_VERSION
+
 internal actual fun userAgent(): String {
     val os = System.getProperty("os.name") ?: "unknown"
     val osVersion = System.getProperty("os.version") ?: ""
     val java = System.getProperty("java.vendor.version") ?: System.getProperty("java.runtime.version") ?: "unknown"
 
-    return "PowerSync Kotlin SDK (running Java $java on $os $osVersion)"
+    return "PowerSync Kotlin SDK v${LIBRARY_VERSION} (running Java $java on $os $osVersion)"
 }

--- a/core/src/nativeMain/kotlin/com/powersync/sync/UserAgent.native.kt
+++ b/core/src/nativeMain/kotlin/com/powersync/sync/UserAgent.native.kt
@@ -1,6 +1,7 @@
 package com.powersync.sync
 
+import com.powersync.build.LIBRARY_VERSION
 import kotlin.experimental.ExperimentalNativeApi
 
 @OptIn(ExperimentalNativeApi::class)
-internal actual fun userAgent(): String = "PowerSync Kotlin SDK (running on ${Platform.cpuArchitecture.name} ${Platform.osFamily.name})"
+internal actual fun userAgent(): String = "PowerSync Kotlin SDK v$LIBRARY_VERSION (running on ${Platform.cpuArchitecture.name} ${Platform.osFamily.name})"

--- a/core/src/nativeMain/kotlin/com/powersync/sync/UserAgent.native.kt
+++ b/core/src/nativeMain/kotlin/com/powersync/sync/UserAgent.native.kt
@@ -4,4 +4,5 @@ import com.powersync.build.LIBRARY_VERSION
 import kotlin.experimental.ExperimentalNativeApi
 
 @OptIn(ExperimentalNativeApi::class)
-internal actual fun userAgent(): String = "PowerSync Kotlin SDK v$LIBRARY_VERSION (running on ${Platform.cpuArchitecture.name} ${Platform.osFamily.name})"
+internal actual fun userAgent(): String =
+    "PowerSync Kotlin SDK v$LIBRARY_VERSION (running on ${Platform.cpuArchitecture.name} ${Platform.osFamily.name})"

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ development=true
 RELEASE_SIGNING_ENABLED=true
 # Library config
 GROUP=com.powersync
-LIBRARY_VERSION=1.1.1
+LIBRARY_VERSION=1.2.0
 GITHUB_REPO=https://github.com/powersync-ja/powersync-kotlin.git
 # POM
 POM_URL=https://github.com/powersync-ja/powersync-kotlin/


### PR DESCRIPTION
This adds a simple Gradle task generating a source set with a single file containing the version of the SDK. This is then imported when creating the user agent to always include the version.

Apart from that, this raises the version to 1.2.0 and prepares a release.