### PR TITLE
v1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.10.0 (unreleased)
+## 1.10.0
 
 - Add `appMetadata` parameter to `PowerSyncDatabase.connect()` to include application metadata in
   sync requests. This metadata is merged into sync requests and displayed in PowerSync service logs.

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ development=true
 RELEASE_SIGNING_ENABLED=true
 # Library config
 GROUP=com.powersync
-LIBRARY_VERSION=1.9.0
+LIBRARY_VERSION=1.10.0
 GITHUB_REPO=https://github.com/powersync-ja/powersync-kotlin.git
 # POM
 POM_URL=https://github.com/powersync-ja/powersync-kotlin/


### PR DESCRIPTION
## 1.10.0

- Add `appMetadata` parameter to `PowerSyncDatabase.connect()` to include application metadata in
  sync requests. This metadata is merged into sync requests and displayed in PowerSync service logs.

Note: This requires a PowerSync service version `>=1.17.0` in order for logs to display metadata.

```kotlin
database.connect(
    connector = connector,
    appMetadata = mapOf(
        "appVersion" to "1.0.0",
        "deviceId" to "device456"
    )
)
```