### PR TITLE
Enable build scans

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -31,7 +31,7 @@ jobs:
           validate-wrappers: true
       - name: Build Docs
         run: |
-          ./gradlew \
+          ./gradlew --scan \
             --no-configuration-cache \
            -PGITHUB_PUBLISH_TOKEN=${{ secrets.GITHUB_TOKEN }} \
           dokkaGenerate

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
 
     - name: Build and run tests with Gradle
       run: |
-        ./gradlew \
+        ./gradlew --scan \
           ${{ matrix.targets }}
       shell: bash
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -75,6 +75,22 @@ dokka {
     moduleName.set("PowerSync Kotlin")
 }
 
+develocity {
+    val isPowerSyncCI = System.getenv("GITHUB_REPOSITORY") == "powersync-ja/powersync-kotlin"
+
+    buildScan {
+        // We can't know if everyone running this build has accepted the TOS, but we've accepted
+        // them for our CI.
+        if (isPowerSyncCI) {
+            termsOfUseUrl.set("https://gradle.com/help/legal-terms-of-use")
+            termsOfUseAgree.set("yes")
+        }
+
+        // Only upload build scan if the --scan parameter is set
+        publishing.onlyIf { false }
+    }
+}
+
 // Serve the generated Dokka documentation using a simple HTTP server
 // File changes are not watched here
 tasks.register("serveDokka") {

--- a/core/src/commonIntegrationTest/kotlin/com/powersync/sync/SyncIntegrationTest.kt
+++ b/core/src/commonIntegrationTest/kotlin/com/powersync/sync/SyncIntegrationTest.kt
@@ -411,8 +411,8 @@ abstract class BaseSyncIntegrationTest(
                 db2.disconnect()
                 turbine2.waitFor { !it.connecting }
 
-                turbine1.cancel()
-                turbine2.cancel()
+                turbine1.cancelAndIgnoreRemainingEvents()
+                turbine2.cancelAndIgnoreRemainingEvents()
             }
         }
 
@@ -433,7 +433,7 @@ abstract class BaseSyncIntegrationTest(
                 database.disconnect()
                 turbine.waitFor { !it.connecting }
 
-                turbine.cancel()
+                turbine.cancelAndIgnoreRemainingEvents()
             }
         }
 
@@ -449,7 +449,7 @@ abstract class BaseSyncIntegrationTest(
                 database.connect(connector, 1000L, retryDelayMs = 5000, options = options)
                 turbine.waitFor { it.connecting }
 
-                turbine.cancel()
+                turbine.cancelAndIgnoreRemainingEvents()
             }
         }
 
@@ -650,7 +650,7 @@ abstract class BaseSyncIntegrationTest(
                 turbine.waitFor { !it.connected }
                 connector.cachedCredentials shouldBe null
 
-                turbine.cancel()
+                turbine.cancelAndIgnoreRemainingEvents()
             }
         }
 
@@ -686,7 +686,7 @@ abstract class BaseSyncIntegrationTest(
                 // Should retry, and the second fetchCredentials call will work
                 turbine.waitFor { it.connected }
 
-                turbine.cancel()
+                turbine.cancelAndIgnoreRemainingEvents()
             }
         }
 }
@@ -740,7 +740,7 @@ class NewSyncIntegrationTest : BaseSyncIntegrationTest(true) {
 
                 turbine.waitFor { it.connected }
                 fetchCredentialsCount shouldBe 2
-                turbine.cancel()
+                turbine.cancelAndIgnoreRemainingEvents()
             }
         }
 

--- a/core/src/commonIntegrationTest/kotlin/com/powersync/testutils/TestUtils.kt
+++ b/core/src/commonIntegrationTest/kotlin/com/powersync/testutils/TestUtils.kt
@@ -7,7 +7,6 @@ import co.touchlab.kermit.LogWriter
 import co.touchlab.kermit.Logger
 import co.touchlab.kermit.Severity
 import co.touchlab.kermit.TestConfig
-import co.touchlab.kermit.TestLogWriter
 import com.powersync.DatabaseDriverFactory
 import com.powersync.PowerSyncTestLogWriter
 import com.powersync.TestConnector

--- a/core/src/commonIntegrationTest/kotlin/com/powersync/testutils/TestUtils.kt
+++ b/core/src/commonIntegrationTest/kotlin/com/powersync/testutils/TestUtils.kt
@@ -9,6 +9,7 @@ import co.touchlab.kermit.Severity
 import co.touchlab.kermit.TestConfig
 import co.touchlab.kermit.TestLogWriter
 import com.powersync.DatabaseDriverFactory
+import com.powersync.PowerSyncTestLogWriter
 import com.powersync.TestConnector
 import com.powersync.bucket.WriteCheckpointData
 import com.powersync.bucket.WriteCheckpointResponse
@@ -73,8 +74,8 @@ internal class ActiveDatabaseTest(
     lateinit var database: PowerSyncDatabaseImpl
 
     val logWriter =
-        TestLogWriter(
-            loggable = Severity.Debug,
+        PowerSyncTestLogWriter(
+            loggable = Severity.Verbose,
         )
     val logger =
         Logger(

--- a/core/src/commonMain/kotlin/com/powersync/sync/SyncStream.kt
+++ b/core/src/commonMain/kotlin/com/powersync/sync/SyncStream.kt
@@ -36,6 +36,7 @@ import io.ktor.utils.io.ByteReadChannel
 import io.ktor.utils.io.readUTF8Line
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
@@ -122,7 +123,7 @@ internal class SyncStream(
     }
 
     fun triggerCrudUploadAsync(): Job =
-        uploadScope.launch {
+        uploadScope.launch(CoroutineName("triggerCrudUploadAsync")) {
             val thisIteration = PendingCrudUpload(CompletableDeferred())
             var holdingUploadLock = false
 

--- a/core/src/commonTest/kotlin/com/powersync/PowerSyncTestLogWriter.kt
+++ b/core/src/commonTest/kotlin/com/powersync/PowerSyncTestLogWriter.kt
@@ -12,18 +12,26 @@ import kotlinx.atomicfu.locks.withLock
  * for concurrent access.
 */
 @OptIn(ExperimentalKermitApi::class)
-class PowerSyncTestLogWriter(private val loggable: Severity) : LogWriter() {
+class PowerSyncTestLogWriter(
+    private val loggable: Severity,
+) : LogWriter() {
     private val lock = reentrantLock()
     private val _logs = mutableListOf<LogEntry>()
 
     val logs: List<LogEntry>
         get() = lock.withLock { _logs.toList() }
 
-    override fun isLoggable(tag: String, severity: Severity): Boolean {
-        return severity.ordinal >= loggable.ordinal
-    }
+    override fun isLoggable(
+        tag: String,
+        severity: Severity,
+    ): Boolean = severity.ordinal >= loggable.ordinal
 
-    override fun log(severity: Severity, message: String, tag: String, throwable: Throwable?) {
+    override fun log(
+        severity: Severity,
+        message: String,
+        tag: String,
+        throwable: Throwable?,
+    ) {
         lock.withLock {
             _logs.add(LogEntry(severity, message, tag, throwable))
         }

--- a/core/src/commonTest/kotlin/com/powersync/PowerSyncTestLogWriter.kt
+++ b/core/src/commonTest/kotlin/com/powersync/PowerSyncTestLogWriter.kt
@@ -1,0 +1,31 @@
+package com.powersync
+
+import co.touchlab.kermit.ExperimentalKermitApi
+import co.touchlab.kermit.LogWriter
+import co.touchlab.kermit.Severity
+import co.touchlab.kermit.TestLogWriter.LogEntry
+import kotlinx.atomicfu.locks.reentrantLock
+import kotlinx.atomicfu.locks.withLock
+
+/**
+ * A version of the `TestLogWriter` from Kermit that uses a mutex around logs instead of throwing
+ * for concurrent access.
+*/
+@OptIn(ExperimentalKermitApi::class)
+class PowerSyncTestLogWriter(private val loggable: Severity) : LogWriter() {
+    private val lock = reentrantLock()
+    private val _logs = mutableListOf<LogEntry>()
+
+    val logs: List<LogEntry>
+        get() = lock.withLock { _logs.toList() }
+
+    override fun isLoggable(tag: String, severity: Severity): Boolean {
+        return severity.ordinal >= loggable.ordinal
+    }
+
+    override fun log(severity: Severity, message: String, tag: String, throwable: Throwable?) {
+        lock.withLock {
+            _logs.add(LogEntry(severity, message, tag, throwable))
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,6 +15,10 @@ dependencyResolutionManagement {
     }
 }
 
+plugins {
+    id("com.gradle.develocity") version "4.1"
+}
+
 rootProject.name = "powersync-root"
 
 include(":core")


### PR DESCRIPTION
This applies the develocity plugin (which isn't required to run Gradle build scans, but necessary to declare our acceptance of the build scan terms of service in code). Build scans are disabled by default, so a `--scan` invocation on the command line is necessary to upload them.

Then, this configures the docs and testing steps to create and upload scans, which the Gradle GH action helpfully [links under "build outcome"](https://github.com/powersync-ja/powersync-kotlin/actions/runs/16345689744).
