### PR TITLE
Fix CRUD uploads with R8 enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.15.1
+
+- Fix broken CRUD upload when R8 is enabled ([#377](https://github.com/powersync-ja/powersync-kotlin/issues/377)).
+
 ## 1.15.0
 
 - Update Kotlin to 2.4.10.

--- a/common/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
+++ b/common/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
@@ -229,7 +229,7 @@ internal class PowerSyncDatabaseImpl(
                 launch {
                     internalDb
                         .updatesOnTables()
-                        .filter { it.contains(InternalTable.CRUD.toString()) }
+                        .filter { it.contains(InternalTable.CRUD) }
                         .collect { stream.triggerCrudUpload() }
                 }
 

--- a/common/src/commonMain/kotlin/com/powersync/db/internal/InternalTable.kt
+++ b/common/src/commonMain/kotlin/com/powersync/db/internal/InternalTable.kt
@@ -1,14 +1,5 @@
 package com.powersync.db.internal
 
-internal enum class InternalTable(
-    private val tableName: String,
-) {
-    DATA("ps_data"),
-    CRUD("ps_crud"),
-    BUCKETS("ps_buckets"),
-    OPLOG("ps_oplog"),
-    UNTYPED("ps_untyped"),
-    ;
-
-    override fun toString(): String = tableName
+internal object InternalTable {
+    const val CRUD = "ps_crud"
 }

--- a/demos/supabase-todolist/androidApp/build.gradle.kts
+++ b/demos/supabase-todolist/androidApp/build.gradle.kts
@@ -23,6 +23,16 @@ android {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
+    buildTypes {
+        release {
+            signingConfig = signingConfigs.getByName("debug")
+            isMinifyEnabled = true
+            isShrinkResources = true
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+            )
+        }
+    }
 }
 
 kotlin {

--- a/demos/supabase-todolist/shared/src/commonMain/kotlin/com/powersync/demos/powersync/Todo.kt
+++ b/demos/supabase-todolist/shared/src/commonMain/kotlin/com/powersync/demos/powersync/Todo.kt
@@ -81,7 +81,7 @@ internal class Todo(
         viewModelScope.launch {
             db.writeTransactionAsync { tx ->
                 tx.executeAsync(
-                    "INSERT INTO $TODOS_TABLE (id, created_at, created_by, description, list_id) VALUES (uuid(), datetime(), ?, ?, ?)",
+                    "INSERT INTO $TODOS_TABLE (id, created_at, created_by, description, list_id, completed) VALUES (uuid(), datetime(), ?, ?, ?, false)",
                     listOf(userId, _inputText.value, listId)
                 )
             }

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ development=true
 RELEASE_SIGNING_ENABLED=true
 # Library config
 GROUP=com.powersync
-LIBRARY_VERSION=1.15.0
+LIBRARY_VERSION=1.15.1
 GITHUB_REPO=https://github.com/powersync-ja/powersync-kotlin.git
 # POM
 POM_URL=https://github.com/powersync-ja/powersync-kotlin/


### PR DESCRIPTION
This removes the `InternalTable` enum to avoid an R8 miscompilation where the `toString()` implementation might be removed (?), causing us to listen to the wrong table for crud uploads.

Instead of using an enum (from which most members weren't even used), this replaces `InternalTable` with an object exposing `CRUD` as a string constant.

I have tested this in a release build of the demo app.

Closes https://github.com/powersync-ja/powersync-kotlin/issues/377.