### PR TITLE
[Legacy Sync] Fix offline upload delay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.5.1 (unreleased)
+
+* Fix issue in legacy sync client where local writes made offline could have their upload delayed
+  until a keepalive event was received. This could also cause downloaded updates to be delayed even
+  further until all uploads were
+  completed.
+
 ## 1.5.0
 
 * Add `PowerSyncDatabase.getCrudTransactions()`, returning a flow of transactions. This is useful

--- a/core/src/commonIntegrationTest/kotlin/com/powersync/sync/SyncIntegrationTest.kt
+++ b/core/src/commonIntegrationTest/kotlin/com/powersync/sync/SyncIntegrationTest.kt
@@ -612,7 +612,6 @@ abstract class BaseSyncIntegrationTest(
                     database.watch("SELECT name FROM users") { it.getString(0)!! }.testIn(scope)
                 query.awaitItem() shouldBe listOf("local write")
 
-                syncLines.send(SyncLine.KeepAlive(tokenExpiresIn = 1234))
                 syncLines.send(
                     SyncLine.FullCheckpoint(
                         Checkpoint(


### PR DESCRIPTION
# Overview

Currently the Legacy sync implementation can cause delays for uploading CRUD operations made while offline.

This can happen if:
- CRUD operations are made while the client is offline
- The PowerSync client `connect` method is then called.
- The client connects to the service, but we don't currently immediately upload the pending operations.
- The client will download updates from the service, but wont apply them until we have uploaded all pending items (this has been delayed/ not triggered)
- The client is effectively blocked until the next keepalive event is received from the service (this kicks off a upload)

This PR triggers an upload after receiving the first PowerSync service command line. This same method is currently used by the Rust implementation.

The `handles write made while offline` test has been updated. We no longer send a keepalive immediately from the mocked service. This test would previously fail without the keepalive.