### PR TITLE
Mark Room integration as beta

### DIFF
--- a/integrations/room/README.md
+++ b/integrations/room/README.md
@@ -1,7 +1,7 @@
 # PowerSync Room integration
 
 > [!NOTE]
-> Note that this package is currently in alpha.
+> Note that this package is currently in beta.
 
 This module integrates PowerSync with Room databases. This allows you run typed queries against the local database with compile-time validation. 
 


### PR DESCRIPTION
We've originally marked it as alpha since it relied on raw tables which were unstable at the time. Now that raw tables are stable, we can at least mark the Room integration as beta.

(For a stable release, we probably need to look at APIs to derive the client-side schema from a Room schema automatically)