### PR TITLE
Add isInitializing to SyncStatusData to distinguish loading state from empty streams

### DIFF
--- a/common/src/commonIntegrationTest/kotlin/com/powersync/sync/SyncStreamTest.kt
+++ b/common/src/commonIntegrationTest/kotlin/com/powersync/sync/SyncStreamTest.kt
@@ -28,6 +28,33 @@ import kotlin.test.Test
 @OptIn(ExperimentalPowerSyncAPI::class)
 class SyncStreamTest : AbstractSyncTest(true) {
     @Test
+    fun `isInitializing is true before database init and false after`() =
+        databaseTest(createInitialDatabase = false) {
+            database = openDatabase()
+            // Init job is queued but not yet started — isInitializing must be true
+            database.currentStatus.isInitializing shouldBe true
+
+            // readLock suspends until initialization completes (resolveOfflineSyncStatus is called)
+            database.readLock { }
+            database.currentStatus.isInitializing shouldBe false
+        }
+
+    @Test
+    fun `isInitializing remains false after connecting`() =
+        databaseTest {
+            database.currentStatus.isInitializing shouldBe false
+
+            database.connect(connector, options = getOptions())
+            turbineScope {
+                val turbine = database.currentStatus.asFlow().testIn(this)
+                turbine.waitFor { it.connected && !it.downloading }
+
+                database.currentStatus.isInitializing shouldBe false
+                turbine.cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
     fun `can disable default streams`() =
         databaseTest {
             database.connect(

--- a/common/src/commonIntegrationTest/kotlin/com/powersync/sync/SyncStreamTest.kt
+++ b/common/src/commonIntegrationTest/kotlin/com/powersync/sync/SyncStreamTest.kt
@@ -28,28 +28,28 @@ import kotlin.test.Test
 @OptIn(ExperimentalPowerSyncAPI::class)
 class SyncStreamTest : AbstractSyncTest(true) {
     @Test
-    fun `isInitializing is true before database init and false after`() =
+    fun `syncStreams is null before database init and non-null after`() =
         databaseTest(createInitialDatabase = false) {
             database = openDatabase()
-            // Init job is queued but not yet started — isInitializing must be true
-            database.currentStatus.isInitializing shouldBe true
+            // Init job is queued but not yet started — syncStreams must be null
+            database.currentStatus.syncStreams shouldBe null
 
             // readLock suspends until initialization completes (resolveOfflineSyncStatus is called)
             database.readLock { }
-            database.currentStatus.isInitializing shouldBe false
+            database.currentStatus.syncStreams shouldBe emptyList()
         }
 
     @Test
-    fun `isInitializing remains false after connecting`() =
+    fun `syncStreams is empty after connecting with no active streams`() =
         databaseTest {
-            database.currentStatus.isInitializing shouldBe false
+            database.currentStatus.syncStreams shouldBe emptyList()
 
             database.connect(connector, options = getOptions())
             turbineScope {
                 val turbine = database.currentStatus.asFlow().testIn(this)
                 turbine.waitFor { it.connected && !it.downloading }
 
-                database.currentStatus.isInitializing shouldBe false
+                database.currentStatus.syncStreams shouldBe emptyList()
                 turbine.cancelAndIgnoreRemainingEvents()
             }
         }

--- a/common/src/commonMain/kotlin/com/powersync/sync/SyncStatus.kt
+++ b/common/src/commonMain/kotlin/com/powersync/sync/SyncStatus.kt
@@ -93,16 +93,7 @@ public sealed class SyncStatusData {
      */
     public abstract val priorityStatusEntries: List<PriorityStatusEntry>
 
-    /**
-     * true while the sync system is still being initialized from the database, before any
-     * sync status has been received from the core extension.
-     *
-     * Becomes false after the first status update from the core, at which point [syncStreams]
-     * and related properties reflect a reliable state (empty or not).
-     */
-    public abstract val isInitializing: Boolean
-
-    internal abstract val internalSubscriptions: List<CoreActiveStreamSubscription>
+    internal abstract val internalSubscriptions: List<CoreActiveStreamSubscription>?
 
     /**
      * Status information for whether buckets in [priority] have been synchronized.
@@ -125,17 +116,18 @@ public sealed class SyncStatusData {
     /**
      * All sync streams currently being tracked in the database.
      *
-     * Returns an empty list both before and after initialization. Use [isInitializing] to
-     * distinguish the initial loading state from a confirmed empty list of streams.
+     * Returns null when the database is currently being opened and we don't have reliable
+     * information about included streams yet. Once non-null, an empty list means the database
+     * is initialized but no streams are active.
      */
-    public val syncStreams: List<SyncStreamStatus>? get() = internalSubscriptions.map(this::exposeStreamStatus)
+    public val syncStreams: List<SyncStreamStatus>? get() = internalSubscriptions?.map(this::exposeStreamStatus)
 
     /**
      * Status information for [stream], if it's a stream that is currently tracked by the sync
      * client.
      */
     public fun forStream(stream: SyncStreamDescription): SyncStreamStatus? {
-        val raw = internalSubscriptions.firstOrNull { it.name == stream.name && it.parameters == stream.parameters } ?: return null
+        val raw = internalSubscriptions?.firstOrNull { it.name == stream.name && it.parameters == stream.parameters } ?: return null
         return exposeStreamStatus(raw)
     }
 
@@ -164,8 +156,7 @@ internal data class SyncStatusDataContainer(
     override val uploadError: Any? = null,
     override val downloadError: Any? = null,
     override val priorityStatusEntries: List<PriorityStatusEntry> = emptyList(),
-    override val isInitializing: Boolean = true,
-    override val internalSubscriptions: List<CoreActiveStreamSubscription> = emptyList(),
+    override val internalSubscriptions: List<CoreActiveStreamSubscription>? = null,
 ) : SyncStatusData() {
     override val anyError
         get() = downloadError ?: uploadError
@@ -188,7 +179,6 @@ internal data class SyncStatusDataContainer(
                         hasSynced = it.hasSynced,
                     )
                 },
-            isInitializing = false,
             internalSubscriptions = status.streams,
         )
     }
@@ -252,10 +242,7 @@ public data class SyncStatus internal constructor(
     override val priorityStatusEntries: List<PriorityStatusEntry>
         get() = data.priorityStatusEntries
 
-    override val isInitializing: Boolean
-        get() = data.isInitializing
-
-    override val internalSubscriptions: List<CoreActiveStreamSubscription>
+    override val internalSubscriptions: List<CoreActiveStreamSubscription>?
         get() = data.internalSubscriptions
 
     override fun toString(): String =

--- a/common/src/commonMain/kotlin/com/powersync/sync/SyncStatus.kt
+++ b/common/src/commonMain/kotlin/com/powersync/sync/SyncStatus.kt
@@ -93,7 +93,16 @@ public sealed class SyncStatusData {
      */
     public abstract val priorityStatusEntries: List<PriorityStatusEntry>
 
-    internal abstract val internalSubscriptions: List<CoreActiveStreamSubscription>?
+    /**
+     * true while the sync system is still being initialized from the database, before any
+     * sync status has been received from the core extension.
+     *
+     * Becomes false after the first status update from the core, at which point [syncStreams]
+     * and related properties reflect a reliable state (empty or not).
+     */
+    public abstract val isInitializing: Boolean
+
+    internal abstract val internalSubscriptions: List<CoreActiveStreamSubscription>
 
     /**
      * Status information for whether buckets in [priority] have been synchronized.
@@ -116,17 +125,17 @@ public sealed class SyncStatusData {
     /**
      * All sync streams currently being tracked in the database.
      *
-     * This returns null when the database is currently being opened and we don't have reliable
-     * information about included streams yet.
+     * Returns an empty list both before and after initialization. Use [isInitializing] to
+     * distinguish the initial loading state from a confirmed empty list of streams.
      */
-    public val syncStreams: List<SyncStreamStatus>? get() = internalSubscriptions?.map(this::exposeStreamStatus)
+    public val syncStreams: List<SyncStreamStatus>? get() = internalSubscriptions.map(this::exposeStreamStatus)
 
     /**
      * Status information for [stream], if it's a stream that is currently tracked by the sync
      * client.
      */
     public fun forStream(stream: SyncStreamDescription): SyncStreamStatus? {
-        val raw = internalSubscriptions?.firstOrNull { it.name == stream.name && it.parameters == stream.parameters } ?: return null
+        val raw = internalSubscriptions.firstOrNull { it.name == stream.name && it.parameters == stream.parameters } ?: return null
         return exposeStreamStatus(raw)
     }
 
@@ -155,6 +164,7 @@ internal data class SyncStatusDataContainer(
     override val uploadError: Any? = null,
     override val downloadError: Any? = null,
     override val priorityStatusEntries: List<PriorityStatusEntry> = emptyList(),
+    override val isInitializing: Boolean = true,
     override val internalSubscriptions: List<CoreActiveStreamSubscription> = emptyList(),
 ) : SyncStatusData() {
     override val anyError
@@ -178,6 +188,7 @@ internal data class SyncStatusDataContainer(
                         hasSynced = it.hasSynced,
                     )
                 },
+            isInitializing = false,
             internalSubscriptions = status.streams,
         )
     }
@@ -240,6 +251,9 @@ public data class SyncStatus internal constructor(
 
     override val priorityStatusEntries: List<PriorityStatusEntry>
         get() = data.priorityStatusEntries
+
+    override val isInitializing: Boolean
+        get() = data.isInitializing
 
     override val internalSubscriptions: List<CoreActiveStreamSubscription>
         get() = data.internalSubscriptions


### PR DESCRIPTION
## Summary

`SyncStatusData.syncStreams` returned an empty list `[]` in two distinct situations that were previously indistinguishable:

- **During initial database setup** — before the core extension emits any sync status, `internalSubscriptions` defaulted to `emptyList()`, making it impossible to know whether the database was still opening or whether there were genuinely no active streams.
- **After sync, with no active streams** — a legitimate state where the database is fully initialized but no streams are being tracked.

This meant consumers could not reliably react to the initial loading state without waiting for `downloading`, `connecting`, or other flags that only become available after a connection attempt.

## Solution

Added a boolean attribute `isInitializing` to `SyncStatusData`:

- Defaults to `true` in `SyncStatusDataContainer`, representing the period before the first core status update.
- Set to `false` in `applyCoreChanges()`, called by `resolveOfflineSyncStatus()` during database initialization.
- No nullable types introduced — `syncStreams` continues to return a non-null list at all times.

```kotlin
  when {
      status.isInitializing       -> // DB still opening, state unknown
      status.syncStreams.isEmpty() -> // initialized, no active streams
      else                        -> // initialized, streams available
  }
```

## Tests

Added two integration tests in SyncStreamTest:
- isInitializing is true before database init and false after — verifies the true → false transition
- isInitializing remains false after connecting — verifies connecting does not reset the flag