### PR TITLE
Add in-memory helpers for Swift SDK

### DIFF
--- a/common/src/commonMain/kotlin/com/powersync/PowerSyncDatabase.kt
+++ b/common/src/commonMain/kotlin/com/powersync/PowerSyncDatabase.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.firstOrNull
 import kotlin.coroutines.cancellation.CancellationException
+import kotlin.native.HiddenFromObjC
 
 /**
  * A PowerSync managed database.
@@ -242,6 +243,7 @@ public interface PowerSyncDatabase : Queries {
     @Throws(PowerSyncException::class, CancellationException::class)
     public suspend fun close()
 
+    @HiddenFromObjC
     public companion object PowerSyncOpenFactory {
         /**
          * Creates a PowerSync database managed by an external connection pool.

--- a/internal/PowerSyncKotlin/src/appleMain/kotlin/com/powersync/pool/SwiftSQLiteConnectionPool.kt
+++ b/internal/PowerSyncKotlin/src/appleMain/kotlin/com/powersync/pool/SwiftSQLiteConnectionPool.kt
@@ -1,11 +1,13 @@
 package com.powersync.pool
 
 import co.touchlab.kermit.Logger
+import com.powersync.InMemoryConnectionFactory
 import com.powersync.PowerSyncDatabase
 import com.powersync.db.driver.SQLiteConnectionLease
 import com.powersync.db.driver.SQLiteConnectionPool
 import com.powersync.db.runWrapped
 import com.powersync.db.schema.Schema
+import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -92,6 +94,14 @@ public class SwiftSQLiteConnectionPool(
     }
 }
 
+@OptIn(DelicateCoroutinesApi::class)
+public fun openPowerSyncInMemory(
+    factory: InMemoryConnectionFactory,
+    schema: Schema,
+    logger: Logger,
+): PowerSyncDatabase = PowerSyncDatabase.openInMemory(factory, schema, GlobalScope, logger)
+
+@OptIn(DelicateCoroutinesApi::class)
 public fun openPowerSyncWithPool(
     pool: SQLiteConnectionPool,
     identifier: String,


### PR DESCRIPTION
In tests for our Swift SDK, we use `:memory:` as a file path with the intention of creating in-memory databases. This isn't actually the case though, `:memory:` is appended to the default database directory to create a database file of that name.

This adds a method to `:PowerSyncKotlin` that will let the Swift SDK open in-memory databases. The Swift SDK can't call `PowerSyncDatabase.openInMemory` because that requires a `CoroutineScope` we can't construct in Swift. So I've hidden those methods and added another factory next to `openPowerSyncWithPool` to create an in-memory connection.