### PR TITLE
Fix documentation build

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -2,7 +2,9 @@ name: Deploy Docs
 
 on:
   push:
-    branches: [ 'main' ]
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
 
 permissions:
   contents: read
@@ -14,9 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v1
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ~/.konan
           key: ${{ runner.os }}-${{ hashFiles('**/.lock') }}
@@ -27,6 +27,8 @@ jobs:
           distribution: 'temurin'
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          validate-wrappers: true
       - name: Build Docs
         run: |
           ./gradlew \
@@ -42,6 +44,7 @@ jobs:
 
   # Deployment job
   deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
This fixes the documentation build, and adds a CI step to run the building part of the docs on each PR (while still only deploying for `main`).