### PR TITLE
Fix release for sqlite3mcandroid

### DIFF
--- a/internal/sqlite3mcandroid/gradle.properties
+++ b/internal/sqlite3mcandroid/gradle.properties
@@ -1,0 +1,3 @@
+POM_ARTIFACT_ID=sqlite3mcandroid
+POM_NAME=sqlite3mcandroid
+POM_DESCRIPTION=Internal Android library using native builds to bundle SQLite3MultipleCiphers.


### PR DESCRIPTION
`:internal:sqlite3mcandroid` was missing a `gradle.properties` file defining name and description, causing validation failures.

This adds the missing file, I've done a one-off release for this package only to complete the 1.10.4 release.