### PR TITLE
New checkpoint request protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Update Kotlin to 2.4.10.
 - Compile against Android SDK 37.
 - Web: Use navigator locks to guard the sync client.
+- Add `SyncOptions.checkpointMode`. When set to `CheckpointMode.Requests()`, the sync client uses a
+  a new protocol for checkpoints after crud uploads with better support for switching users.
 
 ## 1.14.1
 

--- a/common/src/commonIntegrationTest/kotlin/com/powersync/DatabaseTest.kt
+++ b/common/src/commonIntegrationTest/kotlin/com/powersync/DatabaseTest.kt
@@ -23,6 +23,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.cancelAndJoin
@@ -98,7 +99,8 @@ class DatabaseTest {
 
     @Test
     fun testConcurrentReads() =
-        databaseTest {
+        databaseTest(createInitialDatabase = false) {
+            database = openDatabase(databaseIoDispatcher = Dispatchers.IO)
             database.execute(
                 "INSERT INTO users (id, name, email) VALUES (uuid(), ?, ?)",
                 listOf(
@@ -254,7 +256,8 @@ class DatabaseTest {
 
     @Test
     fun testClosingReadPool() =
-        databaseTest {
+        databaseTest(createInitialDatabase = false) {
+            database = openDatabase(databaseIoDispatcher = Dispatchers.IO)
             val pausedLock = CompletableDeferred<Unit>()
             val inLock = CompletableDeferred<Unit>()
             // Request a lock

--- a/common/src/commonIntegrationTest/kotlin/com/powersync/sync/AbstractSyncTest.kt
+++ b/common/src/commonIntegrationTest/kotlin/com/powersync/sync/AbstractSyncTest.kt
@@ -1,7 +1,9 @@
 package com.powersync.sync
 
 import com.powersync.ExperimentalPowerSyncAPI
+import com.powersync.PowerSyncDatabase
 import com.powersync.testutils.ActiveDatabaseTest
+import kotlinx.coroutines.flow.first
 
 /**
  * Small utility to run tests both with the legacy Kotlin sync implementation and the new
@@ -10,6 +12,15 @@ import com.powersync.testutils.ActiveDatabaseTest
 abstract class AbstractSyncTest(
     protected val useBson: Boolean = false,
 ) {
+    protected suspend fun PowerSyncDatabase.waitForStatus(predicate: (SyncStatusData) -> Boolean) {
+        this.currentStatus.asFlow().first { status ->
+            if (predicate(status)) return@first true
+
+            status.anyError?.let { error("Unexpected error in $status") }
+            false
+        }
+    }
+
     @OptIn(ExperimentalPowerSyncAPI::class)
     internal fun ActiveDatabaseTest.getOptions(): SyncOptions =
         SyncOptions(

--- a/common/src/commonIntegrationTest/kotlin/com/powersync/sync/CheckpointRequestTest.kt
+++ b/common/src/commonIntegrationTest/kotlin/com/powersync/sync/CheckpointRequestTest.kt
@@ -21,10 +21,12 @@ import com.powersync.testutils.databaseTest
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.comparables.shouldBeLessThan
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.testTimeSource
 import kotlin.test.Test
 import kotlin.test.assertNotNull
@@ -104,6 +106,9 @@ class CheckpointRequestTest : AbstractSyncTest() {
 
             database.waitForStatus { it.downloadError != null }
             database.currentStatus.connected shouldBe false
+
+            val error = database.currentStatus.downloadError
+            error.toString() shouldContain "The PowerSync service does not support checkpoint requests"
         }
 
     @Test
@@ -183,15 +188,17 @@ class CheckpointRequestTest : AbstractSyncTest() {
             database.connect(connector, options = optionsWithRequests())
             checkpointState.checkpointRequestCount.first { it == 1 }
             database.waitForStatus { it.connected }
-            scope.testScheduler.runCurrent()
 
             // Simulate what would happen if we suddenly switched users after the old token expired. The
             // client expects a checkpoint of 100, for another user the service wouldn't have that counter
             // yet. The client must request a checkpoint with the existing id, allowing the service to
             // recognize that this device + user combo needs higher checkpoint ids.
+            val closed = scope.launch { waitForSyncLinesChannelClosed() }
             checkpointState.lastCheckpointRequest.value = 0
             syncLines.send(SyncLine.KeepAlive(tokenExpiresIn = 0))
-            checkpointState.checkpointRequestCount.first { it == 2 }
+            closed.join()
+
+            checkpointState.checkpointRequestCount.first { it > 1 }
             checkpointState.lastCheckpointRequest.value shouldBe 100
         }
 

--- a/common/src/commonIntegrationTest/kotlin/com/powersync/sync/CheckpointRequestTest.kt
+++ b/common/src/commonIntegrationTest/kotlin/com/powersync/sync/CheckpointRequestTest.kt
@@ -26,7 +26,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.testTimeSource
-import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertNotNull
 import kotlin.time.Duration.Companion.hours
@@ -137,8 +136,6 @@ class CheckpointRequestTest : AbstractSyncTest() {
 
     @Test
     @OptIn(ExperimentalCoroutinesApi::class)
-    // TODO: Un-ignore this test. It's currently broken due to missing crud uploads.
-    @Ignore
     fun `download is retried on checkpoint request`() =
         databaseTest {
             database.connect(connector, retryDelayMs = 10_000, options = optionsWithRequests())
@@ -147,7 +144,8 @@ class CheckpointRequestTest : AbstractSyncTest() {
             syncLines.send(
                 SyncLine.FullCheckpoint(Checkpoint(lastOpId = "invalid line", checksums = emptyList())),
             )
-            database.waitForStatus { it.downloadError != null }
+            waitForSyncLinesChannelClosed()
+            database.waitForStatus { it.downloadError != null && !it.connected }
 
             val timeToReconnect =
                 scope.testTimeSource.measureTime {

--- a/common/src/commonIntegrationTest/kotlin/com/powersync/sync/CheckpointRequestTest.kt
+++ b/common/src/commonIntegrationTest/kotlin/com/powersync/sync/CheckpointRequestTest.kt
@@ -1,0 +1,235 @@
+@file:OptIn(ExperimentalCheckpointRequestsApi::class)
+
+package com.powersync.sync
+
+import app.cash.turbine.turbineScope
+import co.touchlab.kermit.ExperimentalKermitApi
+import com.powersync.ExperimentalCheckpointRequestsApi
+import com.powersync.PowerSyncDatabase
+import com.powersync.connectors.CustomCheckpointRequestConnector
+import com.powersync.connectors.PowerSyncBackendConnector
+import com.powersync.connectors.PowerSyncCredentials
+import com.powersync.testutils.ActiveDatabaseTest
+import com.powersync.testutils.BucketChecksum
+import com.powersync.testutils.Checkpoint
+import com.powersync.testutils.OpType
+import com.powersync.testutils.OplogEntry
+import com.powersync.testutils.SyncLine
+import com.powersync.testutils.SyncLine.SyncDataBucket
+import com.powersync.testutils.UserRow
+import com.powersync.testutils.databaseTest
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.comparables.shouldBeLessThan
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.testTimeSource
+import kotlin.test.Ignore
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.measureTime
+
+@ExperimentalKermitApi
+class CheckpointRequestTest : AbstractSyncTest() {
+    private fun ActiveDatabaseTest.optionsWithRequests() =
+        SyncOptions(
+            clientConfiguration = SyncClientConfiguration.ExistingClient(createSyncClient()),
+            checkpointMode = CheckpointMode.Requests(),
+        )
+
+    @Test
+    fun `warns for custom connectors without requests being enabled`() =
+        databaseTest {
+            database.connect(connector.withCustomRequests(), options = getOptions())
+            database.waitForStatus { it.connected }
+            assertNotNull(
+                logWriter.logs.find {
+                    it.message.contains("CustomCheckpointRequestConnector was used with legacy checkpoints")
+                },
+            )
+        }
+
+    @Test
+    fun `requests checkpoints for updates`() =
+        databaseTest {
+            database.connect(connector, options = optionsWithRequests())
+            database.waitForStatus { it.connected }
+            checkpointState.lastCheckpointRequest.value shouldBe 1
+
+            database.execute("INSERT INTO users (id, name, email) VALUES (?, ?, uuid())", listOf("id", "local write"))
+            turbineScope {
+                val watched = database.watch("SELECT * FROM users") { UserRow.from(it) }.testIn(this)
+                watched.awaitItem() shouldHaveSize 1
+                // The local write should eventually be uploaded
+                checkpointState.lastCheckpointRequest.first { it == 2L }
+
+                syncLines.send(
+                    SyncLine.FullCheckpoint(
+                        Checkpoint(
+                            lastOpId = "1",
+                            writeCheckpoint = "2",
+                            checksums = listOf(BucketChecksum("a", checksum = 0)),
+                        ),
+                    ),
+                )
+                syncLines.send(
+                    SyncDataBucket(
+                        bucket = "a",
+                        data =
+                            listOf(
+                                OplogEntry(
+                                    checksum = 0,
+                                    opId = "1",
+                                    rowId = "id",
+                                    rowType = "users",
+                                    op = OpType.REMOVE,
+                                ),
+                            ),
+                    ),
+                )
+                syncLines.send(SyncLine.CheckpointComplete(lastOpId = "1"))
+                watched.awaitItem() shouldHaveSize 0
+                watched.cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `reports download error when requesting checkpoint fails`() =
+        databaseTest {
+            checkpointState.checkpointRequestsSupported = false
+            database.connect(connector, options = optionsWithRequests())
+
+            database.waitForStatus { it.downloadError != null }
+            database.currentStatus.connected shouldBe false
+        }
+
+    @Test
+    fun `reposts current checkpoint until applied`() =
+        databaseTest {
+            database.connect(connector, options = optionsWithRequests())
+
+            // Wait for the initial post (seed)
+            checkpointState.checkpointRequestCount.first { it >= 1 }
+
+            for (i in 0 until 10) {
+                checkpointState.checkpointRequestCount.first { it >= i + 2 }
+            }
+
+            // Finally, include the checkpoint.
+            syncLines.send(
+                SyncLine.FullCheckpoint(
+                    Checkpoint(lastOpId = "0", checksums = emptyList(), writeCheckpoint = "1"),
+                ),
+            )
+            syncLines.send(SyncLine.CheckpointComplete(lastOpId = "0"))
+            database.waitForFirstSync()
+
+            val totalRequests = checkpointState.checkpointRequestCount.value
+
+            // Which means we shouldn't keep requesting it.
+            delay(1.hours)
+            checkpointState.checkpointRequestCount.value shouldBe totalRequests
+        }
+
+    @Test
+    @OptIn(ExperimentalCoroutinesApi::class)
+    // TODO: Un-ignore this test. It's currently broken due to missing crud uploads.
+    @Ignore
+    fun `download is retried on checkpoint request`() =
+        databaseTest {
+            database.connect(connector, retryDelayMs = 10_000, options = optionsWithRequests())
+
+            // Destroy the initial connection by sending a bogus line
+            syncLines.send(
+                SyncLine.FullCheckpoint(Checkpoint(lastOpId = "invalid line", checksums = emptyList())),
+            )
+            database.waitForStatus { it.downloadError != null }
+
+            val timeToReconnect =
+                scope.testTimeSource.measureTime {
+                    // Trigger an upload here. Because the upload needs a seeded sync iteration, we should
+                    // reconnect immediately instead of after the configured 10s delay.
+                    database.execute(
+                        "INSERT INTO users (id, name, email) VALUES (uuid(), ?, uuid())",
+                        listOf("restart plz"),
+                    )
+
+                    database.currentStatus.asFlow().first { it.connected }
+                }
+            timeToReconnect shouldBeLessThan 5.seconds
+        }
+
+    @Test
+    fun `can use checkpoint method from connector`() =
+        databaseTest {
+            val didRequestCheckpoint = CompletableDeferred<Unit>()
+            val customConnector =
+                connector.withCustomRequests { _, requestId ->
+                    requestId shouldBe 1L
+                    didRequestCheckpoint.complete(Unit)
+                    requestId
+                }
+
+            database.connect(customConnector, options = optionsWithRequests())
+            didRequestCheckpoint.await()
+        }
+
+    @Test
+    fun `reconciles checkpoint state on token expiry`() =
+        databaseTest {
+            checkpointState.lastCheckpointRequest.value = 100
+            database.connect(connector, options = optionsWithRequests())
+            checkpointState.checkpointRequestCount.first { it == 1 }
+            database.waitForStatus { it.connected }
+            scope.testScheduler.runCurrent()
+
+            // Simulate what would happen if we suddenly switched users after the old token expired. The
+            // client expects a checkpoint of 100, for another user the service wouldn't have that counter
+            // yet. The client must request a checkpoint with the existing id, allowing the service to
+            // recognize that this device + user combo needs higher checkpoint ids.
+            checkpointState.lastCheckpointRequest.value = 0
+            syncLines.send(SyncLine.KeepAlive(tokenExpiresIn = 0))
+            checkpointState.checkpointRequestCount.first { it == 2 }
+            checkpointState.lastCheckpointRequest.value shouldBe 100
+        }
+
+    @Test
+    fun `reads sync lines before checkpoint requests are ready`() =
+        databaseTest {
+            val hasInitialRequest = CompletableDeferred<Unit>()
+            val completeInitialRequest = CompletableDeferred<Unit>()
+            checkpointState.beforeCheckpointRequestResponse = {
+                hasInitialRequest.complete(Unit)
+                completeInitialRequest.await()
+            }
+
+            database.connect(connector, options = optionsWithRequests())
+            hasInitialRequest.await()
+
+            syncLines.send(
+                SyncLine.FullCheckpoint(
+                    Checkpoint(lastOpId = "0", checksums = emptyList(), writeCheckpoint = "1"),
+                ),
+            )
+            database.waitForStatus { it.downloading }
+            completeInitialRequest.complete(Unit)
+        }
+}
+
+private fun PowerSyncBackendConnector.withCustomRequests(
+    postRequest: suspend (String, Long) -> Long = { _, req -> req },
+): CustomCheckpointRequestConnector =
+    object : CustomCheckpointRequestConnector() {
+        override suspend fun postCheckpointRequest(
+            clientId: String,
+            requestId: Long,
+        ): Long = postRequest(clientId, requestId)
+
+        override suspend fun fetchCredentials(): PowerSyncCredentials? = this@withCustomRequests.fetchCredentials()
+
+        override suspend fun uploadData(database: PowerSyncDatabase) = this@withCustomRequests.uploadData(database)
+    }

--- a/common/src/commonIntegrationTest/kotlin/com/powersync/sync/CheckpointRequestTest.kt
+++ b/common/src/commonIntegrationTest/kotlin/com/powersync/sync/CheckpointRequestTest.kt
@@ -161,7 +161,7 @@ class CheckpointRequestTest : AbstractSyncTest() {
                         listOf("restart plz"),
                     )
 
-                    database.currentStatus.asFlow().first { it.connected }
+                    database.currentStatus.asFlow().first { it.connecting }
                 }
             timeToReconnect shouldBeLessThan 5.seconds
         }

--- a/common/src/commonIntegrationTest/kotlin/com/powersync/sync/SyncIntegrationTest.kt
+++ b/common/src/commonIntegrationTest/kotlin/com/powersync/sync/SyncIntegrationTest.kt
@@ -1077,9 +1077,7 @@ class SyncIntegrationTest : AbstractSyncTest() {
 
                 syncLines.send("unterminated line".toByteArray())
                 syncLines.close()
-                turbine.waitFor { !it.connected }
-                database.currentStatus.downloadError shouldNotBeNull {
-                }
+                turbine.waitFor { !it.connected && it.downloadError != null }
 
                 syncLines = Channel()
                 turbine.waitFor(allowError = true) { it.connected }

--- a/common/src/commonIntegrationTest/kotlin/com/powersync/sync/SyncIntegrationTest.kt
+++ b/common/src/commonIntegrationTest/kotlin/com/powersync/sync/SyncIntegrationTest.kt
@@ -44,6 +44,7 @@ import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.testTimeSource
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.jsonObject
@@ -787,6 +788,7 @@ class SyncIntegrationTest : AbstractSyncTest() {
                 syncLines.send(SyncLine.KeepAlive(tokenExpiresIn = 4000))
                 turbine.waitFor { it.connected }
                 fetchCredentialsCount shouldBe 1
+                delay(1.seconds) // Make idle, past the initial crud upload
 
                 syncLines.send(SyncLine.KeepAlive(tokenExpiresIn = 10))
                 prefetchCalled.await()
@@ -800,6 +802,7 @@ class SyncIntegrationTest : AbstractSyncTest() {
                         // Wait for a disconnect and reconnect.
                         waitForSyncLinesChannelClosed()
                         syncLines.send(SyncLine.KeepAlive(tokenExpiresIn = 4000))
+                        turbine.waitFor { it.connected }
                     }
                 // We should not wait for the reconnect delay when we reconnect due to a prefetched
                 // token (that's kind of the whole point...).

--- a/common/src/commonIntegrationTest/kotlin/com/powersync/testutils/TestUtils.kt
+++ b/common/src/commonIntegrationTest/kotlin/com/powersync/testutils/TestUtils.kt
@@ -66,6 +66,8 @@ internal class ActiveDatabaseTest(
 
     lateinit var database: PowerSyncDatabaseImpl
 
+    val checkpointState = CheckpointRequestsTestState()
+
     val logWriter =
         PowerSyncTestLogWriter(
             loggable = Severity.Verbose,
@@ -136,6 +138,7 @@ internal class ActiveDatabaseTest(
                 lines = { syncLines },
                 generateCheckpoint = { checkpointResponse() },
                 syncLinesContentType = { syncLinesContentType },
+                requestCheckpoints = checkpointState,
                 trackSyncRequest = {
                     val parsed =
                         JsonUtil.json.parseToJsonElement(it.body.toByteArray().decodeToString())

--- a/common/src/commonIntegrationTest/kotlin/com/powersync/testutils/TestUtils.kt
+++ b/common/src/commonIntegrationTest/kotlin/com/powersync/testutils/TestUtils.kt
@@ -27,6 +27,8 @@ import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import kotlinx.io.files.Path
 import kotlinx.serialization.json.JsonElement
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.coroutines.resume
 
 fun generatePrintLogWriter() =
@@ -114,7 +116,10 @@ internal class ActiveDatabaseTest(
         }
     }
 
-    fun openDatabase(schema: Schema = Schema(UserRow.table)): PowerSyncDatabaseImpl {
+    fun openDatabase(
+        schema: Schema = Schema(UserRow.table),
+        databaseIoDispatcher: CoroutineContext = EmptyCoroutineContext,
+    ): PowerSyncDatabaseImpl {
         logger.d { "Opening database $databaseName in directory $testDirectory" }
         val db =
             createPowerSyncDatabaseImpl(
@@ -124,6 +129,8 @@ internal class ActiveDatabaseTest(
                 dbDirectory = testDirectory,
                 logger = logger,
                 scope = scope,
+                // To make tests more consistent, avoid using Dispatchers.IO.
+                databaseIoDispatcher = databaseIoDispatcher,
             )
         doOnCleanup { db.close() }
         return db

--- a/common/src/commonMain/kotlin/com/powersync/ExperimentalPowerSyncAPI.kt
+++ b/common/src/commonMain/kotlin/com/powersync/ExperimentalPowerSyncAPI.kt
@@ -10,3 +10,14 @@ package com.powersync
     AnnotationTarget.VALUE_PARAMETER,
 )
 public annotation class ExperimentalPowerSyncAPI
+
+@RequiresOptIn(message = "Checkpoint requests are in alpha and might change.")
+@Retention(AnnotationRetention.BINARY)
+@Target(
+    AnnotationTarget.CLASS,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.CONSTRUCTOR,
+    AnnotationTarget.PROPERTY,
+    AnnotationTarget.VALUE_PARAMETER,
+)
+public annotation class ExperimentalCheckpointRequestsApi

--- a/common/src/commonMain/kotlin/com/powersync/PowerSyncException.kt
+++ b/common/src/commonMain/kotlin/com/powersync/PowerSyncException.kt
@@ -1,6 +1,6 @@
 package com.powersync
 
-public class PowerSyncException(
+public open class PowerSyncException(
     message: String,
     cause: Throwable?,
 ) : Exception(message, cause)

--- a/common/src/commonMain/kotlin/com/powersync/bucket/BucketStorage.kt
+++ b/common/src/commonMain/kotlin/com/powersync/bucket/BucketStorage.kt
@@ -5,6 +5,7 @@ import com.powersync.db.StreamKey
 import com.powersync.db.crud.CrudEntry
 import com.powersync.db.internal.PowerSyncTransaction
 import com.powersync.db.schema.Schema
+import com.powersync.sync.CoreSyncStatus
 import com.powersync.sync.Instruction
 import com.powersync.utils.JsonUtil
 import kotlinx.serialization.SerialName
@@ -29,6 +30,8 @@ internal interface BucketStorage {
     suspend fun hasCompletedSync(): Boolean
 
     suspend fun control(args: PowerSyncControlArguments): List<Instruction>
+
+    suspend fun resolveOfflineSyncStatus(): CoreSyncStatus
 
     suspend fun readOrUpdateCheckpoint(
         variant: String,

--- a/common/src/commonMain/kotlin/com/powersync/bucket/BucketStorage.kt
+++ b/common/src/commonMain/kotlin/com/powersync/bucket/BucketStorage.kt
@@ -30,6 +30,11 @@ internal interface BucketStorage {
 
     suspend fun control(args: PowerSyncControlArguments): List<Instruction>
 
+    suspend fun readOrUpdateCheckpoint(
+        variant: String,
+        update: Long? = null,
+    ): Long?
+
     companion object {
         const val MAX_OP_ID = 9223372036854775807L
     }
@@ -46,14 +51,19 @@ internal interface BucketStorage {
  * [BucketStorage.MAX_OP_ID] can be used as a sentinel value in case there are pending changes that
  * have been uploaded, but for which no checkpoint request has been created yet.
  */
-internal suspend fun PowerSyncTransaction.targetCheckpointRequestId(update: Long? = null): Long? {
-    var previousCheckpointRequest: Long? = null
+internal suspend fun PowerSyncTransaction.targetCheckpointRequestId(update: Long? = null): Long? = readOrUpdateCheckpoint("target", update)
 
-    getAsync("SELECT powersync_control(?, ?)", listOf("target_checkpoint_request_id", update)) { row ->
+internal suspend fun PowerSyncTransaction.readOrUpdateCheckpoint(
+    variant: String,
+    update: Long? = null,
+): Long? {
+    var readValue: Long? = null
+
+    getAsync("SELECT powersync_control(?, ?)", listOf("${variant}_checkpoint_request_id", update)) { row ->
         // We can't return nullable values here, so write to the outer local
-        previousCheckpointRequest = row.getLong(0)
+        readValue = row.getLong(0)
     }
-    return previousCheckpointRequest
+    return readValue
 }
 
 internal sealed interface PowerSyncControlArguments {
@@ -72,6 +82,8 @@ internal sealed interface PowerSyncControlArguments {
         val activeStreams: List<StreamKey>,
         @SerialName("app_metadata")
         val appMetadata: Map<String, String>,
+        @SerialName("checkpoint_mode")
+        val checkpointMode: String,
     ) : PowerSyncControlArguments {
         override val sqlArguments: Pair<String, Any?>
             get() = "start" to JsonUtil.json.encodeToString(this)
@@ -109,6 +121,13 @@ internal sealed interface PowerSyncControlArguments {
 
     data object ResponseStreamEnd : PowerSyncControlArguments {
         override val sqlArguments: Pair<String, Any?> = "connection" to "end"
+    }
+
+    data class CheckpointSeedFailed(
+        val cause: Exception,
+    ) : PowerSyncControlArguments {
+        override val sqlArguments: Pair<String, Any?>
+            get() = throw IllegalStateException("Has no control arguments")
     }
 
     class UpdateSubscriptions(

--- a/common/src/commonMain/kotlin/com/powersync/bucket/BucketStorageImpl.kt
+++ b/common/src/commonMain/kotlin/com/powersync/bucket/BucketStorageImpl.kt
@@ -132,4 +132,9 @@ internal class BucketStorageImpl(
             val (op: String, data: Any?) = args.sqlArguments
             tx.getAsync("SELECT powersync_control(?, ?) AS r", listOf(op, data), ::handleControlResult)
         }
+
+    override suspend fun readOrUpdateCheckpoint(
+        variant: String,
+        update: Long?,
+    ): Long? = db.writeTransactionAsync { tx -> tx.readOrUpdateCheckpoint(variant, update) }
 }

--- a/common/src/commonMain/kotlin/com/powersync/bucket/BucketStorageImpl.kt
+++ b/common/src/commonMain/kotlin/com/powersync/bucket/BucketStorageImpl.kt
@@ -8,6 +8,7 @@ import com.powersync.db.crud.CrudRow
 import com.powersync.db.internal.InternalDatabase
 import com.powersync.db.internal.InternalTable
 import com.powersync.db.internal.PowerSyncTransaction
+import com.powersync.sync.CoreSyncStatus
 import com.powersync.sync.Instruction
 import com.powersync.utils.JsonUtil
 
@@ -131,6 +132,11 @@ internal class BucketStorageImpl(
 
             val (op: String, data: Any?) = args.sqlArguments
             tx.getAsync("SELECT powersync_control(?, ?) AS r", listOf(op, data), ::handleControlResult)
+        }
+
+    override suspend fun resolveOfflineSyncStatus(): CoreSyncStatus =
+        db.get("SELECT powersync_offline_sync_status()") {
+            JsonUtil.json.decodeFromString<CoreSyncStatus>(it.getString(0)!!)
         }
 
     override suspend fun readOrUpdateCheckpoint(

--- a/common/src/commonMain/kotlin/com/powersync/bucket/WriteCheckpointResult.kt
+++ b/common/src/commonMain/kotlin/com/powersync/bucket/WriteCheckpointResult.kt
@@ -15,3 +15,24 @@ internal data class WriteCheckpointData(
     @Serializable(with = LongAsStringSerializer::class)
     val writeCheckpoint: Long,
 )
+
+@Serializable
+internal class CheckpointRequestPayload(
+    @SerialName("client_id")
+    val clientId: String,
+    @SerialName("checkpoint_request_id")
+    @Serializable(with = LongAsStringSerializer::class)
+    val checkpointRequestId: Long,
+)
+
+@Serializable
+internal class CheckpointRequestResponse(
+    val data: CheckpointRequestResponseData,
+)
+
+@Serializable
+internal class CheckpointRequestResponseData(
+    @SerialName("checkpoint_request_id")
+    @Serializable(with = LongAsStringSerializer::class)
+    val id: Long,
+)

--- a/common/src/commonMain/kotlin/com/powersync/connectors/PowerSyncBackendConnector.kt
+++ b/common/src/commonMain/kotlin/com/powersync/connectors/PowerSyncBackendConnector.kt
@@ -1,5 +1,7 @@
 package com.powersync.connectors
 
+import com.powersync.ExperimentalCheckpointRequestsApi
+import com.powersync.ExperimentalPowerSyncAPI
 import com.powersync.PowerSyncDatabase
 import com.powersync.PowerSyncException
 import com.powersync.db.runWrapped
@@ -38,7 +40,6 @@ public abstract class PowerSyncBackendConnector {
      *
      * These credentials may have expired already.
      */
-    @Throws(PowerSyncException::class, CancellationException::class)
     public open suspend fun getCredentialsCached(): PowerSyncCredentials? {
         return runWrapped {
             cachedCredentials?.let { return@runWrapped it }
@@ -115,7 +116,6 @@ public abstract class PowerSyncBackendConnector {
      *
      * This token is kept for the duration of a sync connection.
      */
-    @Throws(PowerSyncException::class, CancellationException::class)
     public abstract suspend fun fetchCredentials(): PowerSyncCredentials?
 
     /**
@@ -125,8 +125,35 @@ public abstract class PowerSyncBackendConnector {
      *
      * Any thrown errors will result in a retry after the configured wait period (default: 5 seconds).
      */
-    @Throws(PowerSyncException::class, CancellationException::class)
     public abstract suspend fun uploadData(database: PowerSyncDatabase)
+}
+
+/**
+ * A [PowerSyncBackendConnector] capable of requesting checkpoints.
+ *
+ * Extend this class instead of [PowerSyncBackendConnector] when uploads are processed
+ * asynchronously by the backend (for example through a message queue): The sync client as part of
+ * the PowerSync Kotlin SDK generates a checkpoint request id and hands it to your backend via this
+ * class, which is responsible for creating a matching checkpoint once the uploads preceding the
+ * request have been processed.
+ * For more details, see [asynchronous backend uploads](https://docs.powersync.com/client-sdks/advanced/checkpoint-requests#asynchronous-upload-backends).
+ *
+ * To use this connector, using [com.powersync.sync.CheckpointMode.Requests] is required. Note that
+ * this requires PowerSync service version 1.24.0 or later.
+ */
+@ExperimentalCheckpointRequestsApi
+public abstract class CustomCheckpointRequestConnector : PowerSyncBackendConnector() {
+    /**
+     * Posts a client-generated checkpoint request to the backend and returns the effective
+     * checkpoint request state.
+     *
+     * @param clientId The PowerSync client ID for the current device.
+     * @param requestId The client-generated checkpoint request ID.
+     */
+    public abstract suspend fun postCheckpointRequest(
+        clientId: String,
+        requestId: Long,
+    ): Long
 }
 
 // Not using this indirection causes linker errors in tests: https://youtrack.jetbrains.com/issue/CMP-3318

--- a/common/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
+++ b/common/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
@@ -22,7 +22,6 @@ import com.powersync.db.internal.InternalTable
 import com.powersync.db.internal.PowerSyncVersion
 import com.powersync.db.schema.Schema
 import com.powersync.sync.CheckpointMode
-import com.powersync.sync.CoreSyncStatus
 import com.powersync.sync.StreamingSyncClient
 import com.powersync.sync.SyncOptions
 import com.powersync.sync.SyncStatus
@@ -46,7 +45,6 @@ import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.supervisorScope
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlin.time.Duration.Companion.milliseconds
@@ -465,11 +463,7 @@ internal class PowerSyncDatabaseImpl(
     }
 
     private suspend fun resolveOfflineSyncStatus() {
-        val offlineSyncStatus =
-            internalDb.get("SELECT powersync_offline_sync_status()") {
-                JsonUtil.json.decodeFromString<CoreSyncStatus>(it.getString(0)!!)
-            }
-
+        val offlineSyncStatus = bucketStorage.resolveOfflineSyncStatus()
         currentStatus.update {
             copy(core = offlineSyncStatus)
         }

--- a/common/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
+++ b/common/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
@@ -1,6 +1,7 @@
 package com.powersync.db
 
 import co.touchlab.kermit.Logger
+import com.powersync.ExperimentalCheckpointRequestsApi
 import com.powersync.ExperimentalPowerSyncAPI
 import com.powersync.PowerSyncDatabase
 import com.powersync.PowerSyncException
@@ -8,6 +9,7 @@ import com.powersync.bucket.BucketStorage
 import com.powersync.bucket.BucketStorageImpl
 import com.powersync.bucket.StreamPriority
 import com.powersync.bucket.targetCheckpointRequestId
+import com.powersync.connectors.CustomCheckpointRequestConnector
 import com.powersync.connectors.PowerSyncBackendConnector
 import com.powersync.db.crud.CrudBatch
 import com.powersync.db.crud.CrudEntry
@@ -19,6 +21,7 @@ import com.powersync.db.internal.InternalDatabaseImpl
 import com.powersync.db.internal.InternalTable
 import com.powersync.db.internal.PowerSyncVersion
 import com.powersync.db.schema.Schema
+import com.powersync.sync.CheckpointMode
 import com.powersync.sync.CoreSyncStatus
 import com.powersync.sync.StreamingSyncClient
 import com.powersync.sync.SyncOptions
@@ -156,6 +159,13 @@ internal class PowerSyncDatabaseImpl(
             disconnectInternal()
 
             connectInternal { scope ->
+                @OptIn(ExperimentalCheckpointRequestsApi::class)
+                if (connector is CustomCheckpointRequestConnector && options.checkpointMode == CheckpointMode.Legacy) {
+                    logger.w {
+                        "A CustomCheckpointRequestConnector was used with legacy checkpoints, postCheckpointRequest will not get called"
+                    }
+                }
+
                 StreamingSyncClient(
                     status = currentStatus,
                     bucketStorage = bucketStorage,

--- a/common/src/commonMain/kotlin/com/powersync/sync/CheckpointRequestException.kt
+++ b/common/src/commonMain/kotlin/com/powersync/sync/CheckpointRequestException.kt
@@ -1,0 +1,23 @@
+package com.powersync.sync
+
+import com.powersync.ExperimentalCheckpointRequestsApi
+import com.powersync.PowerSyncException
+
+/**
+ * An exception related to checkpoint requests.
+ */
+@ExperimentalCheckpointRequestsApi
+public open class CheckpointRequestException internal constructor(
+    message: String,
+    cause: Throwable? = null,
+) : PowerSyncException(message, cause) {
+    public class InstanceNotSupported internal constructor() :
+        CheckpointRequestException(
+            "The PowerSync service does not support checkpoint requests. Update to PowerSync service version 1.24.0 or later to use this API.",
+        )
+
+    public class Disconnected internal constructor() : CheckpointRequestException("Cannot request checkpoints, sync client is disconnected")
+
+    public class NotEnabled internal constructor() :
+        CheckpointRequestException("Connected with legacy checkpoint mode, cannot request checkpoints")
+}

--- a/common/src/commonMain/kotlin/com/powersync/sync/CheckpointStateSignals.kt
+++ b/common/src/commonMain/kotlin/com/powersync/sync/CheckpointStateSignals.kt
@@ -1,12 +1,9 @@
 package com.powersync.sync
 
 import com.powersync.ExperimentalCheckpointRequestsApi
-import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.takeWhile
 import kotlin.concurrent.atomics.AtomicReference
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.coroutines.cancellation.CancellationException
@@ -88,11 +85,7 @@ internal class CheckpointStateSignals {
     }
 
     companion object {
-        private fun createNotifyWaitChannel() =
-            Channel<Unit>(
-                capacity = 1,
-                onBufferOverflow = BufferOverflow.DROP_LATEST,
-            )
+        private fun createNotifyWaitChannel() = Channel<Unit>(Channel.CONFLATED)
     }
 }
 

--- a/common/src/commonMain/kotlin/com/powersync/sync/CheckpointStateSignals.kt
+++ b/common/src/commonMain/kotlin/com/powersync/sync/CheckpointStateSignals.kt
@@ -1,0 +1,107 @@
+package com.powersync.sync
+
+import com.powersync.ExperimentalCheckpointRequestsApi
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.takeWhile
+import kotlin.concurrent.atomics.AtomicReference
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+import kotlin.coroutines.cancellation.CancellationException
+
+@ExperimentalCheckpointRequestsApi
+@OptIn(ExperimentalAtomicApi::class)
+internal class CheckpointStateSignals {
+    private val state = MutableStateFlow<CheckpointState>(CheckpointState.Pending)
+    private val waitingForCheckpointsReady = AtomicReference(createNotifyWaitChannel())
+
+    /**
+     * Marks the current download iteration as ended, blocking new checkpoint requests until the
+     * seed was performed in the next iteration.
+     */
+    fun downloadIterationEnded() {
+        state.value = CheckpointState.Pending
+
+        // Checkpoint waiters called after this should be able to resume the download iteration.
+        val old = waitingForCheckpointsReady.exchange(createNotifyWaitChannel())
+        old.cancel()
+    }
+
+    /**
+     * Marks the sync client as disconnected, failing all outstanding checkpoint requests and
+     * preventing new ones.
+     */
+    fun disconnected() {
+        state.value = CheckpointState.Disconnected
+    }
+
+    /**
+     * Waits for a waiter wanting to request a checkpoint.
+     *
+     * As the waiter is blocked for a seed run we start in the download iteration, we use this to
+     * wake up the download iteration if it's currently paused.
+     */
+    suspend fun waitForCheckpointWaiter() {
+        // Ignore errors if the channel is closed.
+        waitingForCheckpointsReady.load().receiveCatching()
+    }
+
+    suspend fun markCheckpointsReady(block: suspend () -> Unit) {
+        try {
+            block()
+            state.value = CheckpointState.DidSeed(Result.success(Unit))
+        } catch (e: Exception) {
+            if (e !is CancellationException) {
+                state.value = CheckpointState.DidSeed(Result.failure(e))
+            }
+
+            throw e
+        }
+    }
+
+    /**
+     * Waits until a download iteration is active and has seeded the checkpoint state, meaning that
+     * checkpoint ids can safely be allocated.
+     */
+    suspend fun waitForCheckpointRequestsReady(wakeDownloadLoop: Boolean = true) {
+        state.first { state ->
+            when (state) {
+                is CheckpointState.DidSeed -> {
+                    state.result.getOrThrow()
+                    true
+                }
+
+                CheckpointState.Disconnected -> {
+                    throw CheckpointRequestException.Disconnected()
+                }
+
+                CheckpointState.Pending -> {
+                    if (wakeDownloadLoop) {
+                        waitingForCheckpointsReady.load().trySend(Unit)
+                    }
+                    false
+                }
+            }
+        }
+    }
+
+    companion object {
+        private fun createNotifyWaitChannel() =
+            Channel<Unit>(
+                capacity = 1,
+                onBufferOverflow = BufferOverflow.DROP_LATEST,
+            )
+    }
+}
+
+private sealed interface CheckpointState {
+    object Pending : CheckpointState
+
+    object Disconnected : CheckpointState
+
+    class DidSeed(
+        val result: Result<Unit>,
+    ) : CheckpointState
+}

--- a/common/src/commonMain/kotlin/com/powersync/sync/CheckpointStateSignals.kt
+++ b/common/src/commonMain/kotlin/com/powersync/sync/CheckpointStateSignals.kt
@@ -19,10 +19,9 @@ internal class CheckpointStateSignals {
      * seed was performed in the next iteration.
      */
     fun downloadIterationEnded() {
-        state.value = CheckpointState.Pending
-
         // Checkpoint waiters called after this should be able to resume the download iteration.
         val old = waitingForCheckpointsReady.exchange(createNotifyWaitChannel())
+        state.value = CheckpointState.Pending
         old.cancel()
     }
 

--- a/common/src/commonMain/kotlin/com/powersync/sync/Instruction.kt
+++ b/common/src/commonMain/kotlin/com/powersync/sync/Instruction.kt
@@ -1,10 +1,13 @@
 package com.powersync.sync
 
+import com.powersync.bucket.CheckpointRequestPayload
 import com.powersync.bucket.StreamPriority
 import com.powersync.db.crud.TypedRow
 import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerialInfo
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.LongAsStringSerializer
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
@@ -42,6 +45,8 @@ internal sealed interface Instruction {
     @Serializable
     data class EstablishSyncStream(
         val request: JsonObject,
+        @SerialName("checkpoint_request")
+        val checkpointRequest: CheckpointRequestPayload?,
     ) : Instruction
 
     @Serializable
@@ -150,6 +155,9 @@ internal data class CoreSyncStatus(
     @SerialName("priority_status")
     val priorityStatus: List<CorePriorityStatus>,
     val streams: List<CoreActiveStreamSubscription>,
+    @SerialName("internal_last_applied_checkpoint_request_id")
+    @Serializable(with = LongAsStringSerializer::class)
+    val lastAppliedCheckpointRequestId: Long?,
 )
 
 @Serializable

--- a/common/src/commonMain/kotlin/com/powersync/sync/StreamingSyncClient.kt
+++ b/common/src/commonMain/kotlin/com/powersync/sync/StreamingSyncClient.kt
@@ -180,6 +180,7 @@ internal class StreamingSyncClient(
                     // Wait for the delay, or another component wanting to request a checkpoint.
                     withTimeoutOrNull(retryDelay) {
                         checkpointSignals.waitForCheckpointWaiter()
+                        logger.v { "Resuming due to pendin checkpoint waiter" }
                     }
                 }
             }
@@ -570,6 +571,14 @@ internal class StreamingSyncClient(
                 if (instruction is Instruction.NonInterruptingInstruction) {
                     handleInstruction(instruction)
                 }
+            }
+
+            if (instructions.isEmpty()) {
+                // For errors reported by the core extension in powersync_control, the sync client
+                // is reset, and we don't get an updated sync status. Fall back to the offline sync
+                // status in that case.
+                val offlineStatus = bucketStorage.resolveOfflineSyncStatus()
+                status.update { copy(core = offlineStatus) }
             }
         }
 

--- a/common/src/commonMain/kotlin/com/powersync/sync/StreamingSyncClient.kt
+++ b/common/src/commonMain/kotlin/com/powersync/sync/StreamingSyncClient.kt
@@ -2,11 +2,16 @@ package com.powersync.sync
 
 import co.touchlab.kermit.Logger
 import co.touchlab.kermit.Severity
+import co.touchlab.stately.concurrency.AtomicReference
+import com.powersync.ExperimentalCheckpointRequestsApi
 import com.powersync.ExperimentalPowerSyncAPI
 import com.powersync.PowerSyncException
 import com.powersync.bucket.BucketStorage
+import com.powersync.bucket.CheckpointRequestPayload
+import com.powersync.bucket.CheckpointRequestResponse
 import com.powersync.bucket.PowerSyncControlArguments
 import com.powersync.bucket.WriteCheckpointResponse
+import com.powersync.connectors.CustomCheckpointRequestConnector
 import com.powersync.connectors.PowerSyncBackendConnector
 import com.powersync.db.SubscriptionGroup
 import com.powersync.db.crud.CrudEntry
@@ -18,6 +23,7 @@ import io.ktor.client.call.body
 import io.ktor.client.request.accept
 import io.ktor.client.request.get
 import io.ktor.client.request.headers
+import io.ktor.client.request.post
 import io.ktor.client.request.preparePost
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.HttpResponse
@@ -52,6 +58,7 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.io.EOFException
 import kotlinx.io.readByteArray
 import kotlinx.io.readIntLe
@@ -61,7 +68,7 @@ import kotlin.coroutines.cancellation.CancellationException
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
-@OptIn(ExperimentalPowerSyncAPI::class)
+@OptIn(ExperimentalPowerSyncAPI::class, ExperimentalCheckpointRequestsApi::class)
 internal class StreamingSyncClient(
     private val status: SyncStatus,
     private val bucketStorage: BucketStorage,
@@ -78,6 +85,7 @@ internal class StreamingSyncClient(
 ) {
     private val requestedCrudUploads = Channel<Unit>(CONFLATED)
     private val completedCrudUploads = Channel<Unit>(CONFLATED)
+    private val checkpointSignals = CheckpointStateSignals()
 
     private var clientId: String? = null
 
@@ -99,6 +107,14 @@ internal class StreamingSyncClient(
         connector.invalidateCredentials()
     }
 
+    private suspend fun loadClientId(): String {
+        clientId?.let { return it }
+
+        val id = bucketStorage.getClientId()
+        clientId = id
+        return id
+    }
+
     /**
      * Triggers a crud upload without awaiting it.
      *
@@ -110,15 +126,20 @@ internal class StreamingSyncClient(
     }
 
     suspend fun streamingSync() {
-        coroutineScope {
-            launch { downloadLoop() }
-            launch { crudUploadLoop() }
+        try {
+            coroutineScope {
+                launch { downloadLoop() }
+                launch { crudUploadLoop() }
+                launch { repostUnacknowledgedCheckpointRequests() }
+            }
+        } finally {
+            checkpointSignals.disconnected()
         }
     }
 
     private suspend fun downloadLoop() {
         var invalidCredentials = false
-        clientId = bucketStorage.getClientId()
+        loadClientId()
 
         while (true) {
             var result = SyncIterationResult()
@@ -156,7 +177,10 @@ internal class StreamingSyncClient(
                 status.update { copy(downloadError = e) }
             } finally {
                 if (!result.hideDisconnectStateAndReconnectImmediately) {
-                    delay(retryDelay)
+                    // Wait for the delay, or another component wanting to request a checkpoint.
+                    withTimeoutOrNull(retryDelay) {
+                        checkpointSignals.waitForCheckpointWaiter()
+                    }
                 }
             }
         }
@@ -204,7 +228,12 @@ internal class StreamingSyncClient(
                     uploadCrud()
                 } else {
                     // Uploading is completed
-                    bucketStorage.updateLocalTarget { getWriteCheckpoint() }
+                    bucketStorage.updateLocalTarget {
+                        when (options.checkpointMode) {
+                            CheckpointMode.Legacy -> getLegacyWriteCheckpoint()
+                            is CheckpointMode.Requests -> requestNextCheckpointFromService()
+                        }
+                    }
                     break
                 }
             } catch (e: Exception) {
@@ -222,10 +251,56 @@ internal class StreamingSyncClient(
         status.update { copy(uploading = false) }
     }
 
-    private suspend fun getWriteCheckpoint(): Long {
+    private suspend fun requestNextCheckpointFromService(): Long {
+        checkpointSignals.waitForCheckpointRequestsReady()
+
+        val nextCheckpointRequestId = bucketStorage.readOrUpdateCheckpoint("next")!!
+        return requestCheckpointFromService(
+            CheckpointRequestPayload(
+                clientId = loadClientId(),
+                checkpointRequestId = nextCheckpointRequestId,
+            ),
+        )
+    }
+
+    private suspend fun requestCheckpointFromService(payload: CheckpointRequestPayload): Long {
+        // First, check if we can use a custom checkpoint request implementation.
+        (connector as? CustomCheckpointRequestConnector)?.let {
+            return it.postCheckpointRequest(payload.clientId, payload.checkpointRequestId)
+        }
+
         val credentials = connector.getCredentialsCached()
         require(credentials != null) { "Not logged in" }
-        val uri = credentials.endpointUri("write-checkpoint2.json?client_id=$clientId")
+        val uri = credentials.endpointUri("sync/checkpoint-request")
+
+        val response =
+            httpClient.post(uri) {
+                contentType(ContentType.Application.Json)
+                headers {
+                    append(HttpHeaders.Authorization, "Token ${credentials.token}")
+                }
+
+                setBody(JsonUtil.json.encodeToString(payload))
+            }
+
+        if (response.status.value == 401) {
+            connector.invalidateCredentials()
+        }
+        if (response.status.value == 404) {
+            throw CheckpointRequestException.InstanceNotSupported()
+        }
+        if (response.status.value != 200) {
+            throw CheckpointRequestException("Error getting checkpoint request: ${response.status}")
+        }
+
+        val body = JsonUtil.json.decodeFromString<CheckpointRequestResponse>(response.body())
+        return body.data.id
+    }
+
+    private suspend fun getLegacyWriteCheckpoint(): Long {
+        val credentials = connector.getCredentialsCached()
+        require(credentials != null) { "Not logged in" }
+        val uri = credentials.endpointUri("write-checkpoint2.json?client_id=${loadClientId()}")
 
         val response =
             httpClient.get(uri) {
@@ -333,6 +408,58 @@ internal class StreamingSyncClient(
         }
     }
 
+    private suspend fun repostUnacknowledgedCheckpointRequests() {
+        val retryDelay =
+            when (val mode = options.checkpointMode) {
+                CheckpointMode.Legacy -> return
+                is CheckpointMode.Requests -> mode.retryDelay
+            }
+
+        while (true) {
+            try {
+                checkpointSignals.waitForCheckpointRequestsReady(wakeDownloadLoop = false)
+
+                val requestId = bucketStorage.readOrUpdateCheckpoint("current") ?: continue
+                // Give the request some time to sync.
+                delay(retryDelay)
+
+                // If a new request was made, reset the timer.
+                if (requestId != bucketStorage.readOrUpdateCheckpoint("current")) {
+                    continue
+                }
+
+                // If the request was applied, we don't need to retry.
+                if (status.isCheckpointRequestApplied(requestId)) {
+                    continue
+                }
+
+                // Make sure we're online and ready before making the request
+                checkpointSignals.waitForCheckpointRequestsReady(wakeDownloadLoop = false)
+
+                // It's safe if this request races with a new one. The service will reject it.
+                logger.d { "Retry checkpoint request $requestId" }
+                requestCheckpointFromService(
+                    CheckpointRequestPayload(
+                        clientId = loadClientId(),
+                        checkpointRequestId = requestId,
+                    ),
+                )
+            } catch (e: Exception) {
+                if (e is kotlinx.coroutines.CancellationException) {
+                    throw e
+                }
+
+                logger.w(throwable = e) { "Error retrying checkpoint request." }
+                delay(retryDelay)
+            }
+        }
+    }
+
+    private suspend fun seedCheckpointRequestState(request: CheckpointRequestPayload) {
+        val seed = requestCheckpointFromService(request)
+        bucketStorage.readOrUpdateCheckpoint("seed", seed)
+    }
+
     /**
      * Implementation of a sync iteration that delegates to helper functions implemented in the
      * Rust core extension.
@@ -374,6 +501,8 @@ internal class StreamingSyncClient(
                     SyncIterationResult()
                 }
             } finally {
+                checkpointSignals.downloadIterationEnded()
+
                 // This can't be canceled because we need to send a stop message, which is async, to
                 // clean up resources.
                 withContext(NonCancellable) {
@@ -402,6 +531,11 @@ internal class StreamingSyncClient(
                         includeDefaults = options.includeDefaultStreams,
                         activeStreams = subscriptions.map { it.key },
                         appMetadata = appMetadata,
+                        checkpointMode =
+                            when (options.checkpointMode) {
+                                CheckpointMode.Legacy -> "legacy"
+                                is CheckpointMode.Requests -> "requests"
+                            },
                     ),
                 )
             var start: Instruction.EstablishSyncStream? = null
@@ -492,6 +626,24 @@ internal class StreamingSyncClient(
                             } else {
                                 logger.w(throwable = e) { "Failure in updateCredentials" }
                             }
+                        }
+                    }
+                }
+
+                instruction.checkpointRequest?.let { seedRequest ->
+                    launch(CoroutineName("Seed checkpoint state")) {
+                        // Start checkpoint request validation concurrently, without blocking
+                        // line processing on it. We need to do this at the start of every sync
+                        // iteration to ensure service and clients align on checkpoint ids, even
+                        // if the active user has changed between iterations.
+                        try {
+                            checkpointSignals.markCheckpointsReady {
+                                seedCheckpointRequestState(seedRequest)
+                            }
+                        } catch (e: Exception) {
+                            if (e is CancellationException) throw e
+
+                            send(PowerSyncControlArguments.CheckpointSeedFailed(e))
                         }
                     }
                 }

--- a/common/src/commonMain/kotlin/com/powersync/sync/StreamingSyncClient.kt
+++ b/common/src/commonMain/kotlin/com/powersync/sync/StreamingSyncClient.kt
@@ -420,7 +420,7 @@ internal class StreamingSyncClient(
             try {
                 checkpointSignals.waitForCheckpointRequestsReady(wakeDownloadLoop = false)
 
-                val requestId = bucketStorage.readOrUpdateCheckpoint("current") ?: continue
+                val requestId = bucketStorage.readOrUpdateCheckpoint("current")
                 // Give the request some time to sync.
                 delay(retryDelay)
 
@@ -430,7 +430,7 @@ internal class StreamingSyncClient(
                 }
 
                 // If the request was applied, we don't need to retry.
-                if (status.isCheckpointRequestApplied(requestId)) {
+                if (requestId == null || status.isCheckpointRequestApplied(requestId)) {
                     continue
                 }
 
@@ -479,6 +479,10 @@ internal class StreamingSyncClient(
                     val channel = produceEvents(establishConnection, subscriptions)
 
                     channel.consumeEach { line ->
+                        if (line is PowerSyncControlArguments.CheckpointSeedFailed) {
+                            throw line.cause
+                        }
+
                         val instructions = bucketStorage.control(line)
                         for (instruction in instructions) {
                             when (instruction) {

--- a/common/src/commonMain/kotlin/com/powersync/sync/StreamingSyncClient.kt
+++ b/common/src/commonMain/kotlin/com/powersync/sync/StreamingSyncClient.kt
@@ -2,7 +2,6 @@ package com.powersync.sync
 
 import co.touchlab.kermit.Logger
 import co.touchlab.kermit.Severity
-import co.touchlab.stately.concurrency.AtomicReference
 import com.powersync.ExperimentalCheckpointRequestsApi
 import com.powersync.ExperimentalPowerSyncAPI
 import com.powersync.PowerSyncException
@@ -20,16 +19,17 @@ import com.powersync.utils.JsonUtil
 import io.ktor.client.HttpClient
 import io.ktor.client.HttpClientConfig
 import io.ktor.client.call.body
+import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.request.accept
-import io.ktor.client.request.get
 import io.ktor.client.request.headers
-import io.ktor.client.request.post
 import io.ktor.client.request.preparePost
+import io.ktor.client.request.request
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.append
 import io.ktor.http.contentType
@@ -264,29 +264,43 @@ internal class StreamingSyncClient(
         )
     }
 
+    private suspend fun authenticatedRequest(
+        path: String,
+        method: HttpMethod = HttpMethod.Get,
+        configure: HttpRequestBuilder.() -> Unit = {},
+    ): HttpResponse {
+        val credentials = connector.getCredentialsCached()
+        require(credentials != null) { "Not logged in" }
+        val uri = credentials.endpointUri(path)
+
+        val response =
+            httpClient.request(uri) {
+                this.method = method
+                contentType(ContentType.Application.Json)
+                headers {
+                    append(HttpHeaders.Authorization, "Token ${credentials.token}")
+                }
+                configure()
+            }
+
+        if (response.status.value == 401) {
+            connector.invalidateCredentials()
+        }
+
+        return response
+    }
+
     private suspend fun requestCheckpointFromService(payload: CheckpointRequestPayload): Long {
         // First, check if we can use a custom checkpoint request implementation.
         (connector as? CustomCheckpointRequestConnector)?.let {
             return it.postCheckpointRequest(payload.clientId, payload.checkpointRequestId)
         }
 
-        val credentials = connector.getCredentialsCached()
-        require(credentials != null) { "Not logged in" }
-        val uri = credentials.endpointUri("sync/checkpoint-request")
-
         val response =
-            httpClient.post(uri) {
-                contentType(ContentType.Application.Json)
-                headers {
-                    append(HttpHeaders.Authorization, "Token ${credentials.token}")
-                }
-
+            authenticatedRequest(path = "sync/checkpoint-request", method = HttpMethod.Post) {
                 setBody(JsonUtil.json.encodeToString(payload))
             }
 
-        if (response.status.value == 401) {
-            connector.invalidateCredentials()
-        }
         if (response.status.value == 404) {
             throw CheckpointRequestException.InstanceNotSupported()
         }
@@ -299,20 +313,8 @@ internal class StreamingSyncClient(
     }
 
     private suspend fun getLegacyWriteCheckpoint(): Long {
-        val credentials = connector.getCredentialsCached()
-        require(credentials != null) { "Not logged in" }
-        val uri = credentials.endpointUri("write-checkpoint2.json?client_id=${loadClientId()}")
+        val response = authenticatedRequest(path = "write-checkpoint2.json?client_id=${loadClientId()}")
 
-        val response =
-            httpClient.get(uri) {
-                contentType(ContentType.Application.Json)
-                headers {
-                    append(HttpHeaders.Authorization, "Token ${credentials.token}")
-                }
-            }
-        if (response.status.value == 401) {
-            connector.invalidateCredentials()
-        }
         if (response.status.value != 200) {
             throw Exception("Error getting write checkpoint: ${response.status}")
         }

--- a/common/src/commonMain/kotlin/com/powersync/sync/StreamingSyncClient.kt
+++ b/common/src/commonMain/kotlin/com/powersync/sync/StreamingSyncClient.kt
@@ -180,7 +180,7 @@ internal class StreamingSyncClient(
                     // Wait for the delay, or another component wanting to request a checkpoint.
                     withTimeoutOrNull(retryDelay) {
                         checkpointSignals.waitForCheckpointWaiter()
-                        logger.v { "Resuming due to pendin checkpoint waiter" }
+                        logger.v { "Resuming due to pending checkpoint waiter" }
                     }
                 }
             }

--- a/common/src/commonMain/kotlin/com/powersync/sync/SyncOptions.kt
+++ b/common/src/commonMain/kotlin/com/powersync/sync/SyncOptions.kt
@@ -1,9 +1,13 @@
 package com.powersync.sync
 
+import com.powersync.ExperimentalCheckpointRequestsApi
+import com.powersync.ExperimentalPowerSyncAPI
 import com.powersync.PowerSyncDatabase
 import io.ktor.client.HttpClient
 import io.ktor.client.HttpClientConfig
 import kotlin.native.HiddenFromObjC
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * Configuration options for the [PowerSyncDatabase.connect] method, allowing customization of
@@ -53,6 +57,10 @@ public class SyncOptions(
      * when they don't have an explicit subscription.
      */
     public val includeDefaultStreams: Boolean = true,
+    /**
+     * The mode used to request checkpoint requests from the PowerSync service.
+     */
+    public val checkpointMode: CheckpointMode = CheckpointMode.Legacy,
 ) {
     public companion object {
         /**
@@ -65,6 +73,50 @@ public class SyncOptions(
     init {
         check(newClientImplementation) {
             "Support for newClientImplementation = false has been removed"
+        }
+    }
+}
+
+/**
+ * The mechanism used to request checkpoints from the PowerSync service.
+ *
+ * Checkpoint requests are used after a client uploads local mutations (or when explicitly requested
+ * on the database). The PowerSync service later references them in downloaded data, allowing the
+ * SDK to assume that uploaded data has been synced down again.
+ *
+ * There are two ways to send checkpoint requests: A [Legacy] (but default and stable) format
+ * supported by all PowerSync service versions, and a newer [Requests] method which is only
+ * available from PowerSync service version 1.24.0 or later.
+ *
+ * Note that the requests checkpoint mode is an alpha API.
+ */
+public sealed class CheckpointMode {
+    /**
+     * Uses a legacy but stable endpoint to request checkpoints.
+     */
+    public object Legacy : CheckpointMode()
+
+    /**
+     * Adopts a new and more efficient checkpoint protocol with better support for switching users
+     * on devices.
+     */
+    @ExperimentalCheckpointRequestsApi
+    public data class Requests(
+        /**
+         * The periodic interval before re-posting the latest checkpoint request to the service if
+         * it has not been applied in time.
+         */
+        val retryDelay: Duration = defaultRetryDelay,
+    ) : CheckpointMode() {
+        init {
+            require(retryDelay >= minimumRetryDelay) {
+                "The retry delay for checkpoints must be at least $minimumRetryDelay"
+            }
+        }
+
+        private companion object {
+            val minimumRetryDelay: Duration = 10.seconds
+            val defaultRetryDelay = minimumRetryDelay
         }
     }
 }

--- a/common/src/commonMain/kotlin/com/powersync/sync/SyncStatus.kt
+++ b/common/src/commonMain/kotlin/com/powersync/sync/SyncStatus.kt
@@ -138,6 +138,11 @@ public sealed class SyncStatusData {
         return exposeStreamStatus(raw)
     }
 
+    internal fun isCheckpointRequestApplied(request: Long): Boolean {
+        val lastApplied = core?.lastAppliedCheckpointRequestId ?: return false
+        return lastApplied >= request
+    }
+
     private fun exposeStreamStatus(internal: CoreActiveStreamSubscription): SyncStreamStatus {
         val progress =
             if (this.downloadProgress == null) {

--- a/common/src/commonMain/kotlin/com/powersync/utils/Json.kt
+++ b/common/src/commonMain/kotlin/com/powersync/utils/Json.kt
@@ -15,6 +15,7 @@ internal object JsonUtil {
         Json {
             encodeDefaults = true
             ignoreUnknownKeys = true
+            explicitNulls = false
         }
 }
 

--- a/common/src/commonNonWeb/kotlin/com/powersync/PowerSyncDatabaseFactory.kt
+++ b/common/src/commonNonWeb/kotlin/com/powersync/PowerSyncDatabaseFactory.kt
@@ -9,7 +9,10 @@ import com.powersync.db.schema.Schema
 import com.powersync.utils.generateLogger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.IO
+import kotlin.coroutines.CoroutineContext
 
 public const val DEFAULT_DB_FILENAME: String = "powersync.db"
 
@@ -49,6 +52,7 @@ internal fun createPowerSyncDatabaseImpl(
     scope: CoroutineScope,
     logger: Logger,
     dbDirectory: String?,
+    databaseIoDispatcher: CoroutineContext = Dispatchers.IO,
 ): PowerSyncDatabaseImpl {
     val identifier = dbDirectory + dbFilename
     val activeDatabaseGroup = ActiveDatabaseGroup.referenceDatabase(logger, identifier)
@@ -61,6 +65,7 @@ internal fun createPowerSyncDatabaseImpl(
                 dbFilename,
                 dbDirectory,
                 activeDatabaseGroup.first.group.writeLockMutex,
+                databaseIoDispatcher,
             )
         }
 

--- a/common/src/commonNonWeb/kotlin/com/powersync/db/driver/InternalConnectionPool.kt
+++ b/common/src/commonNonWeb/kotlin/com/powersync/db/driver/InternalConnectionPool.kt
@@ -6,33 +6,29 @@ import com.powersync.ExperimentalPowerSyncAPI
 import com.powersync.PersistentConnectionFactory
 import com.powersync.utils.JsonUtil
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import kotlin.coroutines.CoroutineContext
 
 @OptIn(ExperimentalPowerSyncAPI::class)
 internal class InternalConnectionPool(
     private val factory: PersistentConnectionFactory,
-    private val scope: CoroutineScope,
+    scope: CoroutineScope,
     private val dbFilename: String,
     private val dbDirectory: String?,
     private val writeLockMutex: Mutex,
+    /**
+     * Database calls are synchronous/blocking, so we always run them on Dispatchers.IO instead of
+     * inheriting the caller-provided scope context. The provided scope is still used for
+     * lifecycle-bound pool coroutines like read workers and update emission.
+     */
+    private val dispatcher: CoroutineContext,
 ) : SQLiteConnectionPool {
     private val writeConnection = newConnection(false)
     private val readPool = ReadPool({ newConnection(true) }, scope = scope)
-
-    // MutableSharedFlow to emit batched table updates
-    private val tableUpdatesFlow = MutableSharedFlow<Set<String>>(replay = 0)
-
-    // Database calls are synchronous/blocking, so we always run them on Dispatchers.IO instead of
-    // inheriting the caller-provided scope context. The provided scope is still used for
-    // lifecycle-bound pool coroutines like read workers and update emission.
-    private val dispatcher = Dispatchers.IO
 
     private fun newConnection(readOnly: Boolean): SQLiteConnection {
         val connection =
@@ -55,18 +51,17 @@ internal class InternalConnectionPool(
 
     override suspend fun <T> write(callback: suspend (SQLiteConnectionLease) -> T): T =
         writeLockMutex.withLock {
-            withContext(dispatcher) {
-                try {
+            try {
+                withContext(dispatcher) {
                     callback(RawConnectionLease(writeConnection))
-                } finally {
-                    // When we've leased a write connection, we may have to update table update flows
-                    // after users ran their custom statements.
-                    val updatedTables = writeConnection.readPendingUpdates()
-                    if (updatedTables.isNotEmpty()) {
-                        scope.launch {
-                            tableUpdatesFlow.emit(updatedTables)
-                        }
-                    }
+                }
+            } finally {
+                // When we've leased a write connection, we may have to update table update flows
+                // after users ran their custom statements. Reading updates is a SQL call, but it
+                // doesn't do IO so we can do it on the main dispatcher.
+                val updatedTables = writeConnection.readPendingUpdates()
+                if (updatedTables.isNotEmpty()) {
+                    updates.emit(updatedTables)
                 }
             }
         }
@@ -83,8 +78,9 @@ internal class InternalConnectionPool(
         }
     }
 
+    // MutableSharedFlow to emit batched table updates
     override val updates: SharedFlow<Set<String>>
-        get() = tableUpdatesFlow
+        field = MutableSharedFlow<Set<String>>(replay = 0)
 
     override suspend fun close() {
         writeConnection.close()

--- a/common/src/commonNonWeb/kotlin/com/powersync/db/driver/InternalConnectionPool.kt
+++ b/common/src/commonNonWeb/kotlin/com/powersync/db/driver/InternalConnectionPool.kt
@@ -49,22 +49,27 @@ internal class InternalConnectionPool(
             }
         }
 
-    override suspend fun <T> write(callback: suspend (SQLiteConnectionLease) -> T): T =
-        writeLockMutex.withLock {
-            try {
+    override suspend fun <T> write(callback: suspend (SQLiteConnectionLease) -> T): T {
+        var updatedTables: Set<String> = emptySet()
+        try {
+            return writeLockMutex.withLock {
                 withContext(dispatcher) {
-                    callback(RawConnectionLease(writeConnection))
-                }
-            } finally {
-                // When we've leased a write connection, we may have to update table update flows
-                // after users ran their custom statements. Reading updates is a SQL call, but it
-                // doesn't do IO so we can do it on the main dispatcher.
-                val updatedTables = writeConnection.readPendingUpdates()
-                if (updatedTables.isNotEmpty()) {
-                    updates.emit(updatedTables)
+                    try {
+                        callback(RawConnectionLease(writeConnection))
+                    } finally {
+                        // When we've leased a write connection, we may have to update table update
+                        // flows after users ran their custom statements.
+                        updatedTables = writeConnection.readPendingUpdates()
+                    }
                 }
             }
+        } finally {
+            // Emit updates on teh main context, and outside the write lock.
+            if (updatedTables.isNotEmpty()) {
+                updates.emit(updatedTables)
+            }
         }
+    }
 
     override suspend fun <R> withAllConnections(action: suspend (SQLiteConnectionLease, List<SQLiteConnectionLease>) -> R) {
         // First get a lock on all read connections

--- a/common/src/commonNonWeb/kotlin/com/powersync/db/driver/InternalConnectionPool.kt
+++ b/common/src/commonNonWeb/kotlin/com/powersync/db/driver/InternalConnectionPool.kt
@@ -64,7 +64,7 @@ internal class InternalConnectionPool(
                 }
             }
         } finally {
-            // Emit updates on teh main context, and outside the write lock.
+            // Emit updates on the main context and outside the write lock.
             if (updatedTables.isNotEmpty()) {
                 updates.emit(updatedTables)
             }

--- a/common/src/commonTest/kotlin/com/powersync/testutils/MockSyncService.kt
+++ b/common/src/commonTest/kotlin/com/powersync/testutils/MockSyncService.kt
@@ -123,7 +123,12 @@ internal class MockSyncService(
             }
 
             val request = JsonUtil.json.decodeFromString<CheckpointRequestPayload>(data.body.toByteArray().decodeToString())
-            requestCheckpoints.lastCheckpointRequest.update { max(it, request.checkpointRequestId) }
+            var checkpointResponse = 0L
+            requestCheckpoints.lastCheckpointRequest.update {
+                val resolved = max(it, request.checkpointRequestId)
+                checkpointResponse = resolved
+                resolved
+            }
             requestCheckpoints.checkpointRequestCount.update { it + 1 }
             requestCheckpoints.beforeCheckpointRequestResponse()
 
@@ -134,7 +139,7 @@ internal class MockSyncService(
                 HttpProtocolVersion.HTTP_1_1,
                 JsonUtil.json.encodeToString(
                     CheckpointRequestResponse(
-                        data = CheckpointRequestResponseData(requestCheckpoints.lastCheckpointRequest.value),
+                        data = CheckpointRequestResponseData(checkpointResponse),
                     ),
                 ),
                 context,

--- a/common/src/commonTest/kotlin/com/powersync/testutils/MockSyncService.kt
+++ b/common/src/commonTest/kotlin/com/powersync/testutils/MockSyncService.kt
@@ -1,6 +1,9 @@
 package com.powersync.testutils
 
 import app.cash.turbine.ReceiveTurbine
+import com.powersync.bucket.CheckpointRequestPayload
+import com.powersync.bucket.CheckpointRequestResponse
+import com.powersync.bucket.CheckpointRequestResponseData
 import com.powersync.bucket.WriteCheckpointResponse
 import com.powersync.sync.SyncStatusData
 import com.powersync.utils.JsonUtil
@@ -8,6 +11,7 @@ import io.ktor.client.engine.HttpClientEngineBase
 import io.ktor.client.engine.HttpClientEngineCapability
 import io.ktor.client.engine.HttpClientEngineConfig
 import io.ktor.client.engine.callContext
+import io.ktor.client.engine.mock.toByteArray
 import io.ktor.client.plugins.HttpTimeoutCapability
 import io.ktor.client.request.HttpRequestData
 import io.ktor.client.request.HttpResponseData
@@ -25,7 +29,13 @@ import io.ktor.utils.io.writer
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.consume
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.sync.Mutex
 import kotlinx.serialization.json.JsonElement
+import kotlin.concurrent.atomics.AtomicLong
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+import kotlin.math.max
 
 /**
  * A mock HTTP engine providing sync lines read from a coroutines [ReceiveChannel].
@@ -37,6 +47,7 @@ import kotlinx.serialization.json.JsonElement
 internal class MockSyncService(
     private val lines: () -> ReceiveChannel<Any>,
     private val syncLinesContentType: () -> ContentType,
+    private val requestCheckpoints: CheckpointRequestsTestState,
     private val generateCheckpoint: () -> WriteCheckpointResponse,
     private val trackSyncRequest: suspend (HttpRequestData) -> Unit,
 ) : HttpClientEngineBase("sync-service") {
@@ -53,7 +64,8 @@ internal class MockSyncService(
         val context = callContext()
         val scope = CoroutineScope(context)
 
-        return if (data.url.encodedPath == "/sync/stream") {
+        val path = data.url.encodedPath
+        return if (path == "/sync/stream") {
             trackSyncRequest(data)
             val job =
                 scope.writer {
@@ -98,7 +110,36 @@ internal class MockSyncService(
                 job.channel,
                 context,
             )
-        } else if (data.url.encodedPath == "/write-checkpoint2.json") {
+        } else if (path == "/sync/checkpoint-request") {
+            if (!requestCheckpoints.checkpointRequestsSupported) {
+                return HttpResponseData(
+                    HttpStatusCode.NotFound,
+                    GMTDate(),
+                    headersOf(),
+                    HttpProtocolVersion.HTTP_1_1,
+                    body = "",
+                    context,
+                )
+            }
+
+            val request = JsonUtil.json.decodeFromString<CheckpointRequestPayload>(data.body.toByteArray().decodeToString())
+            requestCheckpoints.lastCheckpointRequest.update { max(it, request.checkpointRequestId) }
+            requestCheckpoints.checkpointRequestCount.update { it + 1 }
+            requestCheckpoints.beforeCheckpointRequestResponse()
+
+            HttpResponseData(
+                HttpStatusCode.OK,
+                GMTDate(),
+                headersOf(HttpHeaders.ContentType, "application/json"),
+                HttpProtocolVersion.HTTP_1_1,
+                JsonUtil.json.encodeToString(
+                    CheckpointRequestResponse(
+                        data = CheckpointRequestResponseData(requestCheckpoints.lastCheckpointRequest.value),
+                    ),
+                ),
+                context,
+            )
+        } else if (path == "/write-checkpoint2.json") {
             HttpResponseData(
                 HttpStatusCode.OK,
                 GMTDate(),
@@ -138,4 +179,11 @@ suspend inline fun ReceiveTurbine<SyncStatusData>.waitFor(
             }
         }
     }
+}
+
+internal class CheckpointRequestsTestState {
+    val lastCheckpointRequest = MutableStateFlow(0L)
+    val checkpointRequestCount = MutableStateFlow(0)
+    var checkpointRequestsSupported = true
+    var beforeCheckpointRequestResponse: suspend () -> Unit = {}
 }

--- a/common/src/commonTest/kotlin/com/powersync/testutils/SyncLine.kt
+++ b/common/src/commonTest/kotlin/com/powersync/testutils/SyncLine.kt
@@ -43,8 +43,8 @@ internal sealed interface SyncLine {
         val bucket: String,
         val data: List<OplogEntry>,
         @SerialName("has_more") val hasMore: Boolean = false,
-        val after: String?,
-        @SerialName("next_after")val nextAfter: String?,
+        val after: String? = null,
+        @SerialName("next_after")val nextAfter: String? = null,
     ) : SyncLine
 
     data class KeepAlive(

--- a/common/src/commonTest/kotlin/powersync/sync/CheckpointStateSignalsTest.kt
+++ b/common/src/commonTest/kotlin/powersync/sync/CheckpointStateSignalsTest.kt
@@ -1,0 +1,79 @@
+package powersync.sync
+
+import com.powersync.ExperimentalCheckpointRequestsApi
+import com.powersync.sync.CheckpointRequestException
+import com.powersync.sync.CheckpointStateSignals
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.yield
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+@OptIn(ExperimentalCheckpointRequestsApi::class)
+class CheckpointStateSignalsTest {
+    private lateinit var signals: CheckpointStateSignals
+
+    @BeforeTest
+    fun setup() {
+        signals = CheckpointStateSignals()
+    }
+
+    @Test
+    fun markReadySuccess() =
+        runTest {
+            signals.markCheckpointsReady { }
+            signals.waitForCheckpointRequestsReady()
+        }
+
+    @Test
+    fun markReadyFailure() =
+        runTest {
+            shouldThrow<Exception> { signals.markCheckpointsReady { throw Exception("stub") } }
+            shouldThrow<Exception> { signals.waitForCheckpointRequestsReady() }
+        }
+
+    @Test
+    fun markDisconnected() =
+        runTest {
+            signals.disconnected()
+            shouldThrow<CheckpointRequestException.Disconnected> { signals.waitForCheckpointRequestsReady() }
+        }
+
+    @Test
+    fun supportsConcurrentWaiters() =
+        runTest {
+            val first = async { signals.waitForCheckpointRequestsReady() }
+            val second = async { signals.waitForCheckpointRequestsReady() }
+            yield()
+
+            signals.markCheckpointsReady { }
+            first.await()
+            second.await()
+        }
+
+    @Test
+    fun waitForCheckpointWaiterIsNotified() =
+        runTest {
+            val notified = async { signals.waitForCheckpointWaiter() }
+            launch { signals.waitForCheckpointRequestsReady() }
+
+            notified.await()
+            signals.markCheckpointsReady { }
+        }
+
+    @Test
+    fun doesNotNotifyWaiterWhenWakeDownloadLoopIsFalse() =
+        runTest {
+            val notified = async { signals.waitForCheckpointWaiter() }
+            val waitReady = launch { signals.waitForCheckpointRequestsReady(wakeDownloadLoop = false) }
+
+            testScheduler.runCurrent()
+            notified.isCompleted shouldBe false
+
+            waitReady.cancel()
+            notified.cancel()
+        }
+}

--- a/common/src/commonTest/kotlin/powersync/sync/StreamingSyncClientTest.kt
+++ b/common/src/commonTest/kotlin/powersync/sync/StreamingSyncClientTest.kt
@@ -19,11 +19,9 @@ import com.powersync.sync.SyncOptions
 import com.powersync.sync.SyncStatus
 import com.powersync.sync.configureSyncHttpClient
 import com.powersync.test.TestConnector
-import com.powersync.test.waitFor
 import dev.mokkery.answering.returns
 import dev.mokkery.everySuspend
 import dev.mokkery.mock
-import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeTypeOf
@@ -31,21 +29,17 @@ import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.utils.io.ByteChannel
 import io.ktor.utils.io.writeByteArray
-import kotlinx.coroutines.async
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.withTimeout
 import kotlinx.io.EOFException
 import kotlinx.serialization.json.JsonObject
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
-import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 @OptIn(ExperimentalKermitApi::class, ExperimentalPowerSyncAPI::class)


### PR DESCRIPTION
This adds opt-in support for the new checkpoint request endpoint, similar to [this JS PR](https://github.com/powersync-ja/powersync-js/pull/1073).

With the new endpoint, clients keep track of their local request state and reconcile it with the PowerSync service at the beginning of a sync iteration. For the most part, the core extension tells us what to do. The main change in the implementation is to delay checkpoint requests until that initial reconciliation is complete. We also need to periodically re-request checkpoints that haven't been applied yet as the service is allowed to forget about them.

AI use: Tests ported from the JavaScript SDK with Claude Code. I also used Claude to deflake a few tests.