### PR TITLE
Support asynchronous transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Remove internal SQLDelight and SQLiter dependencies.
 * Add `rawConnection` getter to `ConnectionContext`, which is a `SQLiteConnection` instance from
   `androidx.sqlite` that can be used to step through statements in a custom way.
+* Support asynchronous transactions and locks.
 
 ## 1.5.1
 

--- a/core/src/commonIntegrationTest/kotlin/com/powersync/CrudTest.kt
+++ b/core/src/commonIntegrationTest/kotlin/com/powersync/CrudTest.kt
@@ -108,7 +108,7 @@ class CrudTest {
                 ),
             )
 
-            database.writeTransaction { tx ->
+            database.writeTransactionAsync { tx ->
                 tx.execute(
                     "INSERT INTO foo (id,a,b,c) VALUES (uuid(), ?, ?, ?)",
                     listOf(

--- a/core/src/commonIntegrationTest/kotlin/com/powersync/testutils/TestUtils.kt
+++ b/core/src/commonIntegrationTest/kotlin/com/powersync/testutils/TestUtils.kt
@@ -117,7 +117,7 @@ internal class ActiveDatabaseTest(
         return db
     }
 
-    suspend fun openDatabaseAndInitialize(): PowerSyncDatabaseImpl = openDatabase().also { it.readLock { } }
+    suspend fun openDatabaseAndInitialize(): PowerSyncDatabaseImpl = openDatabase().also { it.readLockAsync { } }
 
     @OptIn(ExperimentalPowerSyncAPI::class)
     fun createSyncClient(): HttpClient {

--- a/core/src/commonMain/kotlin/com/powersync/bucket/BucketStorage.kt
+++ b/core/src/commonMain/kotlin/com/powersync/bucket/BucketStorage.kt
@@ -1,8 +1,8 @@
 package com.powersync.bucket
 
+import com.powersync.db.ScopedWriteQueries
 import com.powersync.db.SqlCursor
 import com.powersync.db.crud.CrudEntry
-import com.powersync.db.internal.PowerSyncTransaction
 import com.powersync.db.schema.SerializableSchema
 import com.powersync.sync.Instruction
 import com.powersync.sync.LegacySyncImplementation
@@ -18,11 +18,11 @@ internal interface BucketStorage {
 
     suspend fun nextCrudItem(): CrudEntry?
 
-    fun nextCrudItem(transaction: PowerSyncTransaction): CrudEntry?
+    suspend fun nextCrudItem(transaction: ScopedWriteQueries): CrudEntry?
 
     suspend fun hasCrud(): Boolean
 
-    fun hasCrud(transaction: PowerSyncTransaction): Boolean
+    suspend fun hasCrud(transaction: ScopedWriteQueries): Boolean
 
     fun mapCrudEntry(row: SqlCursor): CrudEntry
 

--- a/core/src/commonMain/kotlin/com/powersync/db/driver/RawConnectionLease.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/driver/RawConnectionLease.kt
@@ -3,6 +3,7 @@ package com.powersync.db.driver
 import androidx.sqlite.SQLiteConnection
 import androidx.sqlite.SQLiteStatement
 import com.powersync.ExperimentalPowerSyncAPI
+import com.powersync.db.runWrapped
 
 /**
  * A temporary view / lease of an inner [androidx.sqlite.SQLiteConnection] managed by the PowerSync
@@ -22,7 +23,9 @@ internal class RawConnectionLease(
 
     override fun isInTransactionSync(): Boolean {
         checkNotCompleted()
-        return connection.inTransaction()
+        return runWrapped {
+            connection.inTransaction()
+        }
     }
 
     override suspend fun <R> usePrepared(
@@ -35,6 +38,8 @@ internal class RawConnectionLease(
         block: (SQLiteStatement) -> R,
     ): R {
         checkNotCompleted()
-        return connection.prepare(sql).use(block)
+        return runWrapped {
+            connection.prepare(sql).use(block)
+        }
     }
 }

--- a/core/src/commonMain/kotlin/com/powersync/db/internal/ConnectionContext.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/internal/ConnectionContext.kt
@@ -7,9 +7,8 @@ import com.powersync.db.SqlCursor
 import com.powersync.db.StatementBasedCursor
 import com.powersync.db.driver.SQLiteConnectionLease
 
+@Deprecated("Use suspending callback instead")
 public interface ConnectionContext {
-    // TODO (breaking): Make asynchronous, create shared superinterface with Queries
-
     @Throws(PowerSyncException::class)
     public fun execute(
         sql: String,
@@ -38,6 +37,7 @@ public interface ConnectionContext {
     ): RowType
 }
 
+@Deprecated("Use suspending callback instead")
 @ExperimentalPowerSyncAPI
 internal class ConnectionContextImplementation(
     private val rawConnection: SQLiteConnectionLease,

--- a/core/src/commonMain/kotlin/com/powersync/db/internal/PowerSyncTransaction.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/internal/PowerSyncTransaction.kt
@@ -5,11 +5,13 @@ import com.powersync.PowerSyncException
 import com.powersync.db.SqlCursor
 import com.powersync.db.driver.SQLiteConnectionLease
 
+@Deprecated("Use suspending callback instead")
 public interface PowerSyncTransaction : ConnectionContext
 
 @ExperimentalPowerSyncAPI
+@Deprecated("Use suspending callback instead")
 internal class PowerSyncTransactionImpl(
-    private val lease: SQLiteConnectionLease,
+    val lease: SQLiteConnectionLease,
 ) : PowerSyncTransaction,
     ConnectionContext {
     private val delegate = ConnectionContextImplementation(lease)
@@ -57,7 +59,7 @@ internal class PowerSyncTransactionImpl(
 }
 
 @ExperimentalPowerSyncAPI
-internal suspend fun <T> SQLiteConnectionLease.runTransaction(cb: suspend (PowerSyncTransaction) -> T): T {
+internal suspend fun <T> SQLiteConnectionLease.runTransaction(cb: suspend (PowerSyncTransactionImpl) -> T): T {
     execSQL("BEGIN")
     return try {
         val result = cb(PowerSyncTransactionImpl(this))

--- a/core/src/commonMain/kotlin/com/powersync/db/internal/ScopedWriteQueriesImplementation.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/internal/ScopedWriteQueriesImplementation.kt
@@ -1,0 +1,81 @@
+package com.powersync.db.internal
+
+import androidx.sqlite.SQLiteStatement
+import com.powersync.ExperimentalPowerSyncAPI
+import com.powersync.PowerSyncException
+import com.powersync.db.ScopedWriteQueries
+import com.powersync.db.SqlCursor
+import com.powersync.db.StatementBasedCursor
+import com.powersync.db.driver.SQLiteConnectionLease
+
+@OptIn(ExperimentalPowerSyncAPI::class)
+internal class ScopedWriteQueriesImplementation(
+    private val rawConnection: SQLiteConnectionLease,
+    private val isTransaction: Boolean = false,
+) : ScopedWriteQueries {
+    override suspend fun execute(
+        sql: String,
+        parameters: List<Any?>?,
+    ): Long {
+        withStatement(sql, parameters) {
+            while (it.step()) {
+                // Iterate through the statement
+            }
+        }
+
+        return withStatement("SELECT changes()", null) {
+            check(it.step())
+            it.getLong(0)
+        }
+    }
+
+    override suspend fun <RowType : Any> get(
+        sql: String,
+        parameters: List<Any?>?,
+        mapper: (SqlCursor) -> RowType,
+    ): RowType = getOptional(sql, parameters, mapper) ?: throw PowerSyncException("get() called with query that returned no rows", null)
+
+    override suspend fun <RowType : Any> getAll(
+        sql: String,
+        parameters: List<Any?>?,
+        mapper: (SqlCursor) -> RowType,
+    ): List<RowType> =
+        withStatement(sql, parameters) { stmt ->
+            buildList {
+                val cursor = StatementBasedCursor(stmt)
+                while (stmt.step()) {
+                    add(mapper(cursor))
+                }
+            }
+        }
+
+    override suspend fun <RowType : Any> getOptional(
+        sql: String,
+        parameters: List<Any?>?,
+        mapper: (SqlCursor) -> RowType,
+    ): RowType? =
+        withStatement(sql, parameters) { stmt ->
+            if (stmt.step()) {
+                mapper(StatementBasedCursor(stmt))
+            } else {
+                null
+            }
+        }
+
+    private suspend fun <T> withStatement(
+        sql: String,
+        parameters: List<Any?>?,
+        block: (SQLiteStatement) -> T,
+    ): T {
+        if (isTransaction) {
+            if (!rawConnection.isInTransactionSync()) {
+                throw PowerSyncException("Tried executing statement on a transaction that has been rolled back", cause = null)
+            }
+        }
+
+        return rawConnection.usePrepared(sql) { stmt ->
+            stmt.bind(parameters)
+            block(stmt)
+        }
+    }
+}

--- a/core/src/commonTest/kotlin/com/powersync/bucket/BucketStorageTest.kt
+++ b/core/src/commonTest/kotlin/com/powersync/bucket/BucketStorageTest.kt
@@ -136,7 +136,7 @@ class BucketStorageTest {
                             any(),
                         )
                     } returns 1L
-                    everySuspend { writeTransaction<Boolean>(any()) } returns true
+                    everySuspend { writeTransactionAsync<Boolean>(any()) } returns true
                 }
             bucketStorage = BucketStorageImpl(mockDb, Logger)
 


### PR DESCRIPTION
Since Room uses an asynchronous-only connection pool, integrating it into the PowerSync SDK would be more efficient if we didn't have to call `runBlocking` around every statement.
Making query methods asynchronous also simplifies some interfaces, since it means that the top-level `Queries` and inner transactions can share asynchronous methods.

So, this PR:

1. Introduces the `ScopedReadQueries` and `ScopedWriteQueries` interfaces. The `get`, `getAll` and `getOptional` methods have been moved to `ScopedReadQueries`; `execute` is now part of `ScopedWriteQueries`.
2. The `Queries` interface now extends from `ScopedWriteQueries`.
3. Instead of implementing virtually every method twice (once in `PowerSyncDatabaseImpl` to await for initialization and then in `InternalDatabaseImpl`), most methods are now implemented directly in `Queries` ontop of the `useConnection` interface.
  - This doesn't break waiting for initialization, as `useConnection` does that for all methods.

I have marked the synchronous callbacks as `@Deprecated`. I'm not sure if we want to be that aggressive or if we want to keep supporting both methods for longer. I'm slightly leaning toward eventually removing them given the nicer unified interface and reduced complexity.