### PR TITLE
Prepare 1.2.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Changelog
 
-## 1.2.1 (pending release)
+## 1.2.1
 
 * [Supabase Connector] Fixed issue where only `400` HTTP status code errors where reported as connection errors. The connector now reports errors for codes `>=400`.
 * Update PowerSync core extension to `0.4.1`, fixing an issue with the new Rust client.
 * Rust sync client: Fix writes made while offline not being uploaded reliably.
+* Add watchOS support.
 
 ## 1.2.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ development=true
 RELEASE_SIGNING_ENABLED=true
 # Library config
 GROUP=com.powersync
-LIBRARY_VERSION=1.2.0
+LIBRARY_VERSION=1.2.1
 GITHUB_REPO=https://github.com/powersync-ja/powersync-kotlin.git
 # POM
 POM_URL=https://github.com/powersync-ja/powersync-kotlin/


### PR DESCRIPTION
This prepares version `1.2.1` of the Kotlin SDK for release. Changes include:

- A Supabase connector fix: https://github.com/powersync-ja/powersync-kotlin/pull/205
- Updating the core extension
- Adding watchOS support
