### PR TITLE
Refactor fetching credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Support tables created outside of PowerSync with the `RawTable` API.
   For more information, see [the documentation](https://docs.powersync.com/usage/use-case-examples/raw-tables).
 * Fix `runWrapped` catching cancellation exceptions.
+* Fix errors in `PowerSyncBackendConnector.fetchCredentials()` crashing Android apps.
 
 ## 1.2.2
 

--- a/core/src/commonIntegrationTest/kotlin/com/powersync/sync/SyncIntegrationTest.kt
+++ b/core/src/commonIntegrationTest/kotlin/com/powersync/sync/SyncIntegrationTest.kt
@@ -667,10 +667,7 @@ abstract class BaseSyncIntegrationTest(
                             fail("Expected exception from fetchCredentials")
                         }
 
-                        return PowerSyncCredentials(
-                            token = "test-token",
-                            endpoint = "https://test.com",
-                        )
+                        return TestConnector.testCredentials
                     }
 
                     override suspend fun uploadData(database: PowerSyncDatabase) {
@@ -716,10 +713,7 @@ class NewSyncIntegrationTest : BaseSyncIntegrationTest(true) {
                             completePrefetch.await()
                         }
 
-                        return PowerSyncCredentials(
-                            token = "test-token",
-                            endpoint = "https://test.com",
-                        )
+                        return TestConnector.testCredentials
                     }
 
                     override suspend fun uploadData(database: PowerSyncDatabase) {}

--- a/core/src/commonIntegrationTest/kotlin/com/powersync/testutils/TestUtils.kt
+++ b/core/src/commonIntegrationTest/kotlin/com/powersync/testutils/TestUtils.kt
@@ -9,19 +9,15 @@ import co.touchlab.kermit.Severity
 import co.touchlab.kermit.TestConfig
 import co.touchlab.kermit.TestLogWriter
 import com.powersync.DatabaseDriverFactory
+import com.powersync.TestConnector
 import com.powersync.bucket.WriteCheckpointData
 import com.powersync.bucket.WriteCheckpointResponse
-import com.powersync.connectors.PowerSyncBackendConnector
-import com.powersync.connectors.PowerSyncCredentials
 import com.powersync.createPowerSyncDatabaseImpl
 import com.powersync.db.PowerSyncDatabaseImpl
 import com.powersync.db.schema.Schema
 import com.powersync.sync.LegacySyncImplementation
 import com.powersync.sync.SyncLine
 import com.powersync.utils.JsonUtil
-import dev.mokkery.answering.returns
-import dev.mokkery.everySuspend
-import dev.mokkery.mock
 import io.ktor.client.HttpClient
 import io.ktor.client.HttpClientConfig
 import io.ktor.client.engine.mock.toByteArray
@@ -103,16 +99,7 @@ internal class ActiveDatabaseTest(
         "db-$suffix"
     }
 
-    var connector =
-        mock<PowerSyncBackendConnector> {
-            everySuspend { getCredentialsCached() } returns
-                PowerSyncCredentials(
-                    token = "test-token",
-                    endpoint = "https://test.com",
-                )
-
-            everySuspend { invalidateCredentials() } returns Unit
-        }
+    var connector = TestConnector()
 
     fun openDatabase(schema: Schema = Schema(UserRow.table)): PowerSyncDatabaseImpl {
         logger.d { "Opening database $databaseName in directory $testDirectory" }

--- a/core/src/commonMain/kotlin/com/powersync/connectors/PowerSyncBackendConnector.kt
+++ b/core/src/commonMain/kotlin/com/powersync/connectors/PowerSyncBackendConnector.kt
@@ -72,8 +72,8 @@ public abstract class PowerSyncBackendConnector {
      * This may be called before the current credentials have expired.
      */
     @Deprecated(
-        "Bring your own CoroutineScope to launch refetchCredentials",
-        replaceWith = ReplaceWith("refetchCredentials"),
+        "Bring your own CoroutineScope to launch updateCredentials",
+        replaceWith = ReplaceWith("updateCredentials"),
     )
     public open fun prefetchCredentials(): Job {
         fetchRequest?.takeIf { it.isActive }?.let { return it }

--- a/core/src/commonMain/kotlin/com/powersync/connectors/PowerSyncBackendConnector.kt
+++ b/core/src/commonMain/kotlin/com/powersync/connectors/PowerSyncBackendConnector.kt
@@ -72,7 +72,7 @@ public abstract class PowerSyncBackendConnector {
      * This may be called before the current credentials have expired.
      */
     @Deprecated(
-        "Bring your own CoroutineScope to launch updateCredentials",
+        "Call updateCredentials, bring your own CoroutineScope if you need it to be asynchronous",
         replaceWith = ReplaceWith("updateCredentials"),
     )
     public open fun prefetchCredentials(): Job {
@@ -94,7 +94,7 @@ public abstract class PowerSyncBackendConnector {
      * This is used by the sync client if a token is about to expire: By fetching a new token early,
      * we can avoid interruptions in the sync process.
      */
-    internal suspend fun updateCredentials() {
+    public suspend fun updateCredentials() {
         if (fetchingCredentials.tryLock()) {
             try {
                 fetchAndCacheCredentials()

--- a/core/src/commonMain/kotlin/com/powersync/connectors/PowerSyncBackendConnector.kt
+++ b/core/src/commonMain/kotlin/com/powersync/connectors/PowerSyncBackendConnector.kt
@@ -8,6 +8,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlin.coroutines.cancellation.CancellationException
 
 /**
@@ -19,9 +21,16 @@ import kotlin.coroutines.cancellation.CancellationException
  *
  */
 public abstract class PowerSyncBackendConnector {
-    private var cachedCredentials: PowerSyncCredentials? = null
+    internal var cachedCredentials: PowerSyncCredentials? = null
+    private var fetchingCredentials = Mutex()
+
     private var fetchRequest: Job? = null
     private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+
+    private suspend fun fetchAndCacheCredentials(): PowerSyncCredentials? =
+        fetchCredentials().also {
+            cachedCredentials = it
+        }
 
     /**
      * Get credentials current cached, or fetch new credentials if none are
@@ -33,8 +42,15 @@ public abstract class PowerSyncBackendConnector {
     public open suspend fun getCredentialsCached(): PowerSyncCredentials? {
         return runWrapped {
             cachedCredentials?.let { return@runWrapped it }
-            prefetchCredentials().join()
-            cachedCredentials
+
+            return fetchingCredentials.withLock {
+                // With concurrent calls, it's possible that credentials have just been fetched.
+                cachedCredentials?.let { return it }
+
+                val credentials = fetchAndCacheCredentials()
+                check(credentials === cachedCredentials)
+                credentials
+            }
         }
     }
 
@@ -55,20 +71,37 @@ public abstract class PowerSyncBackendConnector {
      *
      * This may be called before the current credentials have expired.
      */
-    @Throws(PowerSyncException::class, CancellationException::class)
+    @Deprecated(
+        "Bring your own CoroutineScope to launch refetchCredentials",
+        replaceWith = ReplaceWith("refetchCredentials"),
+    )
     public open fun prefetchCredentials(): Job {
         fetchRequest?.takeIf { it.isActive }?.let { return it }
 
         val request =
             scope.launch {
-                fetchCredentials().also { value ->
-                    cachedCredentials = value
-                    fetchRequest = null
-                }
+                fetchAndCacheCredentials().also { fetchRequest = null }
             }
 
         fetchRequest = request
         return request
+    }
+
+    /**
+     * If no other task is currently fetching credentials, calls [fetchCredentials] again and caches
+     * the result internally.
+     *
+     * This is used by the sync client if a token is about to expire: By fetching a new token early,
+     * we can avoid interruptions in the sync process.
+     */
+    internal suspend fun updateCredentials() {
+        if (fetchingCredentials.tryLock()) {
+            try {
+                fetchAndCacheCredentials()
+            } finally {
+                fetchingCredentials.unlock()
+            }
+        }
     }
 
     /**

--- a/core/src/commonMain/kotlin/com/powersync/sync/SyncStream.kt
+++ b/core/src/commonMain/kotlin/com/powersync/sync/SyncStream.kt
@@ -400,7 +400,7 @@ internal class SyncStream(
                         if (credentialsInvalidation == null) {
                             val job =
                                 scope.launch {
-                                    connector.prefetchCredentials().join()
+                                    connector.updateCredentials()
                                     logger.v { "Stopping because new credentials are available" }
 
                                     // Token has been refreshed, start another iteration

--- a/core/src/commonTest/kotlin/com/powersync/TestConnector.kt
+++ b/core/src/commonTest/kotlin/com/powersync/TestConnector.kt
@@ -5,10 +5,7 @@ import com.powersync.connectors.PowerSyncCredentials
 
 class TestConnector : PowerSyncBackendConnector() {
     var fetchCredentialsCallback: suspend () -> PowerSyncCredentials? = {
-        PowerSyncCredentials(
-            token = "test-token",
-            endpoint = "https://test.com",
-        )
+        testCredentials
     }
     var uploadDataCallback: suspend (PowerSyncDatabase) -> Unit = {
         val tx = it.getNextCrudTransaction()
@@ -19,5 +16,13 @@ class TestConnector : PowerSyncBackendConnector() {
 
     override suspend fun uploadData(database: PowerSyncDatabase) {
         uploadDataCallback(database)
+    }
+
+    companion object {
+        val testCredentials =
+            PowerSyncCredentials(
+                token = "test-token",
+                endpoint = "https://powersynctest.example.com",
+            )
     }
 }


### PR DESCRIPTION
In the `PowerSyncBackendConnector` implementation, errors thrown in `fetchCredentials()` are currently swallowed silently, because:

1. We use a supervisor scope to launch jobs fetching credentials.
2. We then call `join()` on a `Job` instead of using a `Deferrable` and `await()`. `join()` just waits for the job to finish and, for supervisor scopes, doesn't rethrow exceptions.
3. So, `getCredentialsCached()` would silently return `null` on errors, without this information being surfaced to the user.

On Android, it also looks like errors in root coroutines that aren't handled will unconditionally kill the app, regardless of the supervisor scope present (I can reproduce https://github.com/powersync-ja/powersync-kotlin/issues/219 by simply throwing in a connector's `fetchCredentials` on Android).

This PR refactors the implementation to avoid a global coroutine scope. This scope, with a `Job` to fetch credentials essentially had two purposes: First, to avoid fetching credentials concurrently (we want to re-use results instead), and second to implement prefetching credentials asynchronously.
For the first requirement, using a proper mutex is both easier and safer. For the second requirement, it's much better to let callers bring their own `CoroutineScope` that will properly forward errors. We are indeed already using `scope.launch` for the Rust client (the only place prefetching credentials) - so the internal async management can just be removed. This ensures errors in `fetchCredentials` bubble up all the way to the `try/catch` in the sync client which will retry after a delay.

Introducing a final method makes `PowerSyncBackendConnector` impossible to mock, so I've migrated tests to use the `TestConnector` based on callbacks instead.

Closes https://github.com/powersync-ja/powersync-kotlin/issues/219.