### PR TITLE
Rust client: Schedule crud uploads after connecting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [Supabase Connector] Fixed issue where only `400` HTTP status code errors where reported as connection errors. The connector now reports errors for codes `>=400`.
 * Update PowerSync core extension to `0.4.1`, fixing an issue with the new Rust client.
+* Rust sync client: Fix writes made while offline not being uploaded reliably.
 
 ## 1.2.0
 

--- a/core/src/commonIntegrationTest/kotlin/com/powersync/sync/SyncIntegrationTest.kt
+++ b/core/src/commonIntegrationTest/kotlin/com/powersync/sync/SyncIntegrationTest.kt
@@ -564,6 +564,53 @@ abstract class BaseSyncIntegrationTest(
         }
 
     @Test
+    fun `handles write made while offline`() = databaseTest {
+        connector = TestConnector()
+        val uploadCompleted = CompletableDeferred<Unit>()
+        checkpointResponse = {
+            uploadCompleted.complete(Unit)
+            WriteCheckpointResponse(WriteCheckpointData("1"))
+        }
+
+        database.execute("INSERT INTO users (id, name) VALUES (uuid(), ?)", listOf("local write"))
+        database.connect(connector, options = options)
+
+        turbineScope(timeout = 10.0.seconds) {
+            val turbine = database.currentStatus.asFlow().testIn(scope)
+            turbine.waitFor { it.connected }
+
+            val query = database.watch("SELECT name FROM users") { it.getString(0)!! }.testIn(scope)
+            query.awaitItem() shouldBe listOf("local write")
+
+            syncLines.send(SyncLine.FullCheckpoint(
+                Checkpoint(
+                    writeCheckpoint = "1",
+                    lastOpId = "1",
+                    checksums = listOf(BucketChecksum("a", checksum = 0)),
+                ),
+            ))
+            syncLines.send(SyncLine.SyncDataBucket(bucket = "a", data = listOf(
+                OplogEntry(
+                    checksum = 0,
+                    opId = "1",
+                    op = OpType.PUT,
+                    rowId = "1",
+                    rowType = "users",
+                    data = """{"id": "test1", "name": "from server"}""",
+                ),
+            ), after = null, nextAfter = null))
+
+            uploadCompleted.await()
+            syncLines.send(SyncLine.CheckpointComplete("1"))
+
+            query.awaitItem() shouldBe listOf("from server")
+
+            turbine.cancelAndIgnoreRemainingEvents()
+            query.cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun testTokenExpired() =
         databaseTest {
             turbineScope(timeout = 10.0.seconds) {


### PR DESCRIPTION
While a connection task is active, we listen for changes to `ps_crud` and use those to initialize a CRUD upload. With the old sync client, we also do this whenever we receive a `token_expires_in` line.

The Rust client was missing this functionality, causing it to miss local writes made while offline or disconnected. This could lead to local data accumulating and preventing subsequent checkpoints to be applied.