### PR TITLE
Fix structure of Sonatype bundle

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Inspect publication
         run: |
           ./internal/analyze-bundle.py
-          zip -r build/sonatypeBundle.zip build/sonatypeBundle/
+          cd build/sonatypeBundle && zip -r ../sonatypeBundle.zip .
 
       - name: Upload to Maven Central
         env:
@@ -110,4 +110,3 @@ jobs:
           GH_REPO: ${{ github.repository }}
         run: |
           gh release upload "${{ needs.draft_release.outputs.tag }}" prebuilt_libraries.zip
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.14.1
+
+- Fix publish structure for Sonatype bundles.
+
 ## 1.14.0
 
 - __Breaking change__ (for Room integration): The Room integration uses Room 3.0 now.

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ development=true
 RELEASE_SIGNING_ENABLED=true
 # Library config
 GROUP=com.powersync
-LIBRARY_VERSION=1.14.0
+LIBRARY_VERSION=1.14.1
 GITHUB_REPO=https://github.com/powersync-ja/powersync-kotlin.git
 # POM
 POM_URL=https://github.com/powersync-ja/powersync-kotlin/


### PR DESCRIPTION
In https://github.com/powersync-ja/powersync-kotlin/pull/359, the publishing workflow was changed to manually generate the publishing bundle and then archive + upload it to Maven Central.

The structure of the `build/sonatypeBundle` directory is fine, but we archive it using `zip -r build/sonatypeBundle.zip build/sonatypeBundle/`. This keeps the `build/sonatypeBundle` path prefix in the zip, which means the bundle is [invalid](https://central.sonatype.org/publish/publish-portal-upload/) and causes validation errors like the following:

```
File path 'build/sonatypeBundle/com/powersync/integration-room-macosarm64/1.14.0' is not valid for file 'integration-room-macosarm64-1.14.0-javadoc.jar.sha256'
```

This creates the bundle in a way that doesn't include the prefix, and prepares a patch release to retry.

AI use: I suspected it was due to this after seeing the error message, but I let Claude scan the original `build/sonatypeBundle` structure and generate the fix.