### PR TITLE
Prepare 1.10.3 release

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ development=true
 RELEASE_SIGNING_ENABLED=true
 # Library config
 GROUP=com.powersync
-LIBRARY_VERSION=1.10.2
+LIBRARY_VERSION=1.10.3
 GITHUB_REPO=https://github.com/powersync-ja/powersync-kotlin.git
 # POM
 POM_URL=https://github.com/powersync-ja/powersync-kotlin/


### PR DESCRIPTION
This prepares the 1.10.3 release, which:

- Adds support for Ktor 3.4.0: https://github.com/powersync-ja/powersync-kotlin/pull/317
- Updates to Android Gradle Plugin version 9.0: https://github.com/powersync-ja/powersync-kotlin/pull/318
- Prepares tvOS support for our Swift SDK: https://github.com/powersync-ja/powersync-kotlin/pull/315