### PR TITLE
Set timeout for CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,7 @@ jobs:
           - os: windows-latest
             targets: jvmTest
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
The tests tasks are supposed to take a few minutes at most (macOS is the longest one and takes around 8 minutes). Recently, I've noticed that some test jobs seemingly run forever though. I think this can't really be an issue on our end since even individual tests are supposed to have timeouts on them, but I couldn't figure out a root cause yet (I hope it's not the build scan 🙃).

When we run into this issue, it's better to fail the run after 15 minutes instead of consuming resources for 6 hours.