### PR TITLE
Fix broken release for `:common`

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -106,13 +106,6 @@ kotlin {
     powersyncTargets(
         android = {
             namespace = "com.powersync.common"
-
-            optimization {
-                consumerKeepRules.apply {
-                    publish = true
-                    file("proguard-rules.pro")
-                }
-            }
         }
     )
 


### PR DESCRIPTION
The `common` package used to declare proguard rules in `build.gradle.kts` that don't actually exist (we've moved them to `:core`).

It looks like this was a silent warning in AGP 8.x, it's an error now. This removes the mention from `build.gradle.kts` in order to fix the release.

Since no packages for 1.10.3 have been uploaded to Maven Central, I believe we can simply try the release again.