### PR TITLE
Avoid forwarding writes on shadow tables to Room

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.13.0 (unreleased)
+## 1.13.0
 
 - __Breaking change__: Aligning with Kotlin and Androidx multiplatform libraries, this 
   release removes support for `x86_64` Apple targets (`iosX64()`, `macosX64()`, `tvosX64()` and `watchosX64()`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   acquire all connections) to hang. This is the underlying cause of #356.
 - Fix sync status to make `syncStreams` return null when the database is initializing.
 - Fix errors when subscribing to Sync Streams with object or array parameters.
+- Room integration: Fix writes to fts5 tables crashing the update notification mechanism.
 - Support versions 3.6.0 of the Supabase client libraries.
 
 ## 1.12.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ development=true
 RELEASE_SIGNING_ENABLED=true
 # Library config
 GROUP=com.powersync
-LIBRARY_VERSION=1.12.0
+LIBRARY_VERSION=1.13.0
 GITHUB_REPO=https://github.com/powersync-ja/powersync-kotlin.git
 # POM
 POM_URL=https://github.com/powersync-ja/powersync-kotlin/

--- a/integrations/room/src/commonIntegrationTest/kotlin/com/powersync/integrations/room/PowerSyncRoomTest.kt
+++ b/integrations/room/src/commonIntegrationTest/kotlin/com/powersync/integrations/room/PowerSyncRoomTest.kt
@@ -139,6 +139,25 @@ class PowerSyncRoomTest {
             powersync.close()
         }
 
+    @Test
+    fun canWriteToVirtualTables() =
+        runTest {
+            val pool = RoomConnectionPool(database, TestDatabase.schema)
+            val powersync =
+                PowerSyncDatabase.opened(
+                    pool = pool,
+                    scope = this,
+                    schema = TestDatabase.schema,
+                    identifier = "test",
+                    logger = logger,
+                )
+
+            // After inserting into a virtual table, we should not report shadow tables as updates to
+            // Room as that causes a crash. This also means that virtual table updates can't be watched
+            // from Room, but that's a Room limitation.
+            powersync.execute("INSERT into users_fts(id, name) VAlUES (uuid(), ?)", listOf("test name"))
+        }
+
     companion object {
         private val logger = Logger(loggerConfigInit(CommonWriter()))
     }

--- a/integrations/room/src/commonIntegrationTest/kotlin/com/powersync/integrations/room/PowerSyncRoomTest.kt
+++ b/integrations/room/src/commonIntegrationTest/kotlin/com/powersync/integrations/room/PowerSyncRoomTest.kt
@@ -155,7 +155,7 @@ class PowerSyncRoomTest {
             // After inserting into a virtual table, we should not report shadow tables as updates to
             // Room as that causes a crash. This also means that virtual table updates can't be watched
             // from Room, but that's a Room limitation.
-            powersync.execute("INSERT into users_fts(id, name) VAlUES (uuid(), ?)", listOf("test name"))
+            powersync.execute("INSERT into users_fts(id, name) VALUES (uuid(), ?)", listOf("test name"))
         }
 
     companion object {

--- a/integrations/room/src/commonIntegrationTest/kotlin/com/powersync/integrations/room/TestDatabase.kt
+++ b/integrations/room/src/commonIntegrationTest/kotlin/com/powersync/integrations/room/TestDatabase.kt
@@ -10,6 +10,8 @@ import androidx.room.PrimaryKey
 import androidx.room.Query
 import androidx.room.RoomDatabase
 import androidx.room.RoomDatabaseConstructor
+import androidx.sqlite.SQLiteConnection
+import androidx.sqlite.execSQL
 import com.powersync.db.schema.RawTable
 import com.powersync.db.schema.RawTableSchema
 import com.powersync.db.schema.Schema
@@ -41,7 +43,7 @@ interface UserDao {
 abstract class TestDatabase : RoomDatabase() {
     abstract fun userDao(): UserDao
 
-    companion object {
+    companion object : Callback() {
         val schema =
             Schema(
                 RawTable(
@@ -49,6 +51,10 @@ abstract class TestDatabase : RoomDatabase() {
                     schema = RawTableSchema("user"),
                 ),
             )
+
+        override fun onOpen(connection: SQLiteConnection) {
+            connection.execSQL("CREATE VIRTUAL TABLE users_fts USING fts5(id UNINDEXED, name)")
+        }
     }
 }
 

--- a/integrations/room/src/commonMain/kotlin/com/powersync/integrations/room/RoomConnectionPool.kt
+++ b/integrations/room/src/commonMain/kotlin/com/powersync/integrations/room/RoomConnectionPool.kt
@@ -115,7 +115,7 @@ public class RoomConnectionPool(
                 it.usePrepared(statement) { stmt ->
                     while (stmt.step()) {
                         val table = stmt.getText(0)
-                        val type = stmt.getText(1)
+                        val type = if (stmt.isNull(1)) null else stmt.getText(1)
                         allChangedTables.add(table)
                         if (type == "table" && !table.startsWith("ps_") && !table.startsWith("room_")) {
                             changedRoomTables.add(table)

--- a/integrations/room/src/commonMain/kotlin/com/powersync/integrations/room/RoomConnectionPool.kt
+++ b/integrations/room/src/commonMain/kotlin/com/powersync/integrations/room/RoomConnectionPool.kt
@@ -100,23 +100,34 @@ public class RoomConnectionPool(
             try {
                 callback(RoomTransactionLease(it, currentCoroutineContext()))
             } finally {
-                val changed =
-                    it.usePrepared("SELECT powersync_update_hooks('get')") { stmt ->
-                        check(stmt.step())
-                        Json.decodeFromString<Set<String>>(stmt.getText(0))
+                // List changed tables, excluding virtual and shadow tables for e.g. fts5
+                val statement =
+                    """
+                    SELECT
+                        value,
+                        (SELECT type FROM pragma_table_list(value))
+                    FROM json_each(powersync_update_hooks('get'))
+                    """.trimIndent()
+
+                val allChangedTables = mutableSetOf<String>()
+                val changedRoomTables = mutableListOf<String>()
+
+                it.usePrepared(statement) { stmt ->
+                    while (stmt.step()) {
+                        val table = stmt.getText(0)
+                        val type = stmt.getText(1)
+                        allChangedTables.add(table)
+                        if (type == "table" && !table.startsWith("ps_") && !table.startsWith("room_")) {
+                            changedRoomTables.add(table)
+                        }
                     }
-
-                val userTables =
-                    changed
-                        .filter { tbl ->
-                            !tbl.startsWith("ps_") && !tbl.startsWith("room_")
-                        }.toTypedArray()
-
-                if (userTables.isNotEmpty()) {
-                    db.invalidationTracker.refresh(*userTables)
                 }
 
-                _updates.emit(changed)
+                if (changedRoomTables.isNotEmpty()) {
+                    db.invalidationTracker.refresh(*changedRoomTables.toTypedArray())
+                }
+
+                _updates.emit(allChangedTables)
             }
         }
 

--- a/integrations/room/src/jvmTest/kotlin/com/powersync/integrations/room/Utils.jvm.kt
+++ b/integrations/room/src/jvmTest/kotlin/com/powersync/integrations/room/Utils.jvm.kt
@@ -3,4 +3,5 @@ package com.powersync.integrations.room
 import androidx.room.Room
 import androidx.room.RoomDatabase
 
-actual fun createDatabaseBuilder(): RoomDatabase.Builder<TestDatabase> = Room.inMemoryDatabaseBuilder<TestDatabase>()
+actual fun createDatabaseBuilder(): RoomDatabase.Builder<TestDatabase> =
+    Room.inMemoryDatabaseBuilder<TestDatabase>().addCallback(TestDatabase)

--- a/integrations/room/src/nativeTest/kotlin/com/powersync/integrations/room/Utils.native.kt
+++ b/integrations/room/src/nativeTest/kotlin/com/powersync/integrations/room/Utils.native.kt
@@ -3,4 +3,5 @@ package com.powersync.integrations.room
 import androidx.room.Room
 import androidx.room.RoomDatabase
 
-actual fun createDatabaseBuilder(): RoomDatabase.Builder<TestDatabase> = Room.inMemoryDatabaseBuilder()
+actual fun createDatabaseBuilder(): RoomDatabase.Builder<TestDatabase> =
+    Room.inMemoryDatabaseBuilder<TestDatabase>().addCallback(TestDatabase)


### PR DESCRIPTION
For the Room integration, we use the update hook from the core extension to track writes made through PowerSync APIs. Calling `invalidationTracker.refresh` in Room is only allowed for tables tracked by the Room schema of the database, passing another table makes that method throw.

Before this PR, we filtered out internal Room and PowerSync tables and otherwise forwarded all changes. But when an fts5 table is used, we may also get notifications for internal shadow tables (like `fts_data`, `fts_docsize` and others). These also shouldn't be forwarded to Room. This PR adds a check to stop forwarding these.

This also prepares the 1.13.0 release.