### PR TITLE
Add in-memory database for tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.7.0 (unreleased)
+
+- Add `PowerSyncDatabase.inMemory` to create an in-memory SQLite database with PowerSync.
+  This may be useful for testing.
+
 ## 1.6.1
 
 * Fix `dlopen failed: library "libpowersync.so.so" not found` errors on Android.

--- a/core/src/androidMain/kotlin/com/powersync/DatabaseDriverFactory.android.kt
+++ b/core/src/androidMain/kotlin/com/powersync/DatabaseDriverFactory.android.kt
@@ -26,3 +26,5 @@ public fun BundledSQLiteDriver.addPowerSyncExtension() {
 @ExperimentalPowerSyncAPI
 @Throws(PowerSyncException::class)
 public actual fun resolvePowerSyncLoadableExtensionPath(): String? = "libpowersync.so"
+
+internal actual fun openInMemoryConnection(): SQLiteConnection = BundledSQLiteDriver().also { it.addPowerSyncExtension() }.open(":memory:")

--- a/core/src/appleNonWatchOsMain/kotlin/com/powersync/DatabaseDriverFactory.appleNonWatchOs.kt
+++ b/core/src/appleNonWatchOsMain/kotlin/com/powersync/DatabaseDriverFactory.appleNonWatchOs.kt
@@ -25,3 +25,5 @@ public actual class DatabaseDriverFactory {
 @ExperimentalPowerSyncAPI
 @Throws(PowerSyncException::class)
 public actual fun resolvePowerSyncLoadableExtensionPath(): String? = powerSyncExtensionPath
+
+internal actual fun openInMemoryConnection(): SQLiteConnection = DatabaseDriverFactory().openConnection(":memory:", 0x02)

--- a/core/src/commonMain/kotlin/com/powersync/DatabaseDriverFactory.kt
+++ b/core/src/commonMain/kotlin/com/powersync/DatabaseDriverFactory.kt
@@ -17,6 +17,8 @@ public expect class DatabaseDriverFactory {
     ): SQLiteConnection
 }
 
+internal expect fun openInMemoryConnection(): SQLiteConnection
+
 /**
  * Resolves a path to the loadable PowerSync core extension library.
  *

--- a/core/src/commonMain/kotlin/com/powersync/db/driver/SingleConnectionPool.kt
+++ b/core/src/commonMain/kotlin/com/powersync/db/driver/SingleConnectionPool.kt
@@ -1,0 +1,59 @@
+package com.powersync.db.driver
+
+import androidx.sqlite.SQLiteConnection
+import com.powersync.ExperimentalPowerSyncAPI
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * A [SQLiteConnectionPool] backed by a single database connection.
+ *
+ * This does not provide any concurrency, but is still a reasonable implementation to use for e.g. tests.
+ */
+@OptIn(ExperimentalPowerSyncAPI::class)
+internal class SingleConnectionPool(
+    private val conn: SQLiteConnection,
+) : SQLiteConnectionPool {
+    private val mutex: Mutex = Mutex()
+    private var closed = false
+    private val tableUpdatesFlow = MutableSharedFlow<Set<String>>(replay = 0)
+
+    init {
+        conn.setupDefaultPragmas(false)
+    }
+
+    override suspend fun <T> read(callback: suspend (SQLiteConnectionLease) -> T): T = write(callback)
+
+    override suspend fun <T> write(callback: suspend (SQLiteConnectionLease) -> T): T =
+        mutex.withLock {
+            check(!closed) { "Connection closed" }
+
+            try {
+                callback(RawConnectionLease(conn))
+            } finally {
+                val updates = conn.readPendingUpdates()
+                if (updates.isNotEmpty()) {
+                    tableUpdatesFlow.emit(updates)
+                }
+            }
+
+        }
+
+    override suspend fun <R> withAllConnections(
+        action: suspend (writer: SQLiteConnectionLease, readers: List<SQLiteConnectionLease>) -> R,
+    ) = write { writer ->
+        action(writer, emptyList())
+        Unit
+    }
+
+    override val updates: SharedFlow<Set<String>>
+        get() = tableUpdatesFlow
+
+    override suspend fun close() {
+        mutex.withLock {
+            conn.close()
+        }
+    }
+}

--- a/core/src/commonTest/kotlin/com/powersync/db/InMemoryTest.kt
+++ b/core/src/commonTest/kotlin/com/powersync/db/InMemoryTest.kt
@@ -1,0 +1,76 @@
+package com.powersync.db
+
+import app.cash.turbine.turbineScope
+import co.touchlab.kermit.ExperimentalKermitApi
+import co.touchlab.kermit.Logger
+import co.touchlab.kermit.Severity
+import co.touchlab.kermit.TestConfig
+import co.touchlab.kermit.TestLogWriter
+import com.powersync.PowerSyncDatabase
+import com.powersync.db.schema.Column
+import com.powersync.db.schema.Schema
+import com.powersync.db.schema.Table
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+@OptIn(ExperimentalKermitApi::class)
+class InMemoryTest {
+    private val logWriter =
+        TestLogWriter(
+            loggable = Severity.Debug,
+        )
+
+    private val logger =
+        Logger(
+            TestConfig(
+                minSeverity = Severity.Debug,
+                logWriterList = listOf(logWriter),
+            ),
+        )
+
+    @Test
+    fun createsSchema() =
+        runTest {
+            val db = PowerSyncDatabase.inMemory(this, schema, logger)
+            try {
+                db.getAll("SELECT * FROM users") { } shouldHaveSize 0
+            } finally {
+                db.close()
+            }
+        }
+
+    @Test
+    fun watch() =
+        runTest {
+            val db = PowerSyncDatabase.inMemory(this, schema, logger)
+            try {
+                turbineScope {
+                    val turbine =
+                        db.watch("SELECT name FROM users", mapper = { it.getString(0)!! }).testIn(this)
+
+                    turbine.awaitItem() shouldBe listOf()
+
+                    db.execute("INSERT INTO users (id, name) VALUES (uuid(), ?)", listOf("test user"))
+                    turbine.awaitItem() shouldBe listOf("test user")
+                    turbine.cancelAndIgnoreRemainingEvents()
+                }
+            } finally {
+                db.close()
+            }
+        }
+
+    companion object {
+        private val schema =
+            Schema(
+                Table(
+                    name = "users",
+                    columns =
+                        listOf(
+                            Column.text("name"),
+                        ),
+                ),
+            )
+    }
+}

--- a/core/src/jvmMain/kotlin/com/powersync/DatabaseDriverFactory.jvm.kt
+++ b/core/src/jvmMain/kotlin/com/powersync/DatabaseDriverFactory.jvm.kt
@@ -1,6 +1,7 @@
 package com.powersync
 
 import androidx.sqlite.SQLiteConnection
+import androidx.sqlite.driver.bundled.BundledSQLiteConnection
 import androidx.sqlite.driver.bundled.BundledSQLiteDriver
 import com.powersync.db.runWrapped
 
@@ -25,3 +26,5 @@ private val powersyncExtension: String by lazy { extractLib("powersync") }
 @ExperimentalPowerSyncAPI
 @Throws(PowerSyncException::class)
 public actual fun resolvePowerSyncLoadableExtensionPath(): String? = runWrapped { powersyncExtension }
+
+internal actual fun openInMemoryConnection(): SQLiteConnection = DatabaseDriverFactory().openConnection(":memory:", 0x02)

--- a/core/src/watchosMain/kotlin/com/powersync/DatabaseDriverFactory.watchos.kt
+++ b/core/src/watchosMain/kotlin/com/powersync/DatabaseDriverFactory.watchos.kt
@@ -38,3 +38,5 @@ public actual fun resolvePowerSyncLoadableExtensionPath(): String? {
     didLoadExtension
     return null
 }
+
+internal actual fun openInMemoryConnection(): SQLiteConnection = DatabaseDriverFactory().openConnection(":memory:", 0x02)

--- a/integrations/sqldelight/build.gradle.kts
+++ b/integrations/sqldelight/build.gradle.kts
@@ -34,17 +34,6 @@ kotlin {
 
             implementation(libs.sqldelight.coroutines)
         }
-
-        val commonIntegrationTest by creating {
-            dependsOn(commonTest.get())
-        }
-
-        // The PowerSync SDK links the core extension, so we can just run tests as-is.
-        jvmTest.get().dependsOn(commonIntegrationTest)
-
-        // We have special setup in this build configuration to make these tests link the PowerSync extension, so they
-        // can run integration tests along with the executable for unit testing.
-        nativeTest.orNull?.dependsOn(commonIntegrationTest)
     }
 }
 

--- a/integrations/sqldelight/src/appleTest/kotlin/com/powersync/integrations/sqldelight/SqlDelightTest.apple.kt
+++ b/integrations/sqldelight/src/appleTest/kotlin/com/powersync/integrations/sqldelight/SqlDelightTest.apple.kt
@@ -1,5 +1,0 @@
-package com.powersync.integrations.sqldelight
-
-import com.powersync.DatabaseDriverFactory
-
-actual fun databaseDriverFactory(): DatabaseDriverFactory = DatabaseDriverFactory()

--- a/integrations/sqldelight/src/commonTest/kotlin/com/powersync/integrations/sqldelight/SqlDelightTest.kt
+++ b/integrations/sqldelight/src/commonTest/kotlin/com/powersync/integrations/sqldelight/SqlDelightTest.kt
@@ -144,12 +144,9 @@ class SqlDelightTest {
 
 private fun databaseTest(body: suspend TestScope.(PowerSyncDatabase) -> Unit) {
     runTest {
-        val allowedChars = ('A'..'Z') + ('a'..'z') + ('0'..'9')
-        val suffix = CharArray(8) { allowedChars.random() }.concatToString()
-
         val db =
-            PowerSyncDatabase(
-                databaseDriverFactory(),
+            PowerSyncDatabase.inMemory(
+                scope = this,
                 schema =
                     Schema(
                         Table(
@@ -160,13 +157,9 @@ private fun databaseTest(body: suspend TestScope.(PowerSyncDatabase) -> Unit) {
                             ),
                         ),
                     ),
-                dbFilename = "db-$suffix",
-                dbDirectory = SystemTemporaryDirectory.toString(),
             )
 
         body(db)
         db.close()
     }
 }
-
-expect fun databaseDriverFactory(): DatabaseDriverFactory

--- a/integrations/sqldelight/src/jvmTest/kotlin/com/powersync/integrations/sqldelight/SqlDelightTest.jvm.kt
+++ b/integrations/sqldelight/src/jvmTest/kotlin/com/powersync/integrations/sqldelight/SqlDelightTest.jvm.kt
@@ -1,5 +1,0 @@
-package com.powersync.integrations.sqldelight
-
-import com.powersync.DatabaseDriverFactory
-
-actual fun databaseDriverFactory(): DatabaseDriverFactory = DatabaseDriverFactory()


### PR DESCRIPTION
This adds the `PowerSyncDatabase.inMemory` factory to create PowerSync databases backed by a single in-memory connection.

This utility simplifies the test setup for users:

1. It doesn't need an open factory, so users can write tests in `commonMain` instead of having to setup `expect` / `actual`s in tests.
2. One doesn't have to create a temporary file path for each test, databases are isolated on their own.
3. No cleanup logic is required.

We should continue testing the core logic with "real" file-backed databases to ensure the pool works, but having a single in-memory connection is useful to test other packages that can expect `:core` to behave correctly. This adopts that for the SQLDelight integration, I'm also writing tests for the Supabase connector where these changes would simplify the setup.