### PR TITLE
Include common project in API docs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -67,6 +67,7 @@ tasks.getByName<Delete>("clean") {
 
 // Merges individual module docs into a single HTML output
 dependencies {
+    dokka(project(":common:"))
     dokka(project(":core:"))
     dokka(project(":compose:"))
     dokka(project(":integrations:room"))


### PR DESCRIPTION
Because `:common` is the project containing most of our APIs now, it should also be included in the generated documentation site.