### PR TITLE
Explicit checkpoint requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Web: Use navigator locks to guard the sync client.
 - Add `SyncOptions.checkpointMode`. When set to `CheckpointMode.Requests()`, the sync client uses a
   a new protocol for checkpoints after crud uploads with better support for switching users.
+- Add `PowerSyncDatabase.requestCheckpoint()`, which can be used to request sync updates explicitly
+  and wait for those to complete.
 
 ## 1.14.1
 

--- a/common/src/commonIntegrationTest/kotlin/com/powersync/sync/CheckpointRequestTest.kt
+++ b/common/src/commonIntegrationTest/kotlin/com/powersync/sync/CheckpointRequestTest.kt
@@ -9,6 +9,7 @@ import com.powersync.PowerSyncDatabase
 import com.powersync.connectors.CustomCheckpointRequestConnector
 import com.powersync.connectors.PowerSyncBackendConnector
 import com.powersync.connectors.PowerSyncCredentials
+import com.powersync.test.TestConnector
 import com.powersync.testutils.ActiveDatabaseTest
 import com.powersync.testutils.BucketChecksum
 import com.powersync.testutils.Checkpoint
@@ -18,6 +19,7 @@ import com.powersync.testutils.SyncLine
 import com.powersync.testutils.SyncLine.SyncDataBucket
 import com.powersync.testutils.UserRow
 import com.powersync.testutils.databaseTest
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.comparables.shouldBeLessThan
 import io.kotest.matchers.shouldBe
@@ -28,6 +30,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.testTimeSource
+import kotlin.collections.emptyList
 import kotlin.test.Test
 import kotlin.test.assertNotNull
 import kotlin.time.Duration.Companion.hours
@@ -222,6 +225,80 @@ class CheckpointRequestTest : AbstractSyncTest() {
             )
             database.waitForStatus { it.downloading }
             completeInitialRequest.complete(Unit)
+        }
+
+    @Test
+    fun `requestCheckpoint fails when disconnected`() =
+        databaseTest {
+            shouldThrow<CheckpointRequestException.Disconnected> { database.requestCheckpoint() }
+        }
+
+    @Test
+    fun `requestCheckpoint fails when connected in legacy mode`() =
+        databaseTest {
+            database.connect(connector, options = getOptions())
+
+            shouldThrow<CheckpointRequestException.Disabled> { database.requestCheckpoint() }
+        }
+
+    @Test
+    fun `requestCheckpoint waits until data is applied`() =
+        databaseTest {
+            database.connect(TestConnector(), options = optionsWithRequests())
+
+            val checkpoint = database.requestCheckpoint()
+            syncLines.send(SyncLine.FullCheckpoint(Checkpoint(lastOpId = "0", checksums = emptyList(), writeCheckpoint = "2")))
+            checkpoint.hasSynced shouldBe false
+            syncLines.send(SyncLine.CheckpointComplete(lastOpId = "0"))
+
+            checkpoint.waitForSync()
+            checkpoint.hasSynced shouldBe true
+        }
+
+    @Test
+    fun `requestCheckpoint throws on disconnect but can connect again`() =
+        databaseTest {
+            database.connect(TestConnector(), options = optionsWithRequests())
+            val checkpoint = database.requestCheckpoint()
+
+            val firstWaitForSync =
+                scope.launch {
+                    shouldThrow<CheckpointRequestException.Disconnected> { checkpoint.waitForSync() }
+                }
+            database.disconnect()
+            firstWaitForSync.join()
+            waitForSyncLinesChannelClosed()
+
+            database.connect(TestConnector(), options = optionsWithRequests())
+            syncLines.send(SyncLine.FullCheckpoint(Checkpoint(lastOpId = "0", checksums = emptyList(), writeCheckpoint = "2")))
+            syncLines.send(SyncLine.CheckpointComplete(lastOpId = "0"))
+            checkpoint.waitForSync()
+        }
+
+    @Test
+    fun `requestCheckpoint fails when reconnecting with legacy mode`() =
+        databaseTest {
+            database.connect(TestConnector(), options = optionsWithRequests())
+            val checkpoint = database.requestCheckpoint()
+
+            database.disconnect()
+            database.connect(TestConnector(), options = getOptions())
+            shouldThrow<CheckpointRequestException.Disabled> { checkpoint.waitForSync() }
+        }
+
+    @Test
+    fun `requestCheckpoint fails on sync errors`() =
+        databaseTest {
+            database.connect(TestConnector(), options = optionsWithRequests())
+            val checkpoint = database.requestCheckpoint()
+
+            val failureExpectation =
+                scope.launch {
+                    shouldThrow<CheckpointRequestException.StatusError> { checkpoint.waitForSync() }
+                }
+
+            syncLines.send("not a valid sync line")
+            failureExpectation.join()
         }
 }
 

--- a/common/src/commonMain/kotlin/com/powersync/PowerSyncDatabase.kt
+++ b/common/src/commonMain/kotlin/com/powersync/PowerSyncDatabase.kt
@@ -11,6 +11,7 @@ import com.powersync.db.crud.CrudBatch
 import com.powersync.db.crud.CrudTransaction
 import com.powersync.db.driver.SQLiteConnectionPool
 import com.powersync.db.schema.Schema
+import com.powersync.sync.CheckpointRequest
 import com.powersync.sync.SyncOptions
 import com.powersync.sync.SyncStatus
 import com.powersync.sync.SyncStream
@@ -198,6 +199,19 @@ public interface PowerSyncDatabase : Queries {
         name: String,
         parameters: Map<String, JsonParam>? = null,
     ): SyncStream
+
+    /**
+     * Requests a checkpoint from the PowerSync service.
+     *
+     * The returned request can be awaited (using [CheckpointRequest.waitForSync]) to confirm that
+     * the local database has applied server-side changes up to the checkpoint. This method requires
+     * an active or connecting sync client connected with [SyncOptions.checkpointMode] set to
+     * [com.powersync.sync.CheckpointMode.Requests] and PowerSync service version 1.24.0 or later.
+     *
+     * It can throw for connection, mode, authentication, or service request failures.
+     */
+    @ExperimentalCheckpointRequestsApi
+    public suspend fun requestCheckpoint(): CheckpointRequest
 
     /**
      * Close the sync connection.

--- a/common/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
+++ b/common/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
@@ -22,6 +22,8 @@ import com.powersync.db.internal.InternalTable
 import com.powersync.db.internal.PowerSyncVersion
 import com.powersync.db.schema.Schema
 import com.powersync.sync.CheckpointMode
+import com.powersync.sync.CheckpointRequest
+import com.powersync.sync.CheckpointRequestException
 import com.powersync.sync.StreamingSyncClient
 import com.powersync.sync.SyncOptions
 import com.powersync.sync.SyncStatus
@@ -35,7 +37,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.completeWith
 import kotlinx.coroutines.ensureActive
@@ -95,7 +97,7 @@ internal class PowerSyncDatabaseImpl(
     override val currentStatus: SyncStatus = SyncStatus()
 
     private val mutex = Mutex()
-    private var syncSupervisorJob: Job? = null
+    private var syncClient: Pair<Job, StreamingSyncClient>? = null
 
     // This is set before the initialization job completes
     private lateinit var powerSyncVersion: String
@@ -132,7 +134,7 @@ internal class PowerSyncDatabaseImpl(
 
     private suspend fun updateSchemaInternal(schema: Schema) {
         mutex.withLock {
-            if (this.syncSupervisorJob != null) {
+            if (this.syncClient != null) {
                 throw PowerSyncException(
                     "Cannot update schema while connected",
                     cause = Exception("PowerSync client is already connected"),
@@ -143,6 +145,11 @@ internal class PowerSyncDatabaseImpl(
             this.schema = schema
         }
     }
+
+    internal suspend inline fun <T> inspectCurrentStreamClient(inspect: (StreamingSyncClient?) -> T): T =
+        mutex.withLock {
+            inspect(syncClient?.second)
+        }
 
     override suspend fun connect(
         connector: PowerSyncBackendConnector,
@@ -156,7 +163,7 @@ internal class PowerSyncDatabaseImpl(
         mutex.withLock {
             disconnectInternal()
 
-            connectInternal { scope ->
+            connectInternal {
                 @OptIn(ExperimentalCheckpointRequestsApi::class)
                 if (connector is CustomCheckpointRequestConnector && options.checkpointMode == CheckpointMode.Legacy) {
                     logger.w {
@@ -182,63 +189,58 @@ internal class PowerSyncDatabaseImpl(
         }
     }
 
-    private fun connectInternal(createStream: (CoroutineScope) -> StreamingSyncClient) {
+    private fun connectInternal(createStream: () -> StreamingSyncClient) {
         val db = this
-        val job = SupervisorJob(scope.coroutineContext[Job])
-        syncSupervisorJob = job
-        var activeStream: StreamingSyncClient? = null
+        val stream = createStream()
+        val syncJob =
+            scope.launch {
+                launch {
+                    // Get a global lock for checking mutex maps
+                    val streamMutex = resource.group.syncMutex
 
-        scope.launch(job) {
-            // Create the stream in this scope so that everything launched by the stream is bound to
-            // this coroutine scope that can be cancelled independently.
-            val stream = createStream(this)
-            activeStream = stream
-
-            launch {
-                // Get a global lock for checking mutex maps
-                val streamMutex = resource.group.syncMutex
-
-                // Poke the streaming mutex to see if another client is using it
-                var obtainedLock: HeldMutex? = null
-                try {
-                    // This call will throw if the lock is already held by this db client.
-                    // We should never reach that point since we disconnect before connecting.
-                    obtainedLock = streamMutex.tryAcquire(db)
-                    if (obtainedLock == null) {
-                        // The mutex is held already by another PowerSync instance (owner).
-                        // (The tryLock should throw if this client already holds the lock).
-                        logger.w(streamConflictMessage)
+                    // Poke the streaming mutex to see if another client is using it
+                    var obtainedLock: HeldMutex? = null
+                    try {
+                        // This call will throw if the lock is already held by this db client.
+                        // We should never reach that point since we disconnect before connecting.
+                        obtainedLock = streamMutex.tryAcquire(db)
+                        if (obtainedLock == null) {
+                            // The mutex is held already by another PowerSync instance (owner).
+                            // (The tryLock should throw if this client already holds the lock).
+                            logger.w(streamConflictMessage)
+                        }
+                    } catch (_: IllegalStateException) {
+                        logger.e { "The streaming sync client did not disconnect before connecting" }
                     }
-                } catch (_: IllegalStateException) {
-                    logger.e { "The streaming sync client did not disconnect before connecting" }
+
+                    // This effectively queues operations
+                    if (obtainedLock == null) {
+                        // This will throw a CancellationException if the job was cancelled while waiting.
+                        obtainedLock = streamMutex.acquire(db)
+                    }
+
+                    // We have a lock if we reached here
+                    obtainedLock.use {
+                        ensureActive()
+                        stream.streamingSync()
+                    }
                 }
 
-                // This effectively queues operations
-                if (obtainedLock == null) {
-                    // This will throw a CancellationException if the job was cancelled while waiting.
-                    obtainedLock = streamMutex.acquire(db)
+                launch {
+                    internalDb
+                        .updatesOnTables()
+                        .filter { it.contains(InternalTable.CRUD.toString()) }
+                        .collect { stream.triggerCrudUpload() }
                 }
 
-                // We have a lock if we reached here
-                obtainedLock.use {
-                    ensureActive()
-                    stream.streamingSync()
+                try {
+                    awaitCancellation()
+                } catch (e: DisconnectRequestedException) {
+                    stream.invalidateCredentials()
+                    throw e
                 }
             }
-
-            launch {
-                internalDb
-                    .updatesOnTables()
-                    .filter { it.contains(InternalTable.CRUD.toString()) }
-                    .collect { stream.triggerCrudUpload() }
-            }
-        }
-
-        job.invokeOnCompletion {
-            if (it is DisconnectRequestedException) {
-                activeStream?.invalidateCredentials()
-            }
-        }
+        syncClient = syncJob to stream
     }
 
     override suspend fun getCrudBatch(limit: Int): CrudBatch? {
@@ -325,6 +327,22 @@ internal class PowerSyncDatabaseImpl(
         name: String,
         parameters: Map<String, JsonParam>?,
     ): SyncStream = PendingStream(streams, name, parameters)
+
+    @ExperimentalCheckpointRequestsApi
+    override suspend fun requestCheckpoint(): CheckpointRequest {
+        waitReady()
+
+        return inspectCurrentStreamClient { client ->
+            if (client == null) {
+                throw CheckpointRequestException.Disconnected()
+            }
+            if (client.options.checkpointMode !is CheckpointMode.Requests) {
+                throw CheckpointRequestException.Disabled()
+            }
+
+            client.requestCheckpoint(this)
+        }
+    }
 
     override suspend fun getPowerSyncVersion(): String {
         // The initialization sets powerSyncVersion.
@@ -424,12 +442,12 @@ internal class PowerSyncDatabaseImpl(
     }
 
     private suspend fun disconnectInternal() {
-        val syncJob = syncSupervisorJob
+        val syncJob = syncClient?.first
         if (syncJob != null && syncJob.isActive) {
             // Using this exception type will also make the sync job invalidate credentials.
             syncJob.cancel(DisconnectRequestedException())
             syncJob.join()
-            syncSupervisorJob = null
+            syncClient = null
         }
     }
 
@@ -455,7 +473,7 @@ internal class PowerSyncDatabaseImpl(
 
     internal suspend fun resolveOfflineSyncStatusIfNotConnected() {
         mutex.withLock {
-            if (syncSupervisorJob == null) {
+            if (syncClient == null) {
                 // Not connected or connecting
                 resolveOfflineSyncStatus()
             }

--- a/common/src/commonMain/kotlin/com/powersync/sync/CheckpointRequest.kt
+++ b/common/src/commonMain/kotlin/com/powersync/sync/CheckpointRequest.kt
@@ -1,0 +1,65 @@
+package com.powersync.sync
+
+import com.powersync.ExperimentalCheckpointRequestsApi
+import com.powersync.db.PowerSyncDatabaseImpl
+import kotlinx.coroutines.flow.first
+
+/**
+ * A checkpoint request created by [com.powersync.PowerSyncDatabase.requestCheckpoint].
+ *
+ * Use this value to wait until the local database has applied server-side changes up to the
+ * requested checkpoint. This is useful for explicit refresh flows where the caller wants
+ * confirmation that the local view has caught up to the service.
+ *
+ * Checkpoint requests are backed by request ids tracked in the local database, so they are reusable
+ * across disconnect and reconnect cycles. A wait interrupted by a disconnect throws an error, but
+ * the same request can be awaited again once a new connection is established.
+ *
+ * Requests do not survive {@link CommonPowerSyncDatabase#disconnectAndClear}, instances created
+ * before a clear should be discarded and requested again.
+ */
+@ExperimentalCheckpointRequestsApi
+public class CheckpointRequest internal constructor(
+    private val requestId: Long,
+    private val database: PowerSyncDatabaseImpl,
+) {
+    /**
+     * Whether this checkpoint request has synced before.
+     */
+    public val hasSynced: Boolean get() = database.currentStatus.isCheckpointRequestApplied(requestId)
+
+    /**
+     * Waits until this checkpoint has been synced locally.
+     *
+     * This method fails on sync errors: If a download or upload error occurs before this checkpoint
+     * request has synced, that error is rethrown here. This makes it easier to observe sync errors
+     * when relying on checkpoints. Once sync has recovered, it is valid to call this method again
+     * to await the checkpoint.
+     */
+    public suspend fun waitForSync() {
+        if (hasSynced) return
+
+        database.inspectCurrentStreamClient { client ->
+            if (client == null) {
+                throw CheckpointRequestException.Disconnected()
+            }
+            if (client.options.checkpointMode !is CheckpointMode.Requests) {
+                throw CheckpointRequestException.Disabled()
+            }
+        }
+
+        database.currentStatus.asFlow().first { status ->
+            if (status.isCheckpointRequestApplied(requestId)) return@first true
+
+            status.anyError?.let { error ->
+                throw CheckpointRequestException.StatusError(error as? Throwable)
+            }
+
+            if (!status.connected && !status.connecting) {
+                throw CheckpointRequestException.Disconnected()
+            }
+
+            false
+        }
+    }
+}

--- a/common/src/commonMain/kotlin/com/powersync/sync/CheckpointRequestException.kt
+++ b/common/src/commonMain/kotlin/com/powersync/sync/CheckpointRequestException.kt
@@ -18,6 +18,10 @@ public open class CheckpointRequestException internal constructor(
 
     public class Disconnected internal constructor() : CheckpointRequestException("Cannot request checkpoints, sync client is disconnected")
 
-    public class NotEnabled internal constructor() :
+    public class Disabled internal constructor() :
         CheckpointRequestException("Connected with legacy checkpoint mode, cannot request checkpoints")
+
+    public class StatusError internal constructor(
+        cause: Throwable?,
+    ) : CheckpointRequestException("Error on sync status before checkpoint was applied", cause)
 }

--- a/common/src/commonMain/kotlin/com/powersync/sync/StreamingSyncClient.kt
+++ b/common/src/commonMain/kotlin/com/powersync/sync/StreamingSyncClient.kt
@@ -245,6 +245,7 @@ internal class StreamingSyncClient(
                             is CheckpointMode.Requests -> requestNextCheckpointFromService()
                         }
                     }
+                    status.update { copy(uploading = false, uploadError = null) }
                     break
                 }
             } catch (e: Exception) {

--- a/common/src/commonMain/kotlin/com/powersync/sync/StreamingSyncClient.kt
+++ b/common/src/commonMain/kotlin/com/powersync/sync/StreamingSyncClient.kt
@@ -12,6 +12,7 @@ import com.powersync.bucket.PowerSyncControlArguments
 import com.powersync.bucket.WriteCheckpointResponse
 import com.powersync.connectors.CustomCheckpointRequestConnector
 import com.powersync.connectors.PowerSyncBackendConnector
+import com.powersync.db.PowerSyncDatabaseImpl
 import com.powersync.db.SubscriptionGroup
 import com.powersync.db.crud.CrudEntry
 import com.powersync.db.schema.Schema
@@ -78,7 +79,7 @@ internal class StreamingSyncClient(
     private val crudUploadThrottle: Duration = 1.seconds,
     private val logger: Logger,
     private val params: JsonObject,
-    private val options: SyncOptions,
+    val options: SyncOptions,
     private val schema: Schema,
     private val activeSubscriptions: StateFlow<List<SubscriptionGroup>>,
     private val appMetadata: Map<String, String> = emptyMap(),
@@ -123,6 +124,15 @@ internal class StreamingSyncClient(
      */
     suspend fun triggerCrudUpload() {
         requestedCrudUploads.send(Unit)
+    }
+
+    suspend fun requestCheckpoint(db: PowerSyncDatabaseImpl): CheckpointRequest {
+        if (options.checkpointMode !is CheckpointMode.Requests) {
+            throw CheckpointRequestException.Disabled()
+        }
+
+        val requestId = requestNextCheckpointFromService()
+        return CheckpointRequest(requestId, db)
     }
 
     suspend fun streamingSync() {

--- a/demos/supabase-todolist/README.md
+++ b/demos/supabase-todolist/README.md
@@ -56,6 +56,8 @@ POWERSYNC_URL=https://foo.powersync.journeyapps.com
 # Enter your Supabase project's URL and public anon key (Project settings > API)
 SUPABASE_URL=https://foo.supabase.co
 SUPABASE_ANON_KEY=foo
+# Whether to use checkpoint requests for explicit sync (https://docs.powersync.com/client-sdks/advanced/checkpoint-requests).
+USE_CHECKPOINT_REQUESTS=false
 ```
 
 ## Run the app

--- a/demos/supabase-todolist/shared/build.gradle.kts
+++ b/demos/supabase-todolist/shared/build.gradle.kts
@@ -1,3 +1,4 @@
+import com.codingfeline.buildkonfig.compiler.FieldSpec.Type.BOOLEAN
 import com.codingfeline.buildkonfig.compiler.FieldSpec.Type.STRING
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
@@ -97,6 +98,9 @@ buildkonfig {
         stringConfigField("POWERSYNC_URL")
         stringConfigField("SUPABASE_URL")
         stringConfigField("SUPABASE_ANON_KEY")
+
+        val useCheckpointRequests = localProperties.getProperty("USE_CHECKPOINT_REQUESTS", "false")
+        buildConfigField(BOOLEAN, "USE_CHECKPOINT_REQUESTS", useCheckpointRequests)
         
         // App version from Gradle project version
         buildConfigField(STRING, "APP_VERSION", "\"${project.version}\"")

--- a/demos/supabase-todolist/shared/src/commonMain/composeResources/drawable/refresh.xml
+++ b/demos/supabase-todolist/shared/src/commonMain/composeResources/drawable/refresh.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:fillColor="#000000"
+      android:pathData="M480,800Q346,800 253,707Q160,614 160,480Q160,346 253,253Q346,160 480,160Q549,160 612,188.5Q675,217 720,270L720,160L800,160L800,440L520,440L520,360L688,360Q656,304 600.5,272Q545,240 480,240Q380,240 310,310Q240,380 240,480Q240,580 310,650Q380,720 480,720Q557,720 619,676Q681,632 706,560L790,560Q762,666 676,733Q590,800 480,800Z"/>
+</vector>

--- a/demos/supabase-todolist/shared/src/commonMain/kotlin/com/powersync/demos/Auth.kt
+++ b/demos/supabase-todolist/shared/src/commonMain/kotlin/com/powersync/demos/Auth.kt
@@ -3,9 +3,11 @@ package com.powersync.demos
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import co.touchlab.kermit.Logger
+import com.powersync.ExperimentalCheckpointRequestsApi
 import com.powersync.ExperimentalPowerSyncAPI
 import com.powersync.PowerSyncDatabase
 import com.powersync.connector.supabase.SupabaseConnector
+import com.powersync.sync.CheckpointMode
 import com.powersync.sync.SyncClientConfiguration
 import com.powersync.sync.SyncOptions
 import io.github.jan.supabase.auth.status.RefreshFailureCause
@@ -55,6 +57,12 @@ internal class AuthViewModel(
                                 options =
                                     SyncOptions(
                                         newClientImplementation = true,
+                                        checkpointMode = if (Config.USE_CHECKPOINT_REQUESTS) {
+                                            @OptIn(ExperimentalCheckpointRequestsApi::class)
+                                            CheckpointMode.Requests()
+                                        } else {
+                                            CheckpointMode.Legacy
+                                        },
                                         clientConfiguration =
                                             SyncClientConfiguration.ExtendedConfig {
                                                 install(Logging) {

--- a/demos/supabase-todolist/shared/src/commonMain/kotlin/com/powersync/demos/components/RefreshIcon.kt
+++ b/demos/supabase-todolist/shared/src/commonMain/kotlin/com/powersync/demos/components/RefreshIcon.kt
@@ -1,0 +1,86 @@
+package com.powersync.demos.components
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.SnackbarHostState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
+import com.powersync.ExperimentalCheckpointRequestsApi
+import com.powersync.PowerSyncDatabase
+import com.powersync.compose.composeState
+import com.powersync.demos.Config
+import com.powersync.sync.CheckpointRequest
+import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.painterResource
+import org.koin.compose.koinInject
+import powersync_root.demos.supabase_todolist.shared.generated.resources.Res
+import powersync_root.demos.supabase_todolist.shared.generated.resources.refresh
+import kotlin.coroutines.cancellation.CancellationException
+
+/**
+ * A refresh button requesting an explicit sync (via [PowerSyncDatabase.requestCheckpoint]) when
+ * pressed.
+ */
+@OptIn(ExperimentalCheckpointRequestsApi::class)
+@Composable
+fun RefreshIcon(
+    snackBarHostState: SnackbarHostState,
+    modifier: Modifier = Modifier,
+    database: PowerSyncDatabase = koinInject(),
+) {
+    if (!Config.USE_CHECKPOINT_REQUESTS) return
+
+    val scope = rememberCoroutineScope()
+    val syncStatus by database.currentStatus.composeState()
+    var checkpointRequest by remember { mutableStateOf<CheckpointRequest?>(null) }
+    val isSyncing = syncStatus.downloading || checkpointRequest != null
+
+    fun explicitSync() {
+        scope.launch {
+            val message = try {
+                val request = database.requestCheckpoint()
+                checkpointRequest = request
+                request.waitForSync()
+                "Sync request complete!"
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
+
+                println("Checkpoint request failed: $e")
+                "Sync request failed"
+            } finally {
+                checkpointRequest = null
+            }
+
+            snackBarHostState.showSnackbar(message)
+        }
+    }
+
+    val rotation by rememberInfiniteTransition().animateFloat(
+        initialValue = 0f,
+        targetValue = 360f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 1000, easing = LinearEasing),
+            repeatMode = RepeatMode.Restart,
+        ),
+    )
+
+    IconButton(::explicitSync, modifier, enabled = !isSyncing) {
+        Icon(
+            painter = painterResource(Res.drawable.refresh),
+            contentDescription = "Request explicit sync",
+            modifier = Modifier.rotate(if (isSyncing) rotation else 0f),
+        )
+    }
+}

--- a/demos/supabase-todolist/shared/src/commonMain/kotlin/com/powersync/demos/screens/HomeScreen.kt
+++ b/demos/supabase-todolist/shared/src/commonMain/kotlin/com/powersync/demos/screens/HomeScreen.kt
@@ -66,14 +66,14 @@ internal fun HomeScreen(
                 },
             )
         },
-        content = {
+        content = { padding ->
             // This assumes that the buckets for lists has a priority of 1 (but it will work fine with
             // sync rules not defining any priorities at all too). When giving lists a higher priority
             // than items, we can have a consistent snapshot of lists without items. In the case where
             // many items exist (that might take longer to sync initially), this allows us to display
             // lists earlier.
             GuardBySync(priority = StreamPriority(1)) {
-                Column {
+                Column(modifier = Modifier.padding(padding)) {
                     Input(
                         text = inputText,
                         onAddClicked = onAddItemClicked,

--- a/demos/supabase-todolist/shared/src/commonMain/kotlin/com/powersync/demos/screens/HomeScreen.kt
+++ b/demos/supabase-todolist/shared/src/commonMain/kotlin/com/powersync/demos/screens/HomeScreen.kt
@@ -6,9 +6,14 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Snackbar
+import androidx.compose.material.SnackbarHost
+import androidx.compose.material.SnackbarHostState
 import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -18,6 +23,7 @@ import com.powersync.demos.components.GuardBySync
 import com.powersync.demos.components.Input
 import com.powersync.demos.components.ListContent
 import com.powersync.demos.components.Menu
+import com.powersync.demos.components.RefreshIcon
 import com.powersync.demos.components.WifiIcon
 import com.powersync.demos.powersync.ListItem
 import com.powersync.sync.SyncStatusData
@@ -34,47 +40,67 @@ internal fun HomeScreen(
     onAddItemClicked: () -> Unit,
     onInputTextChanged: (value: String) -> Unit,
 ) {
-    Column(modifier) {
-        TopAppBar(
-            title = {
-                Text(
-                    "Todo Lists",
-                    textAlign = TextAlign.Center,
-                    modifier = Modifier.fillMaxWidth().padding(end = 36.dp),
-                )
-            },
-            navigationIcon = {
-                Menu(
-                    true,
-                    onSignOutSelected,
-                )
-            },
-            actions = {
-                WifiIcon(syncStatus)
-                Spacer(modifier = Modifier.width(16.dp))
-            },
-        )
+    val snackbarHostState = remember { SnackbarHostState() }
 
-        // This assumes that the buckets for lists has a priority of 1 (but it will work fine with
-        // sync rules not defining any priorities at all too). When giving lists a higher priority
-        // than items, we can have a consistent snapshot of lists without items. In the case where
-        // many items exist (that might take longer to sync initially), this allows us to display
-        // lists earlier.
-        GuardBySync(priority = StreamPriority(1)) {
-            Input(
-                text = inputText,
-                onAddClicked = onAddItemClicked,
-                onTextChanged = onInputTextChanged,
-                screen = Screen.Home,
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        "Todo Lists",
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier.fillMaxWidth().padding(end = 36.dp),
+                    )
+                },
+                navigationIcon = {
+                    Menu(
+                        true,
+                        onSignOutSelected,
+                    )
+                },
+                actions = {
+                    RefreshIcon(snackbarHostState)
+                    WifiIcon(syncStatus)
+                    Spacer(modifier = Modifier.width(16.dp))
+                },
             )
+        },
+        content = {
+            // This assumes that the buckets for lists has a priority of 1 (but it will work fine with
+            // sync rules not defining any priorities at all too). When giving lists a higher priority
+            // than items, we can have a consistent snapshot of lists without items. In the case where
+            // many items exist (that might take longer to sync initially), this allows us to display
+            // lists earlier.
+            GuardBySync(priority = StreamPriority(1)) {
+                Column {
+                    Input(
+                        text = inputText,
+                        onAddClicked = onAddItemClicked,
+                        onTextChanged = onInputTextChanged,
+                        screen = Screen.Home,
+                    )
 
-            Box(Modifier.weight(1F)) {
-                ListContent(
-                    items = items,
-                    onItemClicked = onItemClicked,
-                    onItemDeleteClicked = onItemDeleteClicked,
-                )
+                    Box(Modifier.weight(1F)) {
+                        ListContent(
+                            items = items,
+                            onItemClicked = onItemClicked,
+                            onItemDeleteClicked = onItemDeleteClicked,
+                        )
+                    }
+                }
             }
+        },
+        snackbarHost = {
+            SnackbarHost(
+                hostState = snackbarHostState,
+                modifier = Modifier.padding(16.dp),
+                snackbar = { data ->
+                    Snackbar {
+                        Text(data.message)
+                    }
+                }
+            )
         }
-    }
+    )
 }


### PR DESCRIPTION
This adds the `PowerSyncDatabase.requestCheckpoint()` method returning a `CheckpointRequest` instance which can be used to await an explicit checkpoint request. The API matches the existing Swift and JavaScript implementations. Tests are [ported from JavaScript](https://github.com/powersync-ja/powersync-js/blob/a875d48b8e99e0ce9999d3f8b305e56d2f554475/packages/node/tests/sync.test.ts#L218-L293).

As a simple demonstration, the multiplatform supabase todolist demo now has a refresh button in the app bar. Pressing it refreshes a checkpoint and waits for that to sync:

https://github.com/user-attachments/assets/8c476c83-fd02-4378-b5ff-732043bdbebd

AI use: I used Claude Code to update the demo and to review these changes.