### PR TITLE
Avoid reconnect delay on token prefetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Remove the legacy Kotlin sync client. `newSyncClientImplementation` is now the only supported
   option.
+- Avoid reconnect delay on reconnects due to a prefetched token.
 
 ## 1.11.2
 

--- a/common/src/commonIntegrationTest/kotlin/com/powersync/sync/SyncIntegrationTest.kt
+++ b/common/src/commonIntegrationTest/kotlin/com/powersync/sync/SyncIntegrationTest.kt
@@ -787,12 +787,13 @@ class SyncIntegrationTest : AbstractSyncTest() {
                 database.currentStatus.connected shouldBe true
 
                 // After the prefetch completes, we should reconnect
-                val timeToReconnect = scope.testTimeSource.measureTime {
-                    completePrefetch.complete(Unit)
-                    turbine.waitFor { !it.connected }
+                val timeToReconnect =
+                    scope.testTimeSource.measureTime {
+                        completePrefetch.complete(Unit)
+                        turbine.waitFor { !it.connected }
 
-                    turbine.waitFor { it.connected }
-                }
+                        turbine.waitFor { it.connected }
+                    }
                 // We should not wait for the reconnect delay when we reconnect due to a prefetched
                 // token (that's kind of the whole point...).
                 timeToReconnect shouldBe 0.seconds

--- a/common/src/commonIntegrationTest/kotlin/com/powersync/sync/SyncIntegrationTest.kt
+++ b/common/src/commonIntegrationTest/kotlin/com/powersync/sync/SyncIntegrationTest.kt
@@ -41,7 +41,9 @@ import io.ktor.utils.io.core.toByteArray
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.test.testTimeSource
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -51,6 +53,7 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.fail
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.measureTime
 
 class SyncIntegrationTest : AbstractSyncTest() {
     private suspend fun PowerSyncDatabase.expectUserCount(amount: Int) {
@@ -745,6 +748,7 @@ class SyncIntegrationTest : AbstractSyncTest() {
             }
         }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun testTokenPrefetch() =
         databaseTest {
@@ -783,10 +787,16 @@ class SyncIntegrationTest : AbstractSyncTest() {
                 database.currentStatus.connected shouldBe true
 
                 // After the prefetch completes, we should reconnect
-                completePrefetch.complete(Unit)
-                turbine.waitFor { !it.connected }
+                val timeToReconnect = scope.testTimeSource.measureTime {
+                    completePrefetch.complete(Unit)
+                    turbine.waitFor { !it.connected }
 
-                turbine.waitFor { it.connected }
+                    turbine.waitFor { it.connected }
+                }
+                // We should not wait for the reconnect delay when we reconnect due to a prefetched
+                // token (that's kind of the whole point...).
+                timeToReconnect shouldBe 0.seconds
+
                 fetchCredentialsCount shouldBe 2
                 turbine.cancelAndIgnoreRemainingEvents()
             }

--- a/common/src/commonMain/kotlin/com/powersync/bucket/BucketStorage.kt
+++ b/common/src/commonMain/kotlin/com/powersync/bucket/BucketStorage.kt
@@ -72,6 +72,10 @@ internal sealed interface PowerSyncControlArguments {
         override val sqlArguments: Pair<String, Any?> = "line_binary" to line
     }
 
+    data object DidRefreshToken : PowerSyncControlArguments {
+        override val sqlArguments: Pair<String, Any?> = "refreshed_token" to null
+    }
+
     data object CompletedUpload : PowerSyncControlArguments {
         override val sqlArguments: Pair<String, Any?> = "completed_upload" to null
     }

--- a/common/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
+++ b/common/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
@@ -455,7 +455,7 @@ internal class PowerSyncDatabaseImpl(
         val syncJob = syncSupervisorJob
         if (syncJob != null && syncJob.isActive) {
             // Using this exception type will also make the sync job invalidate credentials.
-            syncJob.cancel(DisconnectRequestedException)
+            syncJob.cancel(DisconnectRequestedException())
             syncJob.join()
             syncSupervisorJob = null
         }
@@ -558,4 +558,4 @@ internal class PowerSyncDatabaseImpl(
     }
 }
 
-internal object DisconnectRequestedException : CancellationException("disconnect() called")
+internal class DisconnectRequestedException : CancellationException("disconnect() called")

--- a/common/src/commonMain/kotlin/com/powersync/db/schema/RawTable.kt
+++ b/common/src/commonMain/kotlin/com/powersync/db/schema/RawTable.kt
@@ -1,6 +1,5 @@
 package com.powersync.db.schema
 
-import com.powersync.sync.SyncOptions
 import com.powersync.utils.OnlySerializer
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KSerializer
@@ -30,8 +29,6 @@ import kotlinx.serialization.serializer
  * However, it's the responsibility of the developer to create these raw tables, migrate them when necessary and to
  * write triggers detecting local writes. For more information, see
  * [the documentation page](https://docs.powersync.com/usage/use-case-examples/raw-tables).
- *
- * Note that raw tables are only supported when [SyncOptions.newClientImplementation] is enabled.
  */
 public class RawTable private constructor(
     override val name: String,

--- a/common/src/commonMain/kotlin/com/powersync/sync/StreamingSyncClient.kt
+++ b/common/src/commonMain/kotlin/com/powersync/sync/StreamingSyncClient.kt
@@ -493,7 +493,7 @@ internal class StreamingSyncClient(
                                     logger.v { "Stopping because new credentials are available" }
 
                                     // Token has been refreshed, start another iteration
-                                    controlInvocations.send(PowerSyncControlArguments.Stop)
+                                    controlInvocations.send(PowerSyncControlArguments.DidRefreshToken)
                                 }
                             job.invokeOnCompletion {
                                 credentialsInvalidation = null


### PR DESCRIPTION
After pre-fetching a token (a process we start when the service indicates the current JWT is about to expire), we used to send a `stop` command to `powersync_control`. This causes us to stop the iteration and await a regular retry delay, which defeats the purpose of pre-fetching tokens in the first place.

The simple fix is to use the `refreshed_token` command instead.