### PR TITLE
Include Room and SQLDelight modules in Dokka

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -70,6 +70,8 @@ dependencies {
     dokka(project(":core:"))
     dokka(project(":connectors:supabase"))
     dokka(project(":compose:"))
+    dokka(project(":integrations:room"))
+    dokka(project(":integrations:sqldelight"))
 }
 
 dokka {
@@ -97,9 +99,11 @@ develocity {
 tasks.register("serveDokka") {
     group = "dokka"
     dependsOn("dokkaGenerate")
+    val rootProvider = layout.buildDirectory.dir("dokka/html")
+
     doLast {
+        val root = rootProvider.get().asFile
         val server = HttpServer.create(InetSocketAddress(0), 0)
-        val root = file("build/dokka/html")
 
         val handler =
             com.sun.net.httpserver.HttpHandler { exchange: HttpExchange ->

--- a/integrations/room/README.md
+++ b/integrations/room/README.md
@@ -1,11 +1,16 @@
 # PowerSync Room integration
 
+> [!NOTE]
+> Note that this package is currently in alpha.
+
 This module provides the ability to use PowerSync with Room databases. This module aims for complete
 Room support, meaning that:
 
 1. Changes synced from PowerSync automatically update your Room `Flow`s.
 2. Room and PowerSync cooperate on the write connection, avoiding "database is locked errors".
 3. Changes from Room trigger a CRUD upload.
+
+For more details on using this module, see its page on the [PowerSync documentation](https://docs.powersync.com/client-sdk-references/kotlin-multiplatform/libraries/room).
 
 ## Setup
 

--- a/integrations/sqldelight/README.md
+++ b/integrations/sqldelight/README.md
@@ -1,7 +1,12 @@
 ## PowerSync SQLDelight driver
 
+> [!NOTE]
+> Note that this package is currently in beta.
+
 This library provides the `PowerSyncDriver` class, which implements an `SqlDriver` for `SQLDelight`
 backed by PowerSync.
+
+For more details on using this module, see its page on the [PowerSync documentation](https://docs.powersync.com/client-sdk-references/kotlin-multiplatform/libraries/sqldelight).
 
 ## Setup
 

--- a/plugins/build-plugin/src/main/kotlin/dokka-convention.gradle.kts
+++ b/plugins/build-plugin/src/main/kotlin/dokka-convention.gradle.kts
@@ -1,3 +1,5 @@
+import java.net.URI
+
 plugins {
     id("org.jetbrains.dokka")
 }
@@ -28,7 +30,7 @@ dokka {
         sourceLink {
             localDirectory.set(project.rootDir)
             remoteUrl.set(commit.map { commit ->
-                uri("https://github.com/powersync-ja/powersync-kotlin/tree/${commit.trim()}/")
+                URI.create("https://github.com/powersync-ja/powersync-kotlin/tree/${commit.trim()}/")
             })
             remoteLineSuffix.set("#L")
         }


### PR DESCRIPTION
This:

- Adds the Room and SQLDelight modules to the generated Dokka documentation.
- Upates build tasks for the documentation to work with the configuration cache enabled (which mainly consists of changes to avoid referencing `Project` within `doLast` and providers).