### PR TITLE
Fix Apple frameworks to contain version numbers

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ development=true
 RELEASE_SIGNING_ENABLED=true
 # Library config
 GROUP=com.powersync
-LIBRARY_VERSION=1.10.0
+LIBRARY_VERSION=1.10.1
 GITHUB_REPO=https://github.com/powersync-ja/powersync-kotlin.git
 # POM
 POM_URL=https://github.com/powersync-ja/powersync-kotlin/

--- a/internal/PowerSyncKotlin/build.gradle.kts
+++ b/internal/PowerSyncKotlin/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.skie)
     alias(libs.plugins.kotlinter)
+    id("com.powersync.plugins.version")
 }
 
 kotlin {

--- a/plugins/sonatype/build.gradle.kts
+++ b/plugins/sonatype/build.gradle.kts
@@ -11,6 +11,11 @@ gradlePlugin {
         id = "com.powersync.plugins.sonatype"
         implementationClass = "com.powersync.plugins.sonatype.SonatypeCentralUploadPlugin"
     }
+
+    val versionPlugin by plugins.creating {
+        id = "com.powersync.plugins.version"
+        implementationClass = "com.powersync.plugins.PowerSyncVersionPlugin"
+    }
 }
 
 // The target release option here is the version of the JVM running the build by default, but Kotlin

--- a/plugins/sonatype/src/main/kotlin/com/powersync/plugins/PowerSyncVersionPlugin.kt
+++ b/plugins/sonatype/src/main/kotlin/com/powersync/plugins/PowerSyncVersionPlugin.kt
@@ -1,0 +1,11 @@
+package com.powersync.plugins
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+internal class PowerSyncVersionPlugin: Plugin<Project> {
+    override fun apply(project: Project) {
+        project.group = project.property("GROUP") as String
+        project.version = project.property("LIBRARY_VERSION") as String
+    }
+}

--- a/plugins/sonatype/src/main/kotlin/com/powersync/plugins/sonatype/SonatypeCentralUploadPlugin.kt
+++ b/plugins/sonatype/src/main/kotlin/com/powersync/plugins/sonatype/SonatypeCentralUploadPlugin.kt
@@ -1,5 +1,6 @@
 package com.powersync.plugins.sonatype
 
+import com.powersync.plugins.PowerSyncVersionPlugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import com.vanniktech.maven.publish.MavenPublishPlugin
@@ -9,10 +10,9 @@ import com.vanniktech.maven.publish.MavenPublishBaseExtension
 
 internal class SonatypeCentralUploadPlugin : Plugin<Project> {
     override fun apply(project: Project) {
-        project.logger.info("Applying the `gradle-maven-publish` plugin")
-        project.group = project.property("GROUP") as String
-        project.version = project.property("LIBRARY_VERSION") as String
+        project.plugins.apply(PowerSyncVersionPlugin::class.java)
 
+        project.logger.info("Applying the `gradle-maven-publish` plugin")
         project.plugins.apply(MavenPublishPlugin::class.java)
 
         val extension = project.extensions.create(


### PR DESCRIPTION
In https://github.com/powersync-ja/powersync-kotlin/pull/301, we've moved the top-level `allprojects` block responsible for setting the package version into the sonatype publishing plugin.

Since the `:internal:PowerSyncKotlin` project used by the Swift SDK doesn't apply the Sonatype plugin, it doesn't have a version number anymore. This causes AppStore builds of apps using that framework to get rejected.
We shouldn't apply the Sonatype plugin to that project because it's not uploaded to Maven Central, but we can introduce a plugin for just that functionality. I've done that in this PR, and also made the Sonatype plugin apply the version plugin.

I've tested that:

1. Generated frameworks have a bundle identifier again.
2. The version is still applied to the packages we want to upload to Maven Central.
