### PR TITLE
Sync Streams: Allow array and object parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.12.1 (unreleased)
+
+- Fix sync status to make `syncStreams` return null when the database is initializing.
+- Fix errors when subscribing to Sync Streams with object or array parameters.
+
 ## 1.12.0
 
 - Remove the legacy Kotlin sync client. `newSyncClientImplementation` is now the only supported

--- a/common/src/commonIntegrationTest/kotlin/com/powersync/sync/SyncStreamTest.kt
+++ b/common/src/commonIntegrationTest/kotlin/com/powersync/sync/SyncStreamTest.kt
@@ -214,45 +214,52 @@ class SyncStreamTest : AbstractSyncTest(true) {
         }
 
     @Test
-    fun `can subscribe with object and array parameters`() = databaseTest {
-        // Regression test for https://github.com/powersync-ja/powersync-kotlin/issues/349.
-        val stream = database.syncStream(
-            "stream",
-            mapOf(
-                "a" to JsonParam.Collection(listOf(
-                    JsonParam.String("foo"),
-                    JsonParam.String("bar"),
-                )),
-                "b" to JsonParam.Map(mapOf("foo" to JsonParam.String("bar")))
-            )
-        ).subscribe()
+    fun `can subscribe with object and array parameters`() =
+        databaseTest {
+            // Regression test for https://github.com/powersync-ja/powersync-kotlin/issues/349.
+            val stream =
+                database
+                    .syncStream(
+                        "stream",
+                        mapOf(
+                            "a" to
+                                JsonParam.Collection(
+                                    listOf(
+                                        JsonParam.String("foo"),
+                                        JsonParam.String("bar"),
+                                    ),
+                                ),
+                            "b" to JsonParam.Map(mapOf("foo" to JsonParam.String("bar"))),
+                        ),
+                    ).subscribe()
 
-        database.connect(connector, options = getOptions())
-        turbineScope {
-            val turbine = database.currentStatus.asFlow().testIn(this)
-            turbine.waitFor { it.connected && !it.downloading }
+            database.connect(connector, options = getOptions())
+            turbineScope {
+                val turbine = database.currentStatus.asFlow().testIn(this)
+                turbine.waitFor { it.connected && !it.downloading }
 
-            requestedSyncStreams shouldHaveSingleElement {
-                val streams = it.jsonObject["streams"]!!.jsonObject
-                val subscriptions = streams["subscriptions"]!!.jsonArray
+                requestedSyncStreams shouldHaveSingleElement {
+                    val streams = it.jsonObject["streams"]!!.jsonObject
+                    val subscriptions = streams["subscriptions"]!!.jsonArray
 
-                subscriptions shouldHaveSize 1
-                JsonUtil.json.encodeToString(subscriptions[0]) shouldBe
+                    subscriptions shouldHaveSize 1
+                    JsonUtil.json.encodeToString(subscriptions[0]) shouldBe
                         """{"stream":"stream","parameters":{"a":["foo","bar"],"b":{"foo":"bar"}},"override_priority":null}"""
-                true
+                    true
+                }
+
+                turbine.cancelAndIgnoreRemainingEvents()
             }
 
-            turbine.cancelAndIgnoreRemainingEvents()
+            val streams = database.currentStatus.syncStreams!!
+            streams shouldHaveSize 1
+            streams[0].subscription.parameters shouldBe
+                mapOf(
+                    "a" to listOf("foo", "bar"),
+                    "b" to mapOf("foo" to "bar"),
+                )
+            stream.unsubscribe()
         }
-
-        val streams = database.currentStatus.syncStreams!!
-        streams shouldHaveSize 1
-        streams[0].subscription.parameters shouldBe mapOf(
-            "a" to listOf("foo", "bar"),
-            "b" to mapOf("foo" to "bar"),
-        )
-        stream.unsubscribe()
-    }
 
     @Test
     fun `subscriptions update while offline`() =

--- a/common/src/commonIntegrationTest/kotlin/com/powersync/sync/SyncStreamTest.kt
+++ b/common/src/commonIntegrationTest/kotlin/com/powersync/sync/SyncStreamTest.kt
@@ -214,6 +214,47 @@ class SyncStreamTest : AbstractSyncTest(true) {
         }
 
     @Test
+    fun `can subscribe with object and array parameters`() = databaseTest {
+        // Regression test for https://github.com/powersync-ja/powersync-kotlin/issues/349.
+        val stream = database.syncStream(
+            "stream",
+            mapOf(
+                "a" to JsonParam.Collection(listOf(
+                    JsonParam.String("foo"),
+                    JsonParam.String("bar"),
+                )),
+                "b" to JsonParam.Map(mapOf("foo" to JsonParam.String("bar")))
+            )
+        ).subscribe()
+
+        database.connect(connector, options = getOptions())
+        turbineScope {
+            val turbine = database.currentStatus.asFlow().testIn(this)
+            turbine.waitFor { it.connected && !it.downloading }
+
+            requestedSyncStreams shouldHaveSingleElement {
+                val streams = it.jsonObject["streams"]!!.jsonObject
+                val subscriptions = streams["subscriptions"]!!.jsonArray
+
+                subscriptions shouldHaveSize 1
+                JsonUtil.json.encodeToString(subscriptions[0]) shouldBe
+                        """{"stream":"stream","parameters":{"a":["foo","bar"],"b":{"foo":"bar"}},"override_priority":null}"""
+                true
+            }
+
+            turbine.cancelAndIgnoreRemainingEvents()
+        }
+
+        val streams = database.currentStatus.syncStreams!!
+        streams shouldHaveSize 1
+        streams[0].subscription.parameters shouldBe mapOf(
+            "a" to listOf("foo", "bar"),
+            "b" to mapOf("foo" to "bar"),
+        )
+        stream.unsubscribe()
+    }
+
+    @Test
     fun `subscriptions update while offline`() =
         databaseTest {
             turbineScope {

--- a/common/src/commonMain/kotlin/com/powersync/db/crud/SerializedRow.kt
+++ b/common/src/commonMain/kotlin/com/powersync/db/crud/SerializedRow.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.descriptors.serialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
@@ -88,17 +89,26 @@ private data class ToTypedEntry(
     override val key: String
         get() = inner.key
     override val value: Any?
-        get() = inner.value.jsonPrimitive.asData()
+        get() = inner.value.asData()
 
     companion object {
-        private fun JsonPrimitive.asData(): Any? =
-            if (this === JsonNull) {
-                null
-            } else if (isString) {
-                content
-            } else {
-                content.jsonNumberOrBoolean()
+        private fun JsonElement.asData(): Any? {
+            return when (this) {
+                // Note: Array and object values never appear in a CRUD row (they would be
+                // represented as strings instead). We also use TypedRows to represent stream
+                // parameters though, and those can be arrays/objects.
+                is JsonArray -> map { it.asData() }
+                is JsonObject -> mapValues { it.value.asData() }
+                JsonNull -> null
+                is JsonPrimitive -> {
+                    if (isString) {
+                        content
+                    } else {
+                        content.jsonNumberOrBoolean()
+                    }
+                }
             }
+        }
 
         private fun String.jsonNumberOrBoolean(): Any =
             when {

--- a/common/src/commonMain/kotlin/com/powersync/db/crud/SerializedRow.kt
+++ b/common/src/commonMain/kotlin/com/powersync/db/crud/SerializedRow.kt
@@ -92,8 +92,8 @@ private data class ToTypedEntry(
         get() = inner.value.asData()
 
     companion object {
-        private fun JsonElement.asData(): Any? {
-            return when (this) {
+        private fun JsonElement.asData(): Any? =
+            when (this) {
                 // Note: Array and object values never appear in a CRUD row (they would be
                 // represented as strings instead). We also use TypedRows to represent stream
                 // parameters though, and those can be arrays/objects.
@@ -108,7 +108,6 @@ private data class ToTypedEntry(
                     }
                 }
             }
-        }
 
         private fun String.jsonNumberOrBoolean(): Any =
             when {


### PR DESCRIPTION
When subscribing to a Sync Stream with an array or object parameter, the mapping in `TypedRow` attempting to map that value to Kotlin would fail because it only supports primitive values.

Ideally, we should have used `Map<String, JsonParam>` to represent parameters on stream. Doing that would be a breaking change now though, so we have to keep mapping values to Kotlin. So, this adds support for object and arrays to `TypedRow`.

Closes https://github.com/powersync-ja/powersync-kotlin/issues/349.