### PR TITLE
Sync client improvements

### DIFF
--- a/common/src/commonIntegrationTest/kotlin/com/powersync/sync/SyncIntegrationTest.kt
+++ b/common/src/commonIntegrationTest/kotlin/com/powersync/sync/SyncIntegrationTest.kt
@@ -161,7 +161,7 @@ class SyncIntegrationTest : AbstractSyncTest() {
 
                 database.disconnect()
                 turbine.waitFor { !it.connected }
-                turbine.cancel()
+                turbine.cancelAndIgnoreRemainingEvents()
             }
 
             // Disconnecting should have closed the channel
@@ -359,7 +359,7 @@ class SyncIntegrationTest : AbstractSyncTest() {
                 database.disconnect()
 
                 turbine.waitFor { !it.connecting && !it.connected }
-                turbine.cancel()
+                turbine.cancelAndIgnoreRemainingEvents()
             }
         }
 
@@ -721,7 +721,7 @@ class SyncIntegrationTest : AbstractSyncTest() {
             var attempt = 0
             val connector =
                 object : PowerSyncBackendConnector() {
-                    override suspend fun fetchCredentials(): PowerSyncCredentials? {
+                    override suspend fun fetchCredentials(): PowerSyncCredentials {
                         attempt++
                         if (attempt == 1) {
                             fail("Expected exception from fetchCredentials")
@@ -744,7 +744,12 @@ class SyncIntegrationTest : AbstractSyncTest() {
                 database.currentStatus.downloadError?.toString() shouldContain "Expected exception from fetchCredentials"
 
                 // Should retry, and the second fetchCredentials call will work
-                turbine.waitFor { it.connected }
+                turbine.waitFor(allowError = true) { it.connected }
+
+                // The download error is cleared after a complete sync.
+                syncLines.send(SyncLine.FullCheckpoint(Checkpoint(lastOpId = "0", checksums = emptyList())))
+                syncLines.send(SyncLine.CheckpointComplete(lastOpId = "0"))
+                turbine.waitFor(allowError = true) { it.downloadError == null }
 
                 turbine.cancelAndIgnoreRemainingEvents()
             }
@@ -1077,7 +1082,7 @@ class SyncIntegrationTest : AbstractSyncTest() {
                 }
 
                 syncLines = Channel()
-                turbine.waitFor { it.connected }
+                turbine.waitFor(allowError = true) { it.connected }
                 turbine.cancelAndIgnoreRemainingEvents()
             }
         }

--- a/common/src/commonIntegrationTest/kotlin/com/powersync/sync/SyncIntegrationTest.kt
+++ b/common/src/commonIntegrationTest/kotlin/com/powersync/sync/SyncIntegrationTest.kt
@@ -54,7 +54,6 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.fail
 import kotlin.time.Clock
-import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.measureTime
 

--- a/common/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
+++ b/common/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
@@ -156,15 +156,15 @@ internal class PowerSyncDatabaseImpl(
         mutex.withLock {
             disconnectInternal()
 
-            connectInternal(crudThrottleMs) { scope ->
+            connectInternal { scope ->
                 StreamingSyncClient(
                     bucketStorage = bucketStorage,
                     connector = connector,
                     uploadCrud = suspend { connector.uploadData(this) },
-                    retryDelayMs = retryDelayMs,
+                    retryDelay = retryDelayMs.milliseconds,
+                    crudUploadThrottle = crudThrottleMs.milliseconds,
                     logger = logger,
                     params = params.toJsonObject(),
-                    uploadScope = scope,
                     options = options,
                     schema = schema,
                     activeSubscriptions = streams.currentlyReferencedStreams,
@@ -174,10 +174,7 @@ internal class PowerSyncDatabaseImpl(
         }
     }
 
-    private fun connectInternal(
-        crudThrottleMs: Long,
-        createStream: (CoroutineScope) -> StreamingSyncClient,
-    ) {
+    private fun connectInternal(createStream: (CoroutineScope) -> StreamingSyncClient) {
         val db = this
         val job = SupervisorJob(scope.coroutineContext[Job])
         syncSupervisorJob = job
@@ -229,10 +226,7 @@ internal class PowerSyncDatabaseImpl(
                 internalDb
                     .updatesOnTables()
                     .filter { it.contains(InternalTable.CRUD.toString()) }
-                    .throttle(crudThrottleMs.milliseconds)
-                    .collect {
-                        stream.triggerCrudUploadAsync().join()
-                    }
+                    .collect { stream.triggerCrudUpload() }
             }
         }
 

--- a/common/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
+++ b/common/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
@@ -461,7 +461,7 @@ internal class PowerSyncDatabaseImpl(
             }
 
         currentStatus.update {
-            copy(core=offlineSyncStatus)
+            copy(core = offlineSyncStatus)
         }
     }
 

--- a/common/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
+++ b/common/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
@@ -423,15 +423,6 @@ internal class PowerSyncDatabaseImpl(
             syncJob.join()
             syncSupervisorJob = null
         }
-
-        currentStatus.update {
-            copy(
-                connected = false,
-                connecting = false,
-                downloading = false,
-                downloadProgress = null,
-            )
-        }
     }
 
     override suspend fun disconnectAndClear(
@@ -451,7 +442,7 @@ internal class PowerSyncDatabaseImpl(
         internalDb.writeTransactionAsync { tx ->
             tx.getOptionalAsync("SELECT powersync_clear(?)", listOf(flags)) {}
         }
-        currentStatus.update { copy(lastSyncedAt = null, hasSynced = false) }
+        resolveOfflineSyncStatus()
     }
 
     internal suspend fun resolveOfflineSyncStatusIfNotConnected() {
@@ -470,7 +461,7 @@ internal class PowerSyncDatabaseImpl(
             }
 
         currentStatus.update {
-            applyCoreChanges(offlineSyncStatus)
+            copy(core=offlineSyncStatus)
         }
     }
 

--- a/common/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
+++ b/common/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
@@ -28,7 +28,6 @@ import com.powersync.sync.SyncStream
 import com.powersync.utils.HeldMutex
 import com.powersync.utils.JsonParam
 import com.powersync.utils.JsonUtil
-import com.powersync.utils.throttle
 import com.powersync.utils.toJsonObject
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
@@ -158,6 +157,7 @@ internal class PowerSyncDatabaseImpl(
 
             connectInternal { scope ->
                 StreamingSyncClient(
+                    status = currentStatus,
                     bucketStorage = bucketStorage,
                     connector = connector,
                     uploadCrud = suspend { connector.uploadData(this) },
@@ -216,10 +216,6 @@ internal class PowerSyncDatabaseImpl(
                     ensureActive()
                     stream.streamingSync()
                 }
-            }
-
-            launch {
-                currentStatus.trackOther(stream.status)
             }
 
             launch {

--- a/common/src/commonMain/kotlin/com/powersync/sync/Instruction.kt
+++ b/common/src/commonMain/kotlin/com/powersync/sync/Instruction.kt
@@ -26,7 +26,7 @@ internal sealed interface Instruction {
     /**
      * An [Instruction] that doesn't start or stop a sync iteration.
      */
-    sealed interface NonInterruptingInstruction: Instruction
+    sealed interface NonInterruptingInstruction : Instruction
 
     @Serializable
     data class LogLine(

--- a/common/src/commonMain/kotlin/com/powersync/sync/Instruction.kt
+++ b/common/src/commonMain/kotlin/com/powersync/sync/Instruction.kt
@@ -23,16 +23,21 @@ import kotlin.time.Instant
  */
 @Serializable(with = Instruction.Serializer::class)
 internal sealed interface Instruction {
+    /**
+     * An [Instruction] that doesn't start or stop a sync iteration.
+     */
+    sealed interface NonInterruptingInstruction: Instruction
+
     @Serializable
     data class LogLine(
         val severity: String,
         val line: String,
-    ) : Instruction
+    ) : NonInterruptingInstruction
 
     @Serializable
     data class UpdateSyncStatus(
         val status: CoreSyncStatus,
-    ) : Instruction
+    ) : NonInterruptingInstruction
 
     @Serializable
     data class EstablishSyncStream(
@@ -43,9 +48,7 @@ internal sealed interface Instruction {
     data class FetchCredentials(
         @SerialName("did_expire")
         val didExpire: Boolean,
-    ) : Instruction
-
-    data object FlushSileSystem : Instruction
+    ) : NonInterruptingInstruction
 
     @Serializable
     data class CloseSyncStream(
@@ -53,18 +56,17 @@ internal sealed interface Instruction {
         val hideDisconnect: Boolean,
     ) : Instruction
 
-    data object DidCompleteSync : Instruction
+    data object DidCompleteSync : NonInterruptingInstruction
 
     data class UnknownInstruction(
         val raw: JsonElement?,
-    ) : Instruction
+    ) : NonInterruptingInstruction
 
     class Serializer : KSerializer<Instruction> {
         private val logLine = serializer<LogLine>()
         private val updateSyncStatus = serializer<UpdateSyncStatus>()
         private val establishSyncStream = serializer<EstablishSyncStream>()
         private val fetchCredentials = serializer<FetchCredentials>()
-        private val flushFileSystem = serializer<JsonObject>()
         private val closeSyncStream = serializer<CloseSyncStream>()
         private val didCompleteSync = serializer<JsonObject>()
 
@@ -74,7 +76,6 @@ internal sealed interface Instruction {
                 element("UpdateSyncStatus", updateSyncStatus.descriptor, isOptional = true)
                 element("EstablishSyncStream", establishSyncStream.descriptor, isOptional = true)
                 element("FetchCredentials", fetchCredentials.descriptor, isOptional = true)
-                element("FlushFileSystem", flushFileSystem.descriptor, isOptional = true)
                 element("CloseSyncStream", closeSyncStream.descriptor, isOptional = true)
                 element("DidCompleteSync", didCompleteSync.descriptor, isOptional = true)
             }
@@ -100,15 +101,10 @@ internal sealed interface Instruction {
                         }
 
                         4 -> {
-                            decodeSerializableElement(descriptor, 4, flushFileSystem)
-                            FlushSileSystem
-                        }
-
-                        5 -> {
                             decodeSerializableElement(descriptor, 5, closeSyncStream)
                         }
 
-                        6 -> {
+                        5 -> {
                             decodeSerializableElement(descriptor, 6, didCompleteSync)
                             DidCompleteSync
                         }

--- a/common/src/commonMain/kotlin/com/powersync/sync/Instruction.kt
+++ b/common/src/commonMain/kotlin/com/powersync/sync/Instruction.kt
@@ -101,11 +101,11 @@ internal sealed interface Instruction {
                         }
 
                         4 -> {
-                            decodeSerializableElement(descriptor, 5, closeSyncStream)
+                            decodeSerializableElement(descriptor, 4, closeSyncStream)
                         }
 
                         5 -> {
-                            decodeSerializableElement(descriptor, 6, didCompleteSync)
+                            decodeSerializableElement(descriptor, 5, didCompleteSync)
                             DidCompleteSync
                         }
 

--- a/common/src/commonMain/kotlin/com/powersync/sync/StreamingSyncClient.kt
+++ b/common/src/commonMain/kotlin/com/powersync/sync/StreamingSyncClient.kt
@@ -125,13 +125,9 @@ internal class StreamingSyncClient(
     private suspend fun downloadLoop() {
         var invalidCredentials = false
         clientId = bucketStorage.getClientId()
-        var result = SyncIterationResult()
 
         while (true) {
-            if (!result.hideDisconnectStateAndReconnectImmediately) {
-                status.update { copy(connecting = true) }
-            }
-            result = SyncIterationResult()
+            var result = SyncIterationResult()
 
             try {
                 if (invalidCredentials) {
@@ -166,13 +162,6 @@ internal class StreamingSyncClient(
                 status.update { copy(downloadError = e) }
             } finally {
                 if (!result.hideDisconnectStateAndReconnectImmediately) {
-                    status.update {
-                        copy(
-                            connected = false,
-                            connecting = true,
-                            downloading = false,
-                        )
-                    }
                     delay(retryDelay)
                 }
             }
@@ -489,9 +478,7 @@ internal class StreamingSyncClient(
                 }
 
                 is Instruction.UpdateSyncStatus -> {
-                    status.update {
-                        applyCoreChanges(instruction.status)
-                    }
+                    status.update { copy(core=instruction.status) }
                 }
 
                 is Instruction.FetchCredentials -> {

--- a/common/src/commonMain/kotlin/com/powersync/sync/StreamingSyncClient.kt
+++ b/common/src/commonMain/kotlin/com/powersync/sync/StreamingSyncClient.kt
@@ -2,7 +2,6 @@ package com.powersync.sync
 
 import co.touchlab.kermit.Logger
 import co.touchlab.kermit.Severity
-import co.touchlab.stately.concurrency.AtomicReference
 import com.powersync.ExperimentalPowerSyncAPI
 import com.powersync.PowerSyncException
 import com.powersync.bucket.BucketStorage
@@ -33,8 +32,6 @@ import io.ktor.utils.io.readAvailable
 import io.ktor.utils.io.readBuffer
 import io.ktor.utils.io.readLineStrict
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
@@ -58,23 +55,34 @@ import kotlinx.io.readByteArray
 import kotlinx.io.readIntLe
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 @OptIn(ExperimentalPowerSyncAPI::class)
 internal class StreamingSyncClient(
     private val bucketStorage: BucketStorage,
     private val connector: PowerSyncBackendConnector,
     private val uploadCrud: suspend () -> Unit,
-    private val retryDelayMs: Long = 5000L,
+    private val retryDelay: Duration = 5.seconds,
+    private val crudUploadThrottle: Duration = 1.seconds,
     private val logger: Logger,
     private val params: JsonObject,
-    private val uploadScope: CoroutineScope,
     private val options: SyncOptions,
     private val schema: Schema,
     private val activeSubscriptions: StateFlow<List<SubscriptionGroup>>,
     private val appMetadata: Map<String, String> = emptyMap(),
 ) {
-    private var isUploadingCrud = AtomicReference<PendingCrudUpload?>(null)
-    private var completedCrudUploads = Channel<Unit>(onBufferOverflow = BufferOverflow.DROP_OLDEST)
+    private var requestedCrudUploads =
+        Channel<Unit>(
+            capacity = 1,
+            onBufferOverflow = BufferOverflow.DROP_OLDEST,
+        )
+    private var completedCrudUploads =
+        Channel<Unit>(
+            capacity = 1,
+            onBufferOverflow = BufferOverflow.DROP_OLDEST,
+        )
 
     /**
      * The current sync status. This instance is mutated as changes occur
@@ -101,7 +109,24 @@ internal class StreamingSyncClient(
         connector.invalidateCredentials()
     }
 
+    /**
+     * Triggers a crud upload without awaiting it.
+     *
+     * A crud upload will be started at some point after this call, but the upload actor throttles
+     * these requests.
+     */
+    suspend fun triggerCrudUpload() {
+        requestedCrudUploads.send(Unit)
+    }
+
     suspend fun streamingSync() {
+        coroutineScope {
+            launch { downloadLoop() }
+            launch { crudUploadLoop() }
+        }
+    }
+
+    private suspend fun downloadLoop() {
         var invalidCredentials = false
         clientId = bucketStorage.getClientId()
         var result = SyncIterationResult()
@@ -152,34 +177,30 @@ internal class StreamingSyncClient(
                             downloading = false,
                         )
                     }
-                    delay(retryDelayMs)
+                    delay(retryDelay)
                 }
             }
         }
     }
 
-    fun triggerCrudUploadAsync(): Job =
-        uploadScope.launch(CoroutineName("triggerCrudUploadAsync")) {
-            val thisIteration = PendingCrudUpload(CompletableDeferred())
-            var holdingUploadLock = false
-
-            try {
-                if (!status.connected || !isUploadingCrud.compareAndSet(null, thisIteration)) {
-                    return@launch
+    private suspend fun crudUploadLoop() {
+        while (true) {
+            coroutineScope {
+                // Start the initial CRUD upload on connect. Then, keep polling until we're done.
+                launch {
+                    try {
+                        uploadAllCrud()
+                    } finally {
+                        logger.v { "crud upload: notify completion" }
+                        completedCrudUploads.send(Unit)
+                    }
                 }
-
-                holdingUploadLock = true
-                uploadAllCrud()
-            } finally {
-                if (holdingUploadLock) {
-                    logger.v { "crud upload: notify completion" }
-                    completedCrudUploads.send(Unit)
-                    isUploadingCrud.set(null)
-                }
-
-                thisIteration.done.complete(Unit)
+                launch { delay(crudUploadThrottle) }
             }
+
+            requestedCrudUploads.receive()
         }
+    }
 
     private suspend fun uploadAllCrud() {
         var checkedCrudItem: CrudEntry? = null
@@ -216,7 +237,7 @@ internal class StreamingSyncClient(
                 }
 
                 logger.e { "Error uploading crud: ${e.message}" }
-                delay(retryDelayMs)
+                delay(retryDelay)
                 break
             }
         }
@@ -409,7 +430,6 @@ internal class StreamingSyncClient(
                     // cases. We do this on the first sync line because the client is likely to be
                     // online in that case.
                     hadSyncLine = true
-                    triggerCrudUploadAsync()
                 }
             }
 
@@ -585,10 +605,6 @@ internal class StreamingSyncClient(
         }
     }
 }
-
-private class PendingCrudUpload(
-    val done: CompletableDeferred<Unit>,
-)
 
 private class SyncIterationResult(
     val hideDisconnectStateAndReconnectImmediately: Boolean = false,

--- a/common/src/commonMain/kotlin/com/powersync/sync/StreamingSyncClient.kt
+++ b/common/src/commonMain/kotlin/com/powersync/sync/StreamingSyncClient.kt
@@ -41,6 +41,7 @@ import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.ProducerScope
 import kotlinx.coroutines.channels.ReceiveChannel
+import kotlinx.coroutines.channels.consume
 import kotlinx.coroutines.channels.consumeEach
 import kotlinx.coroutines.channels.produce
 import kotlinx.coroutines.coroutineScope
@@ -354,10 +355,11 @@ internal class StreamingSyncClient(
      * improving performance.
      */
     private inner class ActiveIteration {
-        private var needsCredentialsRefresh = Channel<Unit>(
-            capacity = 1,
-            onBufferOverflow = BufferOverflow.DROP_OLDEST,
-        )
+        private var needsCredentialsRefresh =
+            Channel<Unit>(
+                capacity = 1,
+                onBufferOverflow = BufferOverflow.DROP_OLDEST,
+            )
 
         suspend fun syncIteration(): SyncIterationResult {
             return try {
@@ -375,8 +377,14 @@ internal class StreamingSyncClient(
                                     logger.v { "Closing sync stream connection. Hide disconnect: $hideDisconnect" }
                                     return@coroutineScope SyncIterationResult(hideDisconnect)
                                 }
-                                is Instruction.EstablishSyncStream -> error("Already has stream")
-                                is Instruction.NonInterruptingInstruction -> handleInstruction(instruction)
+
+                                is Instruction.EstablishSyncStream -> {
+                                    error("Already has stream")
+                                }
+
+                                is Instruction.NonInterruptingInstruction -> {
+                                    handleInstruction(instruction)
+                                }
                             }
                         }
                     }
@@ -404,15 +412,16 @@ internal class StreamingSyncClient(
         private suspend fun start(): Pair<Instruction.EstablishSyncStream, List<SubscriptionGroup>>? {
             val subscriptions = activeSubscriptions.value
 
-            val startInstructions = bucketStorage.control(
-                PowerSyncControlArguments.Start(
-                    parameters = params,
-                    schema = schema,
-                    includeDefaults = options.includeDefaultStreams,
-                    activeStreams = subscriptions.map { it.key },
-                    appMetadata = appMetadata,
-                ),
-            )
+            val startInstructions =
+                bucketStorage.control(
+                    PowerSyncControlArguments.Start(
+                        parameters = params,
+                        schema = schema,
+                        includeDefaults = options.includeDefaultStreams,
+                        activeStreams = subscriptions.map { it.key },
+                        appMetadata = appMetadata,
+                    ),
+                )
             var start: Instruction.EstablishSyncStream? = null
 
             for (instruction in startInstructions) {
@@ -420,10 +429,14 @@ internal class StreamingSyncClient(
                     is Instruction.EstablishSyncStream -> {
                         start = instruction
                     }
+
                     is Instruction.CloseSyncStream -> {
                         return null
                     }
-                    is Instruction.NonInterruptingInstruction -> handleInstruction(instruction)
+
+                    is Instruction.NonInterruptingInstruction -> {
+                        handleInstruction(instruction)
+                    }
                 }
             }
 
@@ -487,17 +500,17 @@ internal class StreamingSyncClient(
                     needsCredentialsRefresh.consumeEach {
                         try {
                             connector.updateCredentials()
+
+                            logger.v { "Stopping because new credentials are available" }
+                            // Token has been refreshed, start another iteration
+                            send(PowerSyncControlArguments.DidRefreshToken)
                         } catch (e: Exception) {
-                            if (e !is CancellationException) {
-                                logger.w(throwable=e) { "Failure in updateCredentials" }
+                            if (e is CancellationException) {
+                                throw e
+                            } else {
+                                logger.w(throwable = e) { "Failure in updateCredentials" }
                             }
-
-                            throw e
                         }
-
-                        logger.v { "Stopping because new credentials are available" }
-                        // Token has been refreshed, start another iteration
-                        send(PowerSyncControlArguments.DidRefreshToken)
                     }
                 }
             }
@@ -518,9 +531,11 @@ internal class StreamingSyncClient(
                         throwable = null,
                     )
                 }
+
                 is Instruction.UpdateSyncStatus -> {
-                    status.update { copy(core=instruction.status) }
+                    status.update { copy(core = instruction.status) }
                 }
+
                 is Instruction.FetchCredentials -> {
                     if (instruction.didExpire) {
                         connector.invalidateCredentials()
@@ -529,9 +544,11 @@ internal class StreamingSyncClient(
                         needsCredentialsRefresh.send(Unit)
                     }
                 }
+
                 Instruction.DidCompleteSync -> {
                     status.update { copy(downloadError = null) }
                 }
+
                 is Instruction.UnknownInstruction -> {
                     logger.w { "Unknown instruction received from core extension: ${instruction.raw}" }
                 }

--- a/common/src/commonMain/kotlin/com/powersync/sync/StreamingSyncClient.kt
+++ b/common/src/commonMain/kotlin/com/powersync/sync/StreamingSyncClient.kt
@@ -31,12 +31,18 @@ import io.ktor.utils.io.ByteReadChannel
 import io.ktor.utils.io.readAvailable
 import io.ktor.utils.io.readBuffer
 import io.ktor.utils.io.readLineStrict
+import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.ProducerScope
+import kotlinx.coroutines.channels.ReceiveChannel
+import kotlinx.coroutines.channels.consumeEach
+import kotlinx.coroutines.channels.produce
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
@@ -136,7 +142,7 @@ internal class StreamingSyncClient(
                     connector.invalidateCredentials()
                     invalidCredentials = false
                 }
-                result = streamingSyncIteration()
+                result = ActiveIteration().syncIteration()
             } catch (e: PowerSyncRSocketError) {
                 // RSocketError extends Throwable directly (not Exception), so it needs its own
                 // catch block to avoid accidentally catching JVM Errors (OutOfMemoryError, etc.).
@@ -180,6 +186,7 @@ internal class StreamingSyncClient(
                         completedCrudUploads.send(Unit)
                     }
                 }
+
                 launch { delay(crudUploadThrottle) }
             }
 
@@ -339,21 +346,6 @@ internal class StreamingSyncClient(
         }
     }
 
-    private suspend fun streamingSyncIteration(): SyncIterationResult =
-        coroutineScope {
-            val iteration = ActiveIteration(this)
-
-            try {
-                iteration.start()
-            } finally {
-                // This can't be canceled because we need to send a stop message, which is async, to
-                // clean up resources.
-                withContext(NonCancellable) {
-                    iteration.stop()
-                }
-            }
-        }
-
     /**
      * Implementation of a sync iteration that delegates to helper functions implemented in the
      * Rust core extension.
@@ -361,26 +353,58 @@ internal class StreamingSyncClient(
      * This avoids us having to decode sync lines in Kotlin, unlocking the RSocket protocol and
      * improving performance.
      */
-    private inner class ActiveIteration(
-        val scope: CoroutineScope,
-    ) {
-        var fetchLinesJob: Job? = null
-        var credentialsInvalidation: Job? = null
+    private inner class ActiveIteration {
+        private var needsCredentialsRefresh = Channel<Unit>(
+            capacity = 1,
+            onBufferOverflow = BufferOverflow.DROP_OLDEST,
+        )
 
-        // Using a channel for control invocations so that they're handled by a single coroutine,
-        // avoiding races between concurrent jobs like fetching credentials.
-        private val controlInvocations = Channel<PowerSyncControlArguments>()
-        private var result = SyncIterationResult()
+        suspend fun syncIteration(): SyncIterationResult {
+            return try {
+                val (establishConnection, subscriptions) = start() ?: return SyncIterationResult()
 
-        private suspend fun invokeControl(args: PowerSyncControlArguments) {
-            val instructions = bucketStorage.control(args)
-            instructions.forEach { handleInstruction(it) }
+                coroutineScope {
+                    val channel = produceEvents(establishConnection, subscriptions)
+
+                    channel.consumeEach { line ->
+                        val instructions = bucketStorage.control(line)
+                        for (instruction in instructions) {
+                            when (instruction) {
+                                is Instruction.CloseSyncStream -> {
+                                    val hideDisconnect = instruction.hideDisconnect
+                                    logger.v { "Closing sync stream connection. Hide disconnect: $hideDisconnect" }
+                                    return@coroutineScope SyncIterationResult(hideDisconnect)
+                                }
+                                is Instruction.EstablishSyncStream -> error("Already has stream")
+                                is Instruction.NonInterruptingInstruction -> handleInstruction(instruction)
+                            }
+                        }
+                    }
+
+                    SyncIterationResult()
+                }
+            } finally {
+                // This can't be canceled because we need to send a stop message, which is async, to
+                // clean up resources.
+                withContext(NonCancellable) {
+                    stop()
+                }
+
+                logger.v { "Sync stream connection shut down" }
+            }
         }
 
-        suspend fun start(): SyncIterationResult {
-            var subscriptions = activeSubscriptions.value
+        /**
+         * Passes current subscriptions and other options to the core extension to begin a sync
+         * iteration.
+         *
+         * Returns the start instruction and  used subscriptions (to compare them against later
+         * changes).
+         */
+        private suspend fun start(): Pair<Instruction.EstablishSyncStream, List<SubscriptionGroup>>? {
+            val subscriptions = activeSubscriptions.value
 
-            invokeControl(
+            val startInstructions = bucketStorage.control(
                 PowerSyncControlArguments.Start(
                     parameters = params,
                     schema = schema,
@@ -389,80 +413,98 @@ internal class StreamingSyncClient(
                     appMetadata = appMetadata,
                 ),
             )
+            var start: Instruction.EstablishSyncStream? = null
 
-            val listenForUpdatedSubscriptions =
-                scope.launch {
+            for (instruction in startInstructions) {
+                when (instruction) {
+                    is Instruction.EstablishSyncStream -> {
+                        start = instruction
+                    }
+                    is Instruction.CloseSyncStream -> {
+                        return null
+                    }
+                    is Instruction.NonInterruptingInstruction -> handleInstruction(instruction)
+                }
+            }
+
+            return start?.let { it to subscriptions }
+        }
+
+        /**
+         * Sends a stop command and uses returned instructions to e.g. clean up the sync status.
+         */
+        private suspend fun stop() {
+            val instructions = bucketStorage.control(PowerSyncControlArguments.Stop)
+            // We don't need to handle interrupting instructions since we're unconditionally
+            // ending the sync iteration at this point.
+            for (instruction in instructions) {
+                if (instruction is Instruction.NonInterruptingInstruction) {
+                    handleInstruction(instruction)
+                }
+            }
+        }
+
+        /**
+         * Produces events the sync client needs to react to.
+         *
+         * Decoded sync lines received from the PowerSync service are the main source for events.
+         * Additionally, this watches local events (changed subscriptions, completed uploads) to
+         * forward those to the stream client.
+         */
+        @OptIn(ExperimentalCoroutinesApi::class)
+        private fun CoroutineScope.produceEvents(
+            instruction: Instruction.EstablishSyncStream,
+            initialSubscriptions: List<SubscriptionGroup>,
+        ): ReceiveChannel<PowerSyncControlArguments> {
+            var currentSubscriptions = initialSubscriptions
+
+            return produce(CoroutineName("produceEvents")) {
+                launch(CoroutineName("Receive lines from PowerSync service")) {
+                    receiveTextOrBinaryLines(instruction.request).collect {
+                        send(it)
+                    }
+                }
+
+                launch(CoroutineName("Watch subscription updates")) {
                     activeSubscriptions.collect {
-                        if (subscriptions !== it) {
-                            subscriptions = it
-                            controlInvocations.send(
+                        if (currentSubscriptions !== it) {
+                            currentSubscriptions = it
+                            send(
                                 PowerSyncControlArguments.UpdateSubscriptions(activeSubscriptions.value.map { it.key }),
                             )
                         }
                     }
                 }
 
-            var hadSyncLine = false
-            for (line in controlInvocations) {
-                val instructions = bucketStorage.control(line)
-                instructions.forEach { handleInstruction(it) }
+                launch(CoroutineName("Track completed CRUD uploads")) {
+                    while (true) {
+                        completedCrudUploads.receive()
+                        send(PowerSyncControlArguments.CompletedUpload)
+                    }
+                }
 
-                if (!hadSyncLine && (line is PowerSyncControlArguments.TextLine || line is PowerSyncControlArguments.BinaryLine)) {
-                    // Trigger a crud upload when receiving the first sync line: We could have
-                    // pending local writes made while disconnected, so in addition to listening on
-                    // updates to `ps_crud`, we also need to trigger a CRUD upload in some other
-                    // cases. We do this on the first sync line because the client is likely to be
-                    // online in that case.
-                    hadSyncLine = true
+                launch(CoroutineName("Prefetch credentials")) {
+                    needsCredentialsRefresh.consumeEach {
+                        try {
+                            connector.updateCredentials()
+                        } catch (e: Exception) {
+                            if (e !is CancellationException) {
+                                logger.w(throwable=e) { "Failure in updateCredentials" }
+                            }
+
+                            throw e
+                        }
+
+                        logger.v { "Stopping because new credentials are available" }
+                        // Token has been refreshed, start another iteration
+                        send(PowerSyncControlArguments.DidRefreshToken)
+                    }
                 }
             }
-
-            listenForUpdatedSubscriptions.cancel()
-            return result
         }
 
-        suspend fun stop() {
-            invokeControl(PowerSyncControlArguments.Stop)
-            fetchLinesJob?.join()
-        }
-
-        private suspend fun handleInstruction(instruction: Instruction) {
+        private suspend fun handleInstruction(instruction: Instruction.NonInterruptingInstruction) {
             when (instruction) {
-                is Instruction.EstablishSyncStream -> {
-                    fetchLinesJob?.cancelAndJoin()
-                    fetchLinesJob =
-                        scope
-                            .launch {
-                                launch {
-                                    logger.v { "listening for completed uploads" }
-                                    for (completion in completedCrudUploads) {
-                                        controlInvocations.send(PowerSyncControlArguments.CompletedUpload)
-                                    }
-                                }
-
-                                launch {
-                                    connect(instruction)
-                                }
-                            }.also {
-                                it.invokeOnCompletion {
-                                    controlInvocations.close()
-                                }
-                            }
-                }
-
-                is Instruction.CloseSyncStream -> {
-                    val hideDisconnect = instruction.hideDisconnect
-                    logger.v { "Closing sync stream connection. Hide disconnect: $hideDisconnect" }
-                    result = SyncIterationResult(hideDisconnect)
-                    fetchLinesJob?.cancelAndJoin()
-                    fetchLinesJob = null
-                    logger.v { "Sync stream connection shut down" }
-                }
-
-                Instruction.FlushSileSystem -> {
-                    // We have durable file systems, so flushing is not necessary
-                }
-
                 is Instruction.LogLine -> {
                     logger.log(
                         severity =
@@ -476,46 +518,23 @@ internal class StreamingSyncClient(
                         throwable = null,
                     )
                 }
-
                 is Instruction.UpdateSyncStatus -> {
                     status.update { copy(core=instruction.status) }
                 }
-
                 is Instruction.FetchCredentials -> {
                     if (instruction.didExpire) {
                         connector.invalidateCredentials()
                     } else {
                         // Token expires soon - refresh it in the background
-                        if (credentialsInvalidation == null) {
-                            val job =
-                                scope.launch {
-                                    connector.updateCredentials()
-                                    logger.v { "Stopping because new credentials are available" }
-
-                                    // Token has been refreshed, start another iteration
-                                    controlInvocations.send(PowerSyncControlArguments.DidRefreshToken)
-                                }
-                            job.invokeOnCompletion {
-                                credentialsInvalidation = null
-                            }
-                            credentialsInvalidation = job
-                        }
+                        needsCredentialsRefresh.send(Unit)
                     }
                 }
-
                 Instruction.DidCompleteSync -> {
                     status.update { copy(downloadError = null) }
                 }
-
                 is Instruction.UnknownInstruction -> {
                     logger.w { "Unknown instruction received from core extension: ${instruction.raw}" }
                 }
-            }
-        }
-
-        private suspend fun connect(start: Instruction.EstablishSyncStream) {
-            receiveTextOrBinaryLines(start.request).collect {
-                controlInvocations.send(it)
             }
         }
     }

--- a/common/src/commonMain/kotlin/com/powersync/sync/StreamingSyncClient.kt
+++ b/common/src/commonMain/kotlin/com/powersync/sync/StreamingSyncClient.kt
@@ -34,14 +34,10 @@ import io.ktor.utils.io.readLineStrict
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
-import kotlinx.coroutines.cancelAndJoin
-import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.channels.ProducerScope
+import kotlinx.coroutines.channels.Channel.Factory.CONFLATED
 import kotlinx.coroutines.channels.ReceiveChannel
-import kotlinx.coroutines.channels.consume
 import kotlinx.coroutines.channels.consumeEach
 import kotlinx.coroutines.channels.produce
 import kotlinx.coroutines.coroutineScope
@@ -63,7 +59,6 @@ import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.time.Duration
-import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 @OptIn(ExperimentalPowerSyncAPI::class)
@@ -81,16 +76,8 @@ internal class StreamingSyncClient(
     private val activeSubscriptions: StateFlow<List<SubscriptionGroup>>,
     private val appMetadata: Map<String, String> = emptyMap(),
 ) {
-    private var requestedCrudUploads =
-        Channel<Unit>(
-            capacity = 1,
-            onBufferOverflow = BufferOverflow.DROP_OLDEST,
-        )
-    private var completedCrudUploads =
-        Channel<Unit>(
-            capacity = 1,
-            onBufferOverflow = BufferOverflow.DROP_OLDEST,
-        )
+    private val requestedCrudUploads = Channel<Unit>(CONFLATED)
+    private val completedCrudUploads = Channel<Unit>(CONFLATED)
 
     private var clientId: String? = null
 
@@ -178,17 +165,15 @@ internal class StreamingSyncClient(
     private suspend fun crudUploadLoop() {
         while (true) {
             coroutineScope {
-                // Start the initial CRUD upload on connect. Then, keep polling until we're done.
-                launch {
-                    try {
-                        uploadAllCrud()
-                    } finally {
-                        logger.v { "crud upload: notify completion" }
-                        completedCrudUploads.send(Unit)
-                    }
-                }
-
+                // To throttle, ensure we spend at least this much time in the iteration.
                 launch { delay(crudUploadThrottle) }
+
+                try {
+                    uploadAllCrud()
+                } finally {
+                    logger.v { "crud upload: notify completion" }
+                    completedCrudUploads.send(Unit)
+                }
             }
 
             requestedCrudUploads.receive()
@@ -224,6 +209,7 @@ internal class StreamingSyncClient(
                 }
             } catch (e: Exception) {
                 if (e is CancellationException) {
+                    status.update { copy(uploading = false) }
                     throw e
                 }
 
@@ -355,11 +341,7 @@ internal class StreamingSyncClient(
      * improving performance.
      */
     private inner class ActiveIteration {
-        private var needsCredentialsRefresh =
-            Channel<Unit>(
-                capacity = 1,
-                onBufferOverflow = BufferOverflow.DROP_OLDEST,
-            )
+        private val needsCredentialsRefresh = Channel<Unit>(CONFLATED)
 
         suspend fun syncIteration(): SyncIterationResult {
             return try {
@@ -479,11 +461,11 @@ internal class StreamingSyncClient(
                 }
 
                 launch(CoroutineName("Watch subscription updates")) {
-                    activeSubscriptions.collect {
-                        if (currentSubscriptions !== it) {
-                            currentSubscriptions = it
+                    activeSubscriptions.collect { newSubscriptions ->
+                        if (currentSubscriptions !== newSubscriptions) {
+                            currentSubscriptions = newSubscriptions
                             send(
-                                PowerSyncControlArguments.UpdateSubscriptions(activeSubscriptions.value.map { it.key }),
+                                PowerSyncControlArguments.UpdateSubscriptions(newSubscriptions.map { it.key }),
                             )
                         }
                     }

--- a/common/src/commonMain/kotlin/com/powersync/sync/StreamingSyncClient.kt
+++ b/common/src/commonMain/kotlin/com/powersync/sync/StreamingSyncClient.kt
@@ -31,7 +31,6 @@ import io.ktor.utils.io.ByteReadChannel
 import io.ktor.utils.io.readAvailable
 import io.ktor.utils.io.readBuffer
 import io.ktor.utils.io.readLineStrict
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
@@ -55,12 +54,14 @@ import kotlinx.io.readByteArray
 import kotlinx.io.readIntLe
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
+import kotlin.coroutines.cancellation.CancellationException
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 @OptIn(ExperimentalPowerSyncAPI::class)
 internal class StreamingSyncClient(
+    private val status: SyncStatus,
     private val bucketStorage: BucketStorage,
     private val connector: PowerSyncBackendConnector,
     private val uploadCrud: suspend () -> Unit,
@@ -83,11 +84,6 @@ internal class StreamingSyncClient(
             capacity = 1,
             onBufferOverflow = BufferOverflow.DROP_OLDEST,
         )
-
-    /**
-     * The current sync status. This instance is mutated as changes occur
-     */
-    val status = SyncStatus()
 
     private var clientId: String? = null
 
@@ -230,12 +226,11 @@ internal class StreamingSyncClient(
                     break
                 }
             } catch (e: Exception) {
-                status.update { copy(uploading = false, uploadError = e) }
-
                 if (e is CancellationException) {
                     throw e
                 }
 
+                status.update { copy(uploading = false, uploadError = e) }
                 logger.e { "Error uploading crud: ${e.message}" }
                 delay(retryDelay)
                 break
@@ -470,7 +465,7 @@ internal class StreamingSyncClient(
                     val hideDisconnect = instruction.hideDisconnect
                     logger.v { "Closing sync stream connection. Hide disconnect: $hideDisconnect" }
                     result = SyncIterationResult(hideDisconnect)
-                    fetchLinesJob!!.cancelAndJoin()
+                    fetchLinesJob?.cancelAndJoin()
                     fetchLinesJob = null
                     logger.v { "Sync stream connection shut down" }
                 }

--- a/common/src/commonMain/kotlin/com/powersync/sync/SyncStatus.kt
+++ b/common/src/commonMain/kotlin/com/powersync/sync/SyncStatus.kt
@@ -16,26 +16,28 @@ public data class PriorityStatusEntry internal constructor(
 )
 
 public sealed class SyncStatusData {
+    internal abstract val core: CoreSyncStatus?
+
     /**
      * true if currently connected.
      *
      * This means the PowerSync connection is ready to download, and [PowerSyncBackendConnector.uploadData] may be called for any local changes.
      */
-    public abstract val connected: Boolean
+    public val connected: Boolean get() = core?.connected ?: false
 
     /**
      * true if the PowerSync connection is busy connecting.
      *
      * During this stage, [PowerSyncBackendConnector.uploadData] may already be called, and [uploading] may be true.
      */
-    public abstract val connecting: Boolean
+    public val connecting: Boolean get() = core?.connecting ?: false
 
     /**
      * true if actively downloading changes.
      *
      * This is only true when [connected] is also true.
      */
-    public abstract val downloading: Boolean
+    public val downloading: Boolean get() = core?.downloading != null
 
     /**
      * Realtime progress information about downloaded operations during an active sync.
@@ -44,7 +46,7 @@ public sealed class SyncStatusData {
      * For more information on what progress is reported, see [SyncDownloadProgress].
      * This value will be non-null only if [downloading] is true.
      */
-    public abstract val downloadProgress: SyncDownloadProgress?
+    public val downloadProgress: SyncDownloadProgress? get() = core?.downloading?.let { SyncDownloadProgress(it.buckets) }
 
     /**
      * true if uploading changes
@@ -56,14 +58,18 @@ public sealed class SyncStatusData {
      *
      * Currently this is reset to null after a restart.
      */
-    public abstract val lastSyncedAt: Instant?
+    public val lastSyncedAt: Instant? get() {
+        return statusForPriority(StreamPriority.FULL_SYNC_PRIORITY).lastSyncedAt
+    }
 
     /**
      * Indicates whether there has been at least one full sync, if any.
      *
      * Is null when unknown, for example when state is still being loaded from the database.
      */
-    public abstract val hasSynced: Boolean?
+    public val hasSynced: Boolean? get() {
+        return statusForPriority(StreamPriority.FULL_SYNC_PRIORITY).hasSynced
+    }
 
     /**
      * Error during uploading.
@@ -82,7 +88,7 @@ public sealed class SyncStatusData {
     /**
      * Convenience getter for either the value of downloadError or uploadError
      */
-    public abstract val anyError: Any?
+    public val anyError: Any? get() = downloadError ?: uploadError
 
     /**
      * Available [PriorityStatusEntry] reporting the sync status for buckets within priorities.
@@ -91,26 +97,27 @@ public sealed class SyncStatusData {
      * and [lastSyncedAt] are set to indicate that a partial (but no complete) sync has completed.
      * A completed [PriorityStatusEntry] at one priority level always includes all higher priorities too.
      */
-    public abstract val priorityStatusEntries: List<PriorityStatusEntry>
-
-    internal abstract val internalSubscriptions: List<CoreActiveStreamSubscription>?
+    public val priorityStatusEntries: List<PriorityStatusEntry> get() {
+        return core?.priorityStatus?.map(this::exposePriorityStatus) ?: emptyList()
+    }
 
     /**
      * Status information for whether buckets in [priority] have been synchronized.
      */
     public fun statusForPriority(priority: StreamPriority): PriorityStatusEntry {
-        val byDescendingPriorities = priorityStatusEntries.sortedByDescending { it.priority }
+        val statusEntries = core?.priorityStatus ?: return PriorityStatusEntry(priority, null, null)
 
-        for (entry in byDescendingPriorities) {
+        // Note: statusEntries is always sorted by descending bucket priority
+        for (entry in statusEntries) {
             // Lower-priority buckets are synchronized after higher-priority buckets, so we look for the first
             // entry that doesn't have a higher priority.
             if (entry.priority <= priority) {
-                return entry
+                return exposePriorityStatus(entry)
             }
         }
 
         // A complete sync necessarily includes all priorities.
-        return PriorityStatusEntry(priority, lastSyncedAt, hasSynced)
+        return PriorityStatusEntry(priority, null, false)
     }
 
     /**
@@ -120,14 +127,14 @@ public sealed class SyncStatusData {
      * information about included streams yet. Once non-null, an empty list means the database
      * is initialized but no streams are active.
      */
-    public val syncStreams: List<SyncStreamStatus>? get() = internalSubscriptions?.map(this::exposeStreamStatus)
+    public val syncStreams: List<SyncStreamStatus>? get() = core?.streams?.map(this::exposeStreamStatus)
 
     /**
      * Status information for [stream], if it's a stream that is currently tracked by the sync
      * client.
      */
     public fun forStream(stream: SyncStreamDescription): SyncStreamStatus? {
-        val raw = internalSubscriptions?.firstOrNull { it.name == stream.name && it.parameters == stream.parameters } ?: return null
+        val raw = core?.streams?.firstOrNull { it.name == stream.name && it.parameters == stream.parameters } ?: return null
         return exposeStreamStatus(raw)
     }
 
@@ -143,51 +150,29 @@ public sealed class SyncStatusData {
 
         return SyncStreamStatus(progress, internal)
     }
+
+    private fun exposePriorityStatus(internal: CorePriorityStatus): PriorityStatusEntry =
+        PriorityStatusEntry(
+            priority = internal.priority,
+            lastSyncedAt = internal.lastSyncedAt,
+            hasSynced = internal.hasSynced,
+        )
 }
 
 internal data class SyncStatusDataContainer(
-    override val connected: Boolean = false,
-    override val connecting: Boolean = false,
-    override val downloading: Boolean = false,
-    override val downloadProgress: SyncDownloadProgress? = null,
+    override val core: CoreSyncStatus?,
     override val uploading: Boolean = false,
-    override val lastSyncedAt: Instant? = null,
-    override val hasSynced: Boolean? = null,
     override val uploadError: Any? = null,
     override val downloadError: Any? = null,
-    override val priorityStatusEntries: List<PriorityStatusEntry> = emptyList(),
-    override val internalSubscriptions: List<CoreActiveStreamSubscription>? = null,
-) : SyncStatusData() {
-    override val anyError
-        get() = downloadError ?: uploadError
-
-    internal fun applyCoreChanges(status: CoreSyncStatus): SyncStatusDataContainer {
-        val completeSync = status.priorityStatus.firstOrNull { it.priority == StreamPriority.FULL_SYNC_PRIORITY }
-
-        return copy(
-            connected = status.connected,
-            connecting = status.connecting,
-            downloading = status.downloading != null,
-            downloadProgress = status.downloading?.let { SyncDownloadProgress(it.buckets) },
-            lastSyncedAt = completeSync?.lastSyncedAt,
-            hasSynced = completeSync != null,
-            priorityStatusEntries =
-                status.priorityStatus.map {
-                    PriorityStatusEntry(
-                        priority = it.priority,
-                        lastSyncedAt = it.lastSyncedAt,
-                        hasSynced = it.hasSynced,
-                    )
-                },
-            internalSubscriptions = status.streams,
-        )
-    }
-}
+) : SyncStatusData()
 
 @ConsistentCopyVisibility
 public data class SyncStatus internal constructor(
-    private var data: SyncStatusDataContainer = SyncStatusDataContainer(),
+    private var data: SyncStatusDataContainer = SyncStatusDataContainer(null),
 ) : SyncStatusData() {
+    override val core: CoreSyncStatus?
+        get() = data.core
+
     private val stateFlow: MutableStateFlow<SyncStatusDataContainer> = MutableStateFlow(data)
 
     /**
@@ -203,47 +188,14 @@ public data class SyncStatus internal constructor(
         stateFlow.value = data
     }
 
-    internal suspend fun trackOther(source: SyncStatus) {
-        source.stateFlow.collect {
-            update { it }
-        }
-    }
-
-    override val anyError: Any?
-        get() = data.anyError
-
-    override val connected: Boolean
-        get() = data.connected
-
-    override val connecting: Boolean
-        get() = data.connecting
-
-    override val downloading: Boolean
-        get() = data.downloading
-
-    override val downloadProgress: SyncDownloadProgress?
-        get() = data.downloadProgress
-
     override val uploading: Boolean
         get() = data.uploading
-
-    override val lastSyncedAt: Instant?
-        get() = data.lastSyncedAt
-
-    override val hasSynced: Boolean?
-        get() = data.hasSynced
 
     override val uploadError: Any?
         get() = data.uploadError
 
     override val downloadError: Any?
         get() = data.downloadError
-
-    override val priorityStatusEntries: List<PriorityStatusEntry>
-        get() = data.priorityStatusEntries
-
-    override val internalSubscriptions: List<CoreActiveStreamSubscription>?
-        get() = data.internalSubscriptions
 
     override fun toString(): String =
         "SyncStatus(connected=$connected, connecting=$connecting, downloading=$downloading, uploading=$uploading, lastSyncedAt=$lastSyncedAt, hasSynced=$hasSynced, error=$anyError)"

--- a/common/src/commonTest/kotlin/com/powersync/testutils/MockSyncService.kt
+++ b/common/src/commonTest/kotlin/com/powersync/testutils/MockSyncService.kt
@@ -124,7 +124,7 @@ internal class MockSyncService(
 
 suspend inline fun ReceiveTurbine<SyncStatusData>.waitFor(
     allowError: Boolean = false,
-    matcher: (SyncStatusData) -> Boolean
+    matcher: (SyncStatusData) -> Boolean,
 ) {
     while (true) {
         val item = awaitItem()

--- a/common/src/commonTest/kotlin/com/powersync/testutils/MockSyncService.kt
+++ b/common/src/commonTest/kotlin/com/powersync/testutils/MockSyncService.kt
@@ -122,15 +122,20 @@ internal class MockSyncService(
     private object Config : HttpClientEngineConfig()
 }
 
-suspend inline fun ReceiveTurbine<SyncStatusData>.waitFor(matcher: (SyncStatusData) -> Boolean) {
+suspend inline fun ReceiveTurbine<SyncStatusData>.waitFor(
+    allowError: Boolean = false,
+    matcher: (SyncStatusData) -> Boolean
+) {
     while (true) {
         val item = awaitItem()
         if (matcher(item)) {
             break
         }
 
-        item.anyError?.let {
-            error("Unexpected error in $item")
+        if (!allowError) {
+            item.anyError?.let {
+                error("Unexpected error in $item")
+            }
         }
     }
 }

--- a/common/src/commonTest/kotlin/powersync/sync/StreamingSyncClientTest.kt
+++ b/common/src/commonTest/kotlin/powersync/sync/StreamingSyncClientTest.kt
@@ -174,57 +174,6 @@ class StreamingSyncClientTest {
         }
 
     @Test
-    fun testStreamingSyncBasicFlow() =
-        runTest {
-            bucketStorage =
-                mock<BucketStorage> {
-                    everySuspend { getClientId() } returns "test-client-id"
-                }
-
-            streamingSyncClient =
-                StreamingSyncClient(
-                    status = status,
-                    bucketStorage = bucketStorage,
-                    connector = connector,
-                    uploadCrud = { },
-                    retryDelay = 10.milliseconds,
-                    logger = logger,
-                    params = JsonObject(emptyMap()),
-                    options =
-                        SyncOptions(
-                            clientConfiguration =
-                                SyncClientConfiguration.ExistingClient(
-                                    HttpClient(assertNoHttpEngine) {
-                                        configureSyncHttpClient()
-                                    },
-                                ),
-                        ),
-                    schema = Schema(),
-                    activeSubscriptions = MutableStateFlow(emptyList()),
-                )
-
-            // Launch streaming sync in a coroutine that we'll cancel after verification
-            val job =
-                launch {
-                    streamingSyncClient.streamingSync()
-                }
-
-            // Wait for status to update
-            withTimeout(1000.milliseconds) {
-                while (!status.connecting) {
-                    delay(10.milliseconds)
-                }
-            }
-
-            // Verify initial state
-            assertEquals(true, status.connecting)
-            assertEquals(false, status.connected)
-
-            // Clean up
-            job.cancel()
-        }
-
-    @Test
     fun splitBsonObjects() =
         runTest {
             turbineScope {

--- a/common/src/commonTest/kotlin/powersync/sync/StreamingSyncClientTest.kt
+++ b/common/src/commonTest/kotlin/powersync/sync/StreamingSyncClientTest.kt
@@ -16,6 +16,7 @@ import com.powersync.sync.StreamingSyncClient
 import com.powersync.sync.StreamingSyncClient.Companion.bsonObjects
 import com.powersync.sync.SyncClientConfiguration
 import com.powersync.sync.SyncOptions
+import com.powersync.sync.SyncStatus
 import com.powersync.sync.configureSyncHttpClient
 import com.powersync.test.TestConnector
 import com.powersync.test.waitFor
@@ -49,6 +50,7 @@ import kotlin.time.Duration.Companion.seconds
 
 @OptIn(ExperimentalKermitApi::class, ExperimentalPowerSyncAPI::class)
 class StreamingSyncClientTest {
+    private lateinit var status: SyncStatus
     private lateinit var bucketStorage: BucketStorage
     private lateinit var connector: PowerSyncBackendConnector
     private lateinit var streamingSyncClient: StreamingSyncClient
@@ -70,6 +72,7 @@ class StreamingSyncClientTest {
 
     @BeforeTest
     fun setup() {
+        status = SyncStatus()
         bucketStorage =
             mock<BucketStorage> {
                 everySuspend { getClientId() } returns "test-client-id"
@@ -82,6 +85,7 @@ class StreamingSyncClientTest {
         runTest {
             streamingSyncClient =
                 StreamingSyncClient(
+                    status = status,
                     bucketStorage = bucketStorage,
                     connector = connector,
                     uploadCrud = {},
@@ -126,6 +130,7 @@ class StreamingSyncClientTest {
 
             streamingSyncClient =
                 StreamingSyncClient(
+                    status = status,
                     bucketStorage = bucketStorage,
                     connector = connector,
                     uploadCrud = { },
@@ -178,6 +183,7 @@ class StreamingSyncClientTest {
 
             streamingSyncClient =
                 StreamingSyncClient(
+                    status = status,
                     bucketStorage = bucketStorage,
                     connector = connector,
                     uploadCrud = { },
@@ -205,14 +211,14 @@ class StreamingSyncClientTest {
 
             // Wait for status to update
             withTimeout(1000.milliseconds) {
-                while (!streamingSyncClient.status.connecting) {
+                while (!status.connecting) {
                     delay(10.milliseconds)
                 }
             }
 
             // Verify initial state
-            assertEquals(true, streamingSyncClient.status.connecting)
-            assertEquals(false, streamingSyncClient.status.connected)
+            assertEquals(true, status.connecting)
+            assertEquals(false, status.connected)
 
             // Clean up
             job.cancel()

--- a/common/src/commonTest/kotlin/powersync/sync/StreamingSyncClientTest.kt
+++ b/common/src/commonTest/kotlin/powersync/sync/StreamingSyncClientTest.kt
@@ -18,9 +18,11 @@ import com.powersync.sync.SyncClientConfiguration
 import com.powersync.sync.SyncOptions
 import com.powersync.sync.configureSyncHttpClient
 import com.powersync.test.TestConnector
+import com.powersync.test.waitFor
 import dev.mokkery.answering.returns
 import dev.mokkery.everySuspend
 import dev.mokkery.mock
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeTypeOf
@@ -28,8 +30,11 @@ import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.utils.io.ByteChannel
 import io.ktor.utils.io.writeByteArray
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeout
@@ -39,6 +44,8 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 @OptIn(ExperimentalKermitApi::class, ExperimentalPowerSyncAPI::class)
 class StreamingSyncClientTest {
@@ -80,7 +87,6 @@ class StreamingSyncClientTest {
                     uploadCrud = {},
                     logger = logger,
                     params = JsonObject(emptyMap()),
-                    uploadScope = this,
                     options =
                         SyncOptions(
                             clientConfiguration =
@@ -114,6 +120,7 @@ class StreamingSyncClientTest {
                 )
             bucketStorage =
                 mock<BucketStorage> {
+                    everySuspend { getClientId() } returns "test-id"
                     everySuspend { nextCrudItem() } returns mockCrudEntry
                 }
 
@@ -122,10 +129,9 @@ class StreamingSyncClientTest {
                     bucketStorage = bucketStorage,
                     connector = connector,
                     uploadCrud = { },
-                    retryDelayMs = 10,
+                    retryDelay = 10.seconds,
                     logger = logger,
                     params = JsonObject(emptyMap()),
-                    uploadScope = this,
                     options =
                         SyncOptions(
                             clientConfiguration =
@@ -139,12 +145,13 @@ class StreamingSyncClientTest {
                     activeSubscriptions = MutableStateFlow(emptyList()),
                 )
 
-            streamingSyncClient.status.update { copy(connected = true) }
-            streamingSyncClient.triggerCrudUploadAsync().join()
+            val sync = launch { streamingSyncClient.streamingSync() }
+            delay(2.seconds)
+            sync.cancelAndJoin()
 
-            testLogWriter.assertCount(2)
+            val logs = testLogWriter.logs.filter { it.message.contains("CRUD") }
 
-            with(testLogWriter.logs[0]) {
+            with(logs[0]) {
                 assertContains(
                     message,
                     "Potentially previously uploaded CRUD entries are still present in the upload queue.",
@@ -152,7 +159,7 @@ class StreamingSyncClientTest {
                 assertEquals(Severity.Warn, severity)
             }
 
-            with(testLogWriter.logs[1]) {
+            with(logs[1]) {
                 assertEquals(
                     message,
                     "Error uploading crud: Delaying due to previously encountered CRUD item.",
@@ -174,10 +181,9 @@ class StreamingSyncClientTest {
                     bucketStorage = bucketStorage,
                     connector = connector,
                     uploadCrud = { },
-                    retryDelayMs = 10,
+                    retryDelay = 10.milliseconds,
                     logger = logger,
                     params = JsonObject(emptyMap()),
-                    uploadScope = this,
                     options =
                         SyncOptions(
                             clientConfiguration =
@@ -198,9 +204,9 @@ class StreamingSyncClientTest {
                 }
 
             // Wait for status to update
-            withTimeout(1000) {
+            withTimeout(1000.milliseconds) {
                 while (!streamingSyncClient.status.connecting) {
-                    delay(10)
+                    delay(10.milliseconds)
                 }
             }
 


### PR DESCRIPTION
This ports some of the sync client improvements we've recently implemented on our other SDKs to the Kotlin SDK. The main goal here is to reduce technical debt, thereby making checkpoint requests simpler to implement.

There is one improvement per commit:

1. Restructure CRUD uploads: In the Kotlin SDK, crud uploads are triggered as jobs lauched in a coroutine scope, one per upload attempt. To avoid concurrent upload jobs, we keep an atomic reference to bail out early. All our other SDKs use a much cleaner approach: Let a continous asynchronous loop drive CRUD uploads, and trigger iterations through channels. This ports the loop [from JavaScript](https://github.com/powersync-ja/powersync-js/blob/463381c89ca3fa821e4e1a6e35792b90152f9086/packages/shared-internals/src/client/sync/stream/AbstractStreamingSyncImplementation.ts#L232-L242) which is a neat simplification as we can use structured concurrency to scope uploads and downloads. No more `CoroutineScope`s being passed around! A behavioral change inherited from JavaScript is that we now start one upload iteration whenever we connect.
2. Instead of letting the sync client manage its own mutable sync status that is then copied into the database through an async job, just let the sync client mutate the status on the database directly. It's already atomic, stopping the copy means there's no way for the sync client to keep updating its status while the copy job is already cancelled.
3. Drive the sync status from core state: In our other SDKs, the publicly visible sync status is derived from what the core extension gives us, download/upload errors and a `bool isUploading` flag. This ports that approach to Kotlin, dropping some code in `SyncStatus`.
4. Use structured concurrency in download iterations. We have recently restructured the control flow in the sync client for [Dart](https://github.com/powersync-ja/powersync.dart/pull/410), [JavaScript](https://github.com/powersync-ja/powersync-js/pull/951), Swift (in the rewrite) and [C#](https://github.com/powersync-ja/powersync-dotnet/pull/82). This adds that to Kotlin, a language that is very awesome for this: By using a [`ProducerScope`](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.channels/produce.html), we can syntactically group everything that generates sync events (the actual http stream, crud uploads, refreshed tokens, changed sync streams) into a single block that is cancelled when we stop consuming events. This untangles the control flow and makes client state much easier to reason about, a benefit for checkpoint requests which will add a new source of events.

AI use: I used Claude Code for a review and minor fixes.