### PR TITLE
[Internal] Swift Lock Improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   to upload multiple transactions in a batch.
 * Fix modifying severity of the global Kermit logger
 * Add `PowerSync` tag for the logs
+* [INTERNAL] Added helpers for Swift read and write lock exception handling.
 
 ## 1.4.0
 

--- a/PowerSyncKotlin/src/appleMain/kotlin/com/powersync/Locks.kt
+++ b/PowerSyncKotlin/src/appleMain/kotlin/com/powersync/Locks.kt
@@ -1,0 +1,57 @@
+package com.powersync
+
+import com.powersync.db.ThrowableLockCallback
+import com.powersync.db.ThrowableTransactionCallback
+import com.powersync.db.internal.ConnectionContext
+import com.powersync.db.internal.PowerSyncTransaction
+
+/**
+ * The Kotlin [Result] type is an inline class which cannot be used on the Swift side.
+ * This declares something similar which will help to bridge exceptions to Kotlin.
+ * SKIEE doesn't handle generics well.
+ * Making the Result type generic will cause the return type to be casted to "Any", but
+ * also add restrictions that the generic should extend an object - which causes issues when returning
+ * primitive types like `Int` or `String`.
+ */
+public sealed class PowerSyncResult {
+    public data class Success(
+        val value: Any,
+    ) : PowerSyncResult()
+
+    public data class Failure(
+        val exception: PowerSyncException,
+    ) : PowerSyncResult()
+}
+
+// Throws the [PowerSyncException] if the result is a failure, or returns the value if it is a success.
+// We throw the exception on behalf of the Swift SDK.
+@Throws(PowerSyncException::class)
+private fun handleLockResult(result: PowerSyncResult): Any {
+    when (result) {
+        is PowerSyncResult.Failure -> {
+            throw result.exception
+        }
+
+        is PowerSyncResult.Success -> {
+            return result.value
+        }
+    }
+}
+
+public class LockContextWrapper(
+    private val handler: (context: ConnectionContext) -> PowerSyncResult,
+) : ThrowableLockCallback<Any> {
+    override fun execute(context: ConnectionContext): Any = handleLockResult(handler(context))
+}
+
+public class TransactionContextWrapper(
+    private val handler: (context: PowerSyncTransaction) -> PowerSyncResult,
+) : ThrowableTransactionCallback<Any> {
+    override fun execute(transaction: PowerSyncTransaction): Any = handleLockResult(handler(transaction))
+}
+
+public fun wrapContextHandler(handler: (context: ConnectionContext) -> PowerSyncResult): ThrowableLockCallback<Any> =
+    LockContextWrapper(handler)
+
+public fun wrapTransactionContextHandler(handler: (context: PowerSyncTransaction) -> PowerSyncResult): ThrowableTransactionCallback<Any> =
+    TransactionContextWrapper(handler)

--- a/PowerSyncKotlin/src/appleMain/kotlin/com/powersync/SDK.kt
+++ b/PowerSyncKotlin/src/appleMain/kotlin/com/powersync/SDK.kt
@@ -2,6 +2,10 @@
 
 package com.powersync
 
+import com.powersync.db.ThrowableLockCallback
+import com.powersync.db.ThrowableTransactionCallback
+import com.powersync.db.internal.ConnectionContext
+import com.powersync.db.internal.PowerSyncTransaction
 import com.powersync.sync.SyncClientConfiguration
 import com.powersync.sync.SyncOptions
 import io.ktor.client.plugins.logging.LogLevel


### PR DESCRIPTION
# Overview

Related to https://github.com/powersync-ja/powersync-swift/pull/69.

This removes some of the Swift specific error handling we perform in the `core` module, by adding some additional helpers to the `PowerSyncKotlin` module.

A small `Result` like interface is added to the Swift module in order for the Swift SDK to relay exceptions to the Kotlin codebase (throwing Errors directly on the Swift side is not a trivial exercise).