### PR TITLE
Add POM description for :common project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.8.1
+
+- Add POM name and description for `:common` project.
+
 ## 1.8.0
 
 - Refactor SDK: `com.powersync:powersync-core` has an identical API, but now depends on 

--- a/common/gradle.properties
+++ b/common/gradle.properties
@@ -1,0 +1,3 @@
+POM_ARTIFACT_ID=common
+POM_NAME=PowerSync Common
+POM_DESCRIPTION=Common APIs for the PowerSync Kotlin SDK without a fixed SQLite dependency.

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ development=true
 RELEASE_SIGNING_ENABLED=true
 # Library config
 GROUP=com.powersync
-LIBRARY_VERSION=1.8.0
+LIBRARY_VERSION=1.8.1
 GITHUB_REPO=https://github.com/powersync-ja/powersync-kotlin.git
 # POM
 POM_URL=https://github.com/powersync-ja/powersync-kotlin/


### PR DESCRIPTION
Maven central rejected the initial `:common` upload, breaking version 1.8.0 of the Kotlin SDK:

<img width="2292" alt="grafik" src="https://github.com/user-attachments/assets/08095a47-81a0-415c-aff5-b09577a0578e" />

In an attempt to fix this, this adds a `gradle.properties` file to `common` to include that metadata and prepares a 1.8.1 release to try again.