### PR TITLE
Fix missing native library on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.6.1
+
+* Fix `dlopen failed: library "libpowersync.so.so" not found` errors on Android.
+
 ## 1.6.0
 
 * Remove internal SQLDelight and SQLiter dependencies.

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -171,6 +171,7 @@ kotlin {
         androidMain {
             dependsOn(commonJava)
             dependencies {
+                api(libs.powersync.sqlite.core.android)
                 implementation(libs.ktor.client.okhttp)
                 implementation(libs.androidx.sqlite.bundled)
             }
@@ -255,11 +256,6 @@ android {
         consumerProguardFiles("proguard-rules.pro")
     }
 
-    sourceSets {
-        getByName("main") {
-            jniLibs.srcDirs("src/androidMain/jni", "src/main/jni", "src/jniLibs")
-        }
-    }
     ndkVersion = "27.1.12297006"
 }
 

--- a/core/proguard-rules.pro
+++ b/core/proguard-rules.pro
@@ -1,0 +1,2 @@
+# Temporary workaround for https://issuetracker.google.com/issues/442489402
+-keepclasseswithmembers class androidx.sqlite.driver.bundled.** { native <methods>; }

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ development=true
 RELEASE_SIGNING_ENABLED=true
 # Library config
 GROUP=com.powersync
-LIBRARY_VERSION=1.6.0
+LIBRARY_VERSION=1.6.1
 GITHUB_REPO=https://github.com/powersync-ja/powersync-kotlin.git
 # POM
 POM_URL=https://github.com/powersync-ja/powersync-kotlin/

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,9 +30,9 @@ compose = "1.8.2" # This is for the multiplatform compose
 androidCompose = "2025.08.00"
 compose-preview = "1.9.0"
 compose-lifecycle = "2.9.2"
-androidxSqlite = "2.6.0-rc02"
+androidxSqlite = "2.6.0"
 androidxSplashscreen = "1.0.1"
-room = "2.8.0-rc02"
+room = "2.8.0"
 sqldelight = "2.1.0"
 
 # plugins


### PR DESCRIPTION
To distribute `libpowersync.so` on Android, we used to depend on a `:persistence` project which in turn used to depend on `com.powersync:powersync-sqlite-core`, the core extension release for Android.

With the refactoring to `androidx.sqlite`, the `:persistence` project (and thus the dependency on the core extension) is gone. This breaks version 1.6.0 on Android, causing "libpowersync.so not found" errors.

To fix this, this:

1. Restores the dependency! I've tested the fix with both demos on an Android emulator.
2. While running `core-tests-android`, I stumbled across an issue with the proguard configuration of the [bundled sqlite module](https://issuetracker.google.com/issues/442489402). To avoid this impacting our users, we can add the missing proguard rules to the core package instead.
3. This removes unused `jniLibs` for the Android configuration - these are empty since the 1.6.0 release.

These fixes restore Android support for debug (tested with demos) and release (tested with `core-tests-android`). As a follow-up, I'll also look at running Android integration tests in our CI next week.