### PR TITLE
Fix read-pool lease leak that deadlocks updateSchema (#356)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - __Breaking change__: Aligning with Kotlin and Androidx multiplatform libraries, this 
   release removes support for `x86_64` Apple targets (`iosX64()`, `macosX64()`, `tvosX64()` and `watchosX64()`).
+- Fix a deadlock where a read query cancelled at the wrong moment would permanently leak a
+  connection from the read pool, eventually causing `updateSchema()` (and other operations that
+  acquire all connections) to hang. This is the underlying cause of #356.
 - Fix sync status to make `syncStreams` return null when the database is initializing.
 - Fix errors when subscribing to Sync Streams with object or array parameters.
 - Support versions 3.6.0 of the Supabase client libraries.

--- a/common/src/commonIntegrationTest/kotlin/com/powersync/ReadPoolLeaseLeakTest.kt
+++ b/common/src/commonIntegrationTest/kotlin/com/powersync/ReadPoolLeaseLeakTest.kt
@@ -1,0 +1,95 @@
+package com.powersync
+
+import co.touchlab.kermit.Logger
+import co.touchlab.kermit.Severity
+import co.touchlab.kermit.StaticConfig
+import co.touchlab.kermit.platformLogWriter
+import com.powersync.db.schema.Schema
+import com.powersync.test.factory
+import com.powersync.test.getTempDir
+import com.powersync.testutils.UserRow
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.test.Test
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Regression test for https://github.com/powersync-ja/powersync-kotlin/issues/356
+ *
+ * A `read {}` (or the `withAllConnections` acquisition loop) cancelled during the channel
+ * rendezvous used to silently drop its connection lease: the element was handed to the channel
+ * but the cancelled receiver never ran the `done.complete(Unit)` in its `finally`, so the owning
+ * read worker parked in `done.await()` forever and the connection was permanently lost from the
+ * pool. After even one such leak, `ReadPool.withAllConnections` (used by `updateSchema`) can never
+ * acquire all connections and deadlocks while holding the database mutex.
+ *
+ * This must run on real dispatchers - the cancellation race does not surface under the
+ * single-threaded virtual-time test dispatcher.
+ */
+class ReadPoolLeaseLeakTest {
+    @Test
+    fun updateSchemaSurvivesConcurrentReadCancellation() =
+        runBlocking(Dispatchers.Default) {
+            val logger =
+                Logger(
+                    StaticConfig(
+                        minSeverity = Severity.Warn,
+                        logWriterList = listOf(platformLogWriter()),
+                    ),
+                )
+            val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+            val schema = Schema(UserRow.table)
+
+            val db =
+                createPowerSyncDatabaseImpl(
+                    factory = factory,
+                    schema = schema,
+                    dbFilename = "leak-test-${(0..1_000_000).random()}.db",
+                    dbDirectory = getTempDir(),
+                    logger = logger,
+                    scope = scope,
+                )
+
+            try {
+                // Force initialization so the read workers are up and offering connections.
+                db.readLock { }
+
+                // Hammer the read pool with reads that are cancelled at varied points, under
+                // contention. A read cancelled during the channel rendezvous leaks its connection
+                // lease permanently (pre-fix), after which withAllConnections() can never get all
+                // connections.
+                val attackers =
+                    List(64) {
+                        scope.launch(Dispatchers.Default) {
+                            repeat(2_000) { i ->
+                                // 0ms cancels essentially immediately (most likely to land in the
+                                // handoff); 1ms/2ms spread the cancellation across other points.
+                                withTimeoutOrNull((i % 3).milliseconds) { db.readLock { } }
+                            }
+                        }
+                    }
+                attackers.joinAll()
+
+                // If any lease leaked, the pool is permanently short and this never returns.
+                // PRE-FIX: times out. POST-FIX: completes in a few ms.
+                withTimeout(10.seconds) {
+                    db.updateSchema(schema)
+                }
+            } finally {
+                // If a lease leaked, readPool.close() -> connections.joinAll() would itself block
+                // forever on the worker parked in done.await(). Bound the cleanup so the test fails
+                // fast on the updateSchema timeout instead of hanging; cancelling the scope tears
+                // down any leaked worker either way.
+                withTimeoutOrNull(5.seconds) { db.close() }
+                scope.cancel()
+            }
+        }
+}

--- a/common/src/commonMain/kotlin/com/powersync/db/driver/ReadPool.kt
+++ b/common/src/commonMain/kotlin/com/powersync/db/driver/ReadPool.kt
@@ -21,7 +21,16 @@ internal class ReadPool(
     size: Int = 5,
     private val scope: CoroutineScope,
 ) {
-    private val available = Channel<Pair<SQLiteConnection, CompletableDeferred<Unit>>>()
+    private val available =
+        Channel<Pair<SQLiteConnection, CompletableDeferred<Unit>>>(
+            // If an element is sent but not delivered - e.g. the receiving read()/withAllConnections
+            // coroutine was cancelled during the channel rendezvous, or the channel is closed with an
+            // element in flight - complete its `done` so the owning worker returns the connection to
+            // the pool instead of parking in done.await() forever. Without this, a single read
+            // cancelled at the wrong moment permanently shrinks the pool and deadlocks any later
+            // withAllConnections()/updateSchema().
+            onUndeliveredElement = { (_, done) -> done.complete(Unit) },
+        )
     private val connections: List<Job> =
         List(size) {
             val driver = factory()


### PR DESCRIPTION
## What

`ReadPool`'s connection-lease handoff channel (`available`) lacked an `onUndeliveredElement` handler. When a `read {}` (or the `withAllConnections` acquisition loop) is **cancelled during the channel rendezvous** — after a worker `send`s `(connection, done)` but before the receiver delivers it into its `try/finally` — the element is silently dropped. `done.complete(Unit)` is never called, so that worker parks in `done.await()` **forever** and the connection is permanently lost from the pool.

Once any lease leaks, `ReadPool.withAllConnections { repeat(size) { available.receive() } }` can never acquire all connections and **hangs forever**. `updateSchema()` reaches the pool through exactly this path:

```
PowerSyncDatabaseImpl.updateSchema
  → mutex.withLock
    → InternalDatabaseImpl.updateSchema
      → InternalConnectionPool.withAllConnections
        → ReadPool.withAllConnections → repeat(size){ available.receive() }
```

so a single leaked read lease wedges `updateSchema` indefinitely while it holds the database mutex.

## Why #356 looked schema-related

It isn't about passing the same `Schema` instance or about `connect()`. The reporter's app calls `updateSchema` on cold start while concurrent `watch()` queries are being cancelled (auth churn over a dead/slow network) — that cancellation is what leaks the lease. A standalone `updateSchema` with no concurrent reads (the minimal repro) never leaks, which is why it passed.

## Fix

Add `onUndeliveredElement` to the `available` channel:

```kotlin
onUndeliveredElement = { (_, done) -> done.complete(Unit) }
```

`onUndeliveredElement` fires exactly when an element was handed to the channel but not received (cancelled receiver, or `close()`/`cancel()` with an in-flight element). Completing `done` returns the connection to circulation. `CompletableDeferred.complete()` is idempotent and non-suspending, so there's no double-completion hazard with the normal `finally` paths. This covers both leak windows — `read()` and the `withAllConnections` `add(receive())` gap — and the close path.

## How we found this

A thread dump was useless — every thread was idle/parked with no SQLite or native frame (a suspended-coroutine deadlock, not a blocked thread). Coroutine debug probes are inert on Android/ART, so we reflected into the live pool from a debug build at the moment of the hang: all 5 read workers alive, DB mutex held, `writeLockMutex` still free, but one connection checked out and never returned — i.e. `withAllConnections` stuck on its final `available.receive()` after a leaked read lease. That pointed straight at `ReadPool` and the missing `onUndeliveredElement`.

## Test

`ReadPoolLeaseLeakTest` hammers the read pool with concurrent reads cancelled at varied points, then asserts `updateSchema` completes under a timeout. It runs on real dispatchers (the race is hidden by the virtual-time test dispatcher).

- **Before the fix:** fails with `TimeoutCancellationException` from `updateSchema`.
- **After the fix:** passes in a few ms.

Full `:common:jvmTest` suite: 130 tests, 0 failures.

Fixes #356.
