### PR TITLE
Demo tweaks

### DIFF
--- a/demos/android-supabase-todolist/src/main/java/com/powersync/androidexample/screens/SignInScreen.kt
+++ b/demos/android-supabase-todolist/src/main/java/com/powersync/androidexample/screens/SignInScreen.kt
@@ -1,6 +1,7 @@
 package com.powersync.demos.screens
 
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -52,6 +53,7 @@ internal fun SignInScreen(
             onValueChange = { password = it },
             label = { Text("Password") },
             visualTransformation = PasswordVisualTransformation(),
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(bottom = 16.dp)

--- a/demos/android-supabase-todolist/src/main/java/com/powersync/androidexample/screens/SignUpScreen.kt
+++ b/demos/android-supabase-todolist/src/main/java/com/powersync/androidexample/screens/SignUpScreen.kt
@@ -1,10 +1,12 @@
 package com.powersync.demos.screens
 
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import com.powersync.demos.AuthViewModel
@@ -48,6 +50,7 @@ internal fun SignUpScreen(
             onValueChange = { password = it },
             label = { Text("Password") },
             visualTransformation = PasswordVisualTransformation(),
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(bottom = 16.dp)
@@ -58,6 +61,7 @@ internal fun SignUpScreen(
             onValueChange = { confirmPassword = it },
             label = { Text("Confirm Password") },
             visualTransformation = PasswordVisualTransformation(),
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(bottom = 16.dp)

--- a/demos/supabase-todolist/README.md
+++ b/demos/supabase-todolist/README.md
@@ -41,7 +41,7 @@ all items have been received.
 1. Clone this repo: ```git clone https://github.com/powersync-ja/powersync-kotlin.git```
 2. Open the repo in Android Studio. This creates a `local.properties` file in root and should contain a `sdk.dir=/path/to/android/sdk` line.
 3. Sync the project with Gradle (this should happen automatically, or choose File > Sync project with Gradle Files).
-4. Insert your Supabase project URL, Supabase Anon Key, and PowerSync instance URL into the `demos/supabase-todlist/local.properties` file:
+4. Insert your Supabase project URL, Supabase Anon Key, and PowerSync instance URL into the `demos/supabase-todolist/local.properties` file:
 
 ```bash
 # local.properties

--- a/demos/supabase-todolist/androidApp/src/androidMain/kotlin/com/powersync/demos/MainActivity.kt
+++ b/demos/supabase-todolist/androidApp/src/androidMain/kotlin/com/powersync/demos/MainActivity.kt
@@ -2,6 +2,7 @@ package com.powersync.demos
 
 import android.os.Bundle
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
@@ -10,6 +11,9 @@ import com.powersync.DatabaseDriverFactory
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        // Needed to render system bar properly
+        enableEdgeToEdge()
 
         setContent {
             MaterialTheme {

--- a/demos/supabase-todolist/shared/src/commonMain/kotlin/com/powersync/demos/screens/SignInScreen.kt
+++ b/demos/supabase-todolist/shared/src/commonMain/kotlin/com/powersync/demos/screens/SignInScreen.kt
@@ -1,7 +1,9 @@
 package com.powersync.demos.screens
 
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -26,13 +28,16 @@ internal fun SignInScreen(
     var isLoading by remember { mutableStateOf(false) }
 
     val coroutineScope = rememberCoroutineScope()
+    val scrollState = rememberScrollState()
 
     Column(
         modifier = Modifier
             .fillMaxSize()
+            .verticalScroll(scrollState)
             .padding(16.dp),
         verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.CenterHorizontally
+        horizontalAlignment = Alignment.CenterHorizontally,
+
     ) {
         Text(
             "Sign In",

--- a/demos/supabase-todolist/shared/src/commonMain/kotlin/com/powersync/demos/screens/SignInScreen.kt
+++ b/demos/supabase-todolist/shared/src/commonMain/kotlin/com/powersync/demos/screens/SignInScreen.kt
@@ -1,10 +1,12 @@
 package com.powersync.demos.screens
 
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import com.powersync.demos.AuthViewModel
@@ -52,6 +54,7 @@ internal fun SignInScreen(
             onValueChange = { password = it },
             label = { Text("Password") },
             visualTransformation = PasswordVisualTransformation(),
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(bottom = 16.dp)

--- a/demos/supabase-todolist/shared/src/commonMain/kotlin/com/powersync/demos/screens/SignUpScreen.kt
+++ b/demos/supabase-todolist/shared/src/commonMain/kotlin/com/powersync/demos/screens/SignUpScreen.kt
@@ -1,10 +1,12 @@
 package com.powersync.demos.screens
 
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import com.powersync.demos.AuthViewModel
@@ -48,6 +50,7 @@ internal fun SignUpScreen(
             onValueChange = { password = it },
             label = { Text("Password") },
             visualTransformation = PasswordVisualTransformation(),
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(bottom = 16.dp)
@@ -58,6 +61,7 @@ internal fun SignUpScreen(
             onValueChange = { confirmPassword = it },
             label = { Text("Confirm Password") },
             visualTransformation = PasswordVisualTransformation(),
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(bottom = 16.dp)

--- a/demos/supabase-todolist/shared/src/commonMain/kotlin/com/powersync/demos/screens/SignUpScreen.kt
+++ b/demos/supabase-todolist/shared/src/commonMain/kotlin/com/powersync/demos/screens/SignUpScreen.kt
@@ -1,7 +1,9 @@
 package com.powersync.demos.screens
 
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -26,10 +28,12 @@ internal fun SignUpScreen(
     var isLoading by remember { mutableStateOf(false) }
 
     val coroutineScope = rememberCoroutineScope()
+    val scrollState = rememberScrollState()
 
     Column(
         modifier = Modifier
             .fillMaxSize()
+            .verticalScroll(scrollState)
             .padding(16.dp),
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally


### PR DESCRIPTION
These are some minor tweaks to the `supabase-todolist` demo app, fixing issues that I ran into when testing.

1. Set the correct keyboard type for all password fields. Without this, the input was hidden, but the keyboard would use auto-correct for example, and wouldn't integrate with password managers. This prevented me from signing in.
2. Add scrolling to sign-in and sign-up screens. A sign-in error could move content off-screen, which made it unusable after an error.
3. Use `enableEdgeToEdge()` to avoid the system bar having the same color as the background. I don't fully understand all the options and implications here, but this appeared to be the simplest and most consistent solution.
