### PR TITLE
Typed crud values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 * Added the ability to log PowerSync service HTTP request information via specifying a
   `SyncClientConfiguration` in the `SyncOptions.clientConfiguration` parameter used in
   `PowerSyncDatabase.connect()` calls.
-* `CrudEntry`: Add `data` and `typedPreviousValues` fields as typed variants of
-  `opData` and `previousValues`, respectively.
+* `CrudEntry`: Introduce `SqliteRow` interface for `opData` and `previousValues`, providing typed
+  access to the underlying values.
 
 ## 1.3.1
 

--- a/connectors/supabase/src/commonMain/kotlin/com/powersync/connector/supabase/SupabaseConnector.kt
+++ b/connectors/supabase/src/commonMain/kotlin/com/powersync/connector/supabase/SupabaseConnector.kt
@@ -26,6 +26,7 @@ import io.ktor.client.statement.bodyAsText
 import io.ktor.utils.io.InternalAPI
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonPrimitive
 
 /**
  * Get a Supabase token to authenticate against the PowerSync instance.
@@ -190,19 +191,20 @@ public class SupabaseConnector(
 
                     when (entry.op) {
                         UpdateType.PUT -> {
-                            val data = entry.opData?.toMutableMap() ?: mutableMapOf()
-                            data["id"] = entry.id
+                            val data =
+                                buildMap {
+                                    put("id", JsonPrimitive(entry.id))
+                                    entry.opData?.jsonValues?.let { putAll(it) }
+                                }
                             table.upsert(data)
                         }
-
                         UpdateType.PATCH -> {
-                            table.update(entry.opData!!) {
+                            table.update(entry.opData!!.jsonValues) {
                                 filter {
                                     eq("id", entry.id)
                                 }
                             }
                         }
-
                         UpdateType.DELETE -> {
                             table.delete {
                                 filter {

--- a/core/src/commonIntegrationTest/kotlin/com/powersync/CrudTest.kt
+++ b/core/src/commonIntegrationTest/kotlin/com/powersync/CrudTest.kt
@@ -126,20 +126,20 @@ class CrudTest {
             }
 
             var batch = database.getNextCrudTransaction()!!
-            batch.crud[0].data shouldBe
+            batch.crud[0].opData?.typed shouldBe
                 mapOf(
                     "a" to "text",
                     "b" to 42,
                     "c" to 13.37,
                 )
-            batch.crud[0].typedPreviousValues shouldBe null
+            batch.crud[0].previousValues shouldBe null
 
-            batch.crud[1].data shouldBe
+            batch.crud[1].opData?.typed shouldBe
                 mapOf(
                     "a" to "te\"xt",
                     "b" to null,
                 )
-            batch.crud[1].typedPreviousValues shouldBe
+            batch.crud[1].previousValues?.typed shouldBe
                 mapOf(
                     "a" to "text",
                     "b" to 42,
@@ -152,7 +152,7 @@ class CrudTest {
             )
 
             batch = database.getNextCrudTransaction()!!
-            batch.crud[0].data shouldBe
+            batch.crud[0].opData?.typed shouldBe
                 mapOf(
                     "a" to "42", // Not an integer!
                 )

--- a/core/src/commonMain/kotlin/com/powersync/db/crud/CrudEntry.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/crud/CrudEntry.kt
@@ -1,9 +1,8 @@
 package com.powersync.db.crud
 
+import com.powersync.PowerSyncDatabase
 import com.powersync.db.schema.Table
 import com.powersync.utils.JsonUtil
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 
@@ -58,75 +57,29 @@ public data class CrudEntry internal constructor(
      *
      * For DELETE, this is null.
      */
-    @Deprecated("Use data instead", replaceWith = ReplaceWith("data"))
-    val opData: Map<String, String?>?,
-    /**
-     * Data associated with the change.
-     *
-     * For PUT, this is contains all non-null columns of the row.
-     *
-     * For PATCH, this is contains the columns that changed.
-     *
-     * For DELETE, this is null.
-     */
-    val data: Map<String, Any?>?,
+    val opData: SqliteRow?,
     /**
      * Previous values before this change.
      *
      * These values can be tracked for `UPDATE` statements when [Table.trackPreviousValues] is
      * enabled.
      */
-    @Deprecated("Use typedPreviousValues instead", replaceWith = ReplaceWith("typedPreviousValues"))
-    val previousValues: Map<String, String?>? = null,
-    /**
-     * Previous values before this change.
-     *
-     * These values can be tracked for `UPDATE` statements when [Table.trackPreviousValues] is
-     * enabled.
-     */
-    val typedPreviousValues: Map<String, Any?>? = null,
+    val previousValues: SqliteRow? = null,
 ) {
     public companion object {
         public fun fromRow(row: CrudRow): CrudEntry {
             val data = JsonUtil.json.parseToJsonElement(row.data).jsonObject
-            val opData = data["data"]?.asData()
-            val previousValues = data["old"]?.asData()
-
             return CrudEntry(
                 id = data["id"]!!.jsonPrimitive.content,
                 clientId = row.id.toInt(),
                 op = UpdateType.fromJsonChecked(data["op"]!!.jsonPrimitive.content),
-                opData = opData?.toStringMap(),
-                data = opData,
+                opData = data["data"]?.let { SerializedRow(it.jsonObject) },
                 table = data["type"]!!.jsonPrimitive.content,
                 transactionId = row.txId,
                 metadata = data["metadata"]?.jsonPrimitive?.content,
-                typedPreviousValues = previousValues,
-                previousValues = previousValues?.toStringMap(),
+                previousValues = data["old"]?.let { SerializedRow(it.jsonObject) },
             )
         }
-
-        private fun JsonElement.asData(): Map<String, Any?> =
-            jsonObject.mapValues { (_, value) ->
-                val primitive = value.jsonPrimitive
-                if (primitive === JsonNull) {
-                    null
-                } else if (primitive.isString) {
-                    primitive.content
-                } else {
-                    primitive.content.jsonNumberOrBoolean()
-                }
-            }
-
-        private fun String.jsonNumberOrBoolean(): Any =
-            when {
-                this == "true" -> true
-                this == "false" -> false
-                this.any { char -> char == '.' || char == 'e' || char == 'E' } -> this.toDouble()
-                else -> this.toInt()
-            }
-
-        private fun Map<String, Any?>.toStringMap(): Map<String, String> = mapValues { (_, v) -> v.toString() }
     }
 
     override fun toString(): String = "CrudEntry<$transactionId/$clientId ${op.toJson()} $table/$id $opData>"

--- a/core/src/commonMain/kotlin/com/powersync/db/crud/SerializedRow.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/crud/SerializedRow.kt
@@ -1,0 +1,93 @@
+package com.powersync.db.crud
+
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.experimental.ExperimentalObjCRefinement
+import kotlin.native.HiddenFromObjC
+
+/**
+ * A named collection of values as they appear in a SQLite row.
+ *
+ * We represent values as a `Map<String, String?>` to ensure compatible with earlier versions of the
+ * SDK, but the [typed] getter can be used to obtain a `Map<String, Any>` where values are either
+ * [String]s, [Int]s or [Double]s.
+ */
+@OptIn(ExperimentalObjCRefinement::class)
+public interface SqliteRow : Map<String, String?> {
+    /**
+     * A typed view of the SQLite row.
+     */
+    public val typed: Map<String, Any?>
+
+    /**
+     * A [JsonObject] of all values in this row that can be represented as JSON.
+     */
+    @HiddenFromObjC
+    public val jsonValues: JsonObject
+}
+
+/**
+ * A [SqliteRow] implemented over a [JsonObject] view.
+ */
+internal class SerializedRow(
+    override val jsonValues: JsonObject,
+) : AbstractMap<String, String?>(),
+    SqliteRow {
+    override val entries: Set<Map.Entry<String, String?>> =
+        jsonValues.entries.mapTo(
+            mutableSetOf(),
+            ::ToStringEntry,
+        )
+
+    override val typed: Map<String, Any?> = TypedRow(jsonValues)
+}
+
+private data class ToStringEntry(
+    val inner: Map.Entry<String, JsonElement>,
+) : Map.Entry<String, String> {
+    override val key: String
+        get() = inner.key
+    override val value: String
+        get() = inner.value.jsonPrimitive.content
+}
+
+private class TypedRow(
+    inner: JsonObject,
+) : AbstractMap<String, Any?>() {
+    override val entries: Set<Map.Entry<String, Any?>> =
+        inner.entries.mapTo(
+            mutableSetOf(),
+            ::ToTypedEntry,
+        )
+}
+
+private data class ToTypedEntry(
+    val inner: Map.Entry<String, JsonElement>,
+) : Map.Entry<String, Any?> {
+    override val key: String
+        get() = inner.key
+    override val value: Any?
+        get() = inner.value.jsonPrimitive.asData()
+
+    companion object {
+        private fun JsonPrimitive.asData(): Any? =
+            if (this === JsonNull) {
+                null
+            } else if (isString) {
+                content
+            } else {
+                content.jsonNumberOrBoolean()
+            }
+
+        private fun String.jsonNumberOrBoolean(): Any =
+            when {
+                this == "true" -> true
+                this == "false" -> false
+                this.any { char -> char == '.' || char == 'e' || char == 'E' } -> this.toDouble()
+                else -> this.toInt()
+            }
+    }
+}

--- a/core/src/commonTest/kotlin/com/powersync/bucket/BucketStorageTest.kt
+++ b/core/src/commonTest/kotlin/com/powersync/bucket/BucketStorageTest.kt
@@ -75,11 +75,7 @@ class BucketStorageTest {
                     op = UpdateType.PUT,
                     table = "table1",
                     transactionId = 1,
-                    opData =
-                        mapOf(
-                            "key" to "value",
-                        ),
-                    data = mapOf("key" to "value"),
+                    opData = null,
                 )
             mockDb =
                 mock<InternalDatabase> {

--- a/core/src/commonTest/kotlin/com/powersync/sync/SyncStreamTest.kt
+++ b/core/src/commonTest/kotlin/com/powersync/sync/SyncStreamTest.kt
@@ -102,11 +102,7 @@ class SyncStreamTest {
                     op = UpdateType.PUT,
                     table = "table1",
                     transactionId = 1,
-                    opData =
-                        mapOf(
-                            "key" to "value",
-                        ),
-                    data = mapOf("key" to "value"),
+                    opData = null,
                 )
             bucketStorage =
                 mock<BucketStorage> {


### PR DESCRIPTION
Most of our SDKs (I've checked Dart and JS) represent `CrudEntry.opData` and `CrudEntry.previousValues` as a `Map<String, Any?>`. In Kotlin however, we're using a `Map<String, String?>` ([reported on Discord](https://discord.com/channels/1138230179878154300/1400787677875408907/1400787677875408907)). This is somewhat unfortunate, as:

1. It means that the Supabase connector will upload everything as a string, regardless of the actual type. While this isn't a huge problem since Postgrest will cast, it's also not great.
2. It's a blocker if we want to represent binary data in the future.
3. Since SQLite is dynamically typed, it would be nice to properly preserve type information so that users can act on the type of values at runtime.

This PR adds information to construct the type of values in `opData` and `previousValues` with backwards-compatibility in mind:

1. As a technically-breaking change, the `CrudEntry` constructor is made `internal`. Users probably weren't invoking it directly though, that's an SDK responsibility.
2. To keep the public `Map<String, String?>` type, this introduces the `SqliteRow` interface extending that type, while also providing a getter to get access to typed values.
3. The interface also has a method to return a `JsonObject`, which we can use in the Supabase connector to upload values unchanged (giving users a serializable object without making `SqliteRow` serializable, which would blow up the framework size).

This way, existing reads on the fields still work because we have a `Map<String, String?>` type.