### PR TITLE
Dokka: Link to source

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,18 @@
 
 # PowerSync Kotlin Multiplatform SDK
 
-This is the PowerSync client SDK for Kotlin Mutliplatform. This SDK currently supports Android and iOS as targets.
+This is the PowerSync client SDK for Kotlin. This SDK currently supports the following Kotlin targets:
 
-See a summary of features [here](https://docs.powersync.com/client-sdk-references/kotlin-multiplatform#sdk-features).
+- Android
+- JVM
+- iOS
+- macOS
+- watchOS
+
+If you need support for additional targets, please reach out!
+
+See a summary of features [here](https://docs.powersync.com/client-sdk-references/kotlin-multiplatform#sdk-features)
+and API documentation [here](https://powersync-ja.github.io/powersync-kotlin/).
 
 ## Structure: Packages
 

--- a/plugins/build-plugin/src/main/kotlin/dokka-convention.gradle.kts
+++ b/plugins/build-plugin/src/main/kotlin/dokka-convention.gradle.kts
@@ -4,6 +4,11 @@ plugins {
 
 // Shared Dokka config for additional assets
 dokka {
+    val commit = providers.exec {
+        executable = "git"
+        args("rev-parse", "HEAD")
+    }.standardOutput.asText
+
     pluginsConfiguration.html {
         val docsAssetsDir = rootProject.file("docs/assets")
 
@@ -17,5 +22,15 @@ dokka {
         customAssets.from(docsAssetsDir.resolve("linkedin.svg"))
         customStyleSheets.from(docsAssetsDir.resolve("doc-styles.css"))
         templatesDir = file(docsAssetsDir.resolve("dokka-templates"))
+    }
+
+    dokkaSourceSets.configureEach {
+        sourceLink {
+            localDirectory.set(project.rootDir)
+            remoteUrl.set(commit.map { commit ->
+                uri("https://github.com/powersync-ja/powersync-kotlin/tree/${commit.trim()}/")
+            })
+            remoteLineSuffix.set("#L")
+        }
     }
 }


### PR DESCRIPTION
This configures Dokka to add a source link for each documented member, which is very convenient to check out the implementation for those cases where the documentation alone doesn't provide enough information.

This also updates the readme to update supported targets and to link to the generated API docs more prominently.