### PR TITLE
Investigate CI failures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,12 @@ jobs:
       with:
         cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
+    - name: Set up XCode
+      if: runner.os == 'macOS'
+      uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: latest-stable
+
     - name: Build and run tests with Gradle
       run: |
         ./gradlew --scan \


### PR DESCRIPTION
- Explicitly use the latest stable XCode version, since older versions may target a simulator GitHub no longer installs by default.