### PR TITLE
Build `:internal:PowerSyncKotlin` for tvOS

### DIFF
--- a/internal/PowerSyncKotlin/build.gradle.kts
+++ b/internal/PowerSyncKotlin/build.gradle.kts
@@ -31,6 +31,9 @@ kotlin {
         watchosArm64(),
         watchosSimulatorArm64(),
         watchosX64(),
+        tvosSimulatorArm64(),
+        tvosX64(),
+        tvosArm64(),
     ).forEach {
         it.binaries.framework {
             baseName = "PowerSyncKotlin"


### PR DESCRIPTION
While we've been building and testing tvOS builds of the Kotlin SDK for a while, I seemingly forgot to include tvOS as a supported target for the Swift SDK helper framework 🤦.

This adds the missing targets, allowing us to support tvOS in our Swift SDK (I ran unit tests with a local framework build).