### PR TITLE
Update error handling to capture all 4xx responses

### DIFF
--- a/connectors/supabase/src/commonMain/kotlin/com/powersync/connector/supabase/SupabaseConnector.kt
+++ b/connectors/supabase/src/commonMain/kotlin/com/powersync/connector/supabase/SupabaseConnector.kt
@@ -93,7 +93,7 @@ public class SupabaseConnector(
         supabaseClient.httpClient.httpClient.plugin(HttpSend).intercept { request ->
             val resp = execute(request)
             val response = resp.response
-            if (response.status.value == 400) {
+            if (response.status.value >= 400) {
                 val responseText = response.bodyAsText()
 
                 try {


### PR DESCRIPTION
interceptor was only capturing error codes when the HTTP status was exactly 400, but RLS violations from Supabase were coming with a different HTTP status code. For example fatal error [INSUFFICIENT PRIVILEGE 42501](https://github.com/powersync-ja/powersync-kotlin/blob/main/connectors/supabase/src/commonMain/kotlin/com/powersync/connector/supabase/SupabaseConnector.kt#L50) was 403.

closes #204 