### PR TITLE
Backend connector split

### DIFF
--- a/common/src/commonIntegrationTest/kotlin/com/powersync/sync/CheckpointRequestTest.kt
+++ b/common/src/commonIntegrationTest/kotlin/com/powersync/sync/CheckpointRequestTest.kt
@@ -304,8 +304,8 @@ class CheckpointRequestTest : AbstractSyncTest() {
 
 private fun PowerSyncBackendConnector.withCustomRequests(
     postRequest: suspend (String, Long) -> Long = { _, req -> req },
-): CustomCheckpointRequestConnector =
-    object : CustomCheckpointRequestConnector() {
+): PowerSyncBackendConnector =
+    object : PowerSyncBackendConnector(), CustomCheckpointRequestConnector {
         override suspend fun postCheckpointRequest(
             clientId: String,
             requestId: Long,

--- a/common/src/commonIntegrationTest/kotlin/com/powersync/sync/SyncIntegrationTest.kt
+++ b/common/src/commonIntegrationTest/kotlin/com/powersync/sync/SyncIntegrationTest.kt
@@ -9,6 +9,7 @@ import com.powersync.PowerSyncException
 import com.powersync.bucket.StreamPriority
 import com.powersync.bucket.WriteCheckpointData
 import com.powersync.bucket.WriteCheckpointResponse
+import com.powersync.connectors.Authenticator
 import com.powersync.connectors.PowerSyncBackendConnector
 import com.powersync.connectors.PowerSyncCredentials
 import com.powersync.connectors.readCachedCredentials
@@ -60,6 +61,7 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.fail
 import kotlin.time.Clock
+import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.measureTime
 
@@ -1208,4 +1210,89 @@ class SyncIntegrationTest : AbstractSyncTest() {
                 true
             }
         }
+
+    @Test
+    fun connectDownloadOnly() =
+        databaseTest {
+            val didUpload = CompletableDeferred<Unit>()
+            database.connect(
+                endpoint = "https://powersynctest.example.com",
+                authenticator = TestAuthenticator,
+                options = getOptions(),
+            )
+
+            turbineScope(timeout = 10.0.seconds) {
+                val turbine = database.currentStatus.asFlow().testIn(this)
+                turbine.waitFor { it.connected }
+                turbine.cancel()
+            }
+
+            // Create a local mutation, which is never uploaded
+            database.execute("INSERT INTO users (id, name) VALUES (uuid(), ?)", listOf("local mutation"))
+            delay(1.hours)
+
+            // Upgrade to a full connection, which should upload
+            database.connect(
+                endpoint = "https://powersynctest.example.com",
+                authenticator = TestAuthenticator,
+                uploader = { db ->
+                    val batch = db.getNextCrudTransaction() ?: return@connect
+                    didUpload.complete(Unit)
+                    batch.complete(null)
+                },
+                options = getOptions(),
+            )
+            didUpload.join()
+        }
+
+    @OptIn(ExperimentalPowerSyncAPI::class)
+    @Test
+    fun connectUploadOnly() =
+        databaseTest {
+            val didUpload = CompletableDeferred<Unit>()
+            val didRequestCheckpoint = CompletableDeferred<Unit>()
+            val assertNoHttpEngine =
+                MockEngine { request ->
+                    error("Unexpected HTTP request: $request")
+                }
+            checkpointResponse = {
+                didRequestCheckpoint.complete(Unit)
+                WriteCheckpointResponse(WriteCheckpointData(1))
+            }
+
+            // Connecting in upload-only mode should make no SDK-initiated HTTP requests.
+            database.connect(
+                endpoint = "https://powersynctest.example.com",
+                uploader = { db ->
+                    val batch = db.getNextCrudTransaction() ?: return@connect
+                    didUpload.complete(Unit)
+                    batch.complete(null)
+                },
+                options =
+                    SyncOptions(
+                        clientConfiguration =
+                            SyncClientConfiguration.ExistingClient(
+                                HttpClient(assertNoHttpEngine) { configureSyncHttpClient() },
+                            ),
+                    ),
+            )
+
+            database.execute("INSERT INTO users (id, name) VALUES (uuid(), ?)", listOf("local mutation"))
+            didUpload.join()
+
+            // Reconnect in download-only mode. This should request a write checkpoint because the
+            // upload-only mode can't.
+            database.connect(
+                endpoint = "https://powersynctest.example.com",
+                authenticator = TestAuthenticator,
+                options = getOptions(),
+            )
+            didRequestCheckpoint.join()
+        }
+}
+
+private object TestAuthenticator : Authenticator {
+    override suspend fun resolveCredentials(): String = "test token"
+
+    override fun invalidateCredentials() {}
 }

--- a/common/src/commonMain/kotlin/com/powersync/PowerSyncDatabase.kt
+++ b/common/src/commonMain/kotlin/com/powersync/PowerSyncDatabase.kt
@@ -120,9 +120,10 @@ public interface PowerSyncDatabase : Queries {
     )
 
     public suspend fun connect(
+        endpoint: String,
         authenticator: Authenticator? = null,
         uploader: MutationUploader? = null,
-        options: SyncOptions = SyncOptions()
+        options: SyncOptions = SyncOptions(),
     )
 
     /**

--- a/common/src/commonMain/kotlin/com/powersync/PowerSyncDatabase.kt
+++ b/common/src/commonMain/kotlin/com/powersync/PowerSyncDatabase.kt
@@ -2,6 +2,8 @@ package com.powersync
 
 import co.touchlab.kermit.Logger
 import com.powersync.bucket.StreamPriority
+import com.powersync.connectors.Authenticator
+import com.powersync.connectors.MutationUploader
 import com.powersync.connectors.PowerSyncBackendConnector
 import com.powersync.db.ActiveDatabaseGroup
 import com.powersync.db.ActiveDatabaseResource
@@ -115,6 +117,12 @@ public interface PowerSyncDatabase : Queries {
         params: Map<String, JsonParam?> = emptyMap(),
         options: SyncOptions = SyncOptions(),
         appMetadata: Map<String, String> = emptyMap(),
+    )
+
+    public suspend fun connect(
+        authenticator: Authenticator? = null,
+        uploader: MutationUploader? = null,
+        options: SyncOptions = SyncOptions()
     )
 
     /**

--- a/common/src/commonMain/kotlin/com/powersync/connectors/PowerSyncBackendConnector.kt
+++ b/common/src/commonMain/kotlin/com/powersync/connectors/PowerSyncBackendConnector.kt
@@ -44,7 +44,9 @@ public fun interface MutationUploader {
  * 1. Creating credentials for connecting to the PowerSync service.
  * 2. Applying local changes against the backend application server.
  */
-public abstract class PowerSyncBackendConnector: Authenticator, MutationUploader {
+public abstract class PowerSyncBackendConnector :
+    Authenticator,
+    MutationUploader {
     internal var cachedCredentials: PowerSyncCredentials? = null
     private var fetchingCredentials = Mutex()
 
@@ -153,6 +155,10 @@ public abstract class PowerSyncBackendConnector: Authenticator, MutationUploader
      * Any thrown errors will result in a retry after the configured wait period (default: 5 seconds).
      */
     public abstract suspend fun uploadData(database: PowerSyncDatabase)
+
+    override suspend fun uploadMutations(onDatabase: PowerSyncDatabase) {
+        uploadData(onDatabase)
+    }
 }
 
 /**

--- a/common/src/commonMain/kotlin/com/powersync/connectors/PowerSyncBackendConnector.kt
+++ b/common/src/commonMain/kotlin/com/powersync/connectors/PowerSyncBackendConnector.kt
@@ -1,9 +1,7 @@
 package com.powersync.connectors
 
 import com.powersync.ExperimentalCheckpointRequestsApi
-import com.powersync.ExperimentalPowerSyncAPI
 import com.powersync.PowerSyncDatabase
-import com.powersync.PowerSyncException
 import com.powersync.db.runWrapped
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -12,7 +10,32 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlin.coroutines.cancellation.CancellationException
+
+/**
+ * Authenticates the PowerSync SDK against a PowerSync service, allowing it to download changes.
+ */
+public interface Authenticator {
+    public suspend fun resolveCredentials(): String
+
+    /**
+     * Invoked by the SDK when the PowerSync service has rejected credentials previously returned by
+     * [Authenticator.resolveCredentials].
+     *
+     * If the connector returns cached tokens, it can use this as a hint to refresh its local state.
+     */
+    public fun invalidateCredentials()
+}
+
+/**
+ * Uploads local mutations (from `INSERT`, `UPDATE` and `DELETE` statements against the local
+ * database) to your source database.
+ *
+ * While simple cases might use a protocol like PostgREST to write directly into the database,
+ * a custom backend is commonly used to validate uploaded mutations.
+ */
+public fun interface MutationUploader {
+    public suspend fun uploadMutations(onDatabase: PowerSyncDatabase)
+}
 
 /**
  * Implement this to connect an app backend.
@@ -20,9 +43,8 @@ import kotlin.coroutines.cancellation.CancellationException
  * The connector is responsible for:
  * 1. Creating credentials for connecting to the PowerSync service.
  * 2. Applying local changes against the backend application server.
- *
  */
-public abstract class PowerSyncBackendConnector {
+public abstract class PowerSyncBackendConnector: Authenticator, MutationUploader {
     internal var cachedCredentials: PowerSyncCredentials? = null
     private var fetchingCredentials = Mutex()
 
@@ -60,7 +82,7 @@ public abstract class PowerSyncBackendConnector {
      *
      * This may be called when the current credentials have expired.
      */
-    public open fun invalidateCredentials() {
+    public override fun invalidateCredentials() {
         cachedCredentials = null
     }
 
@@ -118,6 +140,11 @@ public abstract class PowerSyncBackendConnector {
      */
     public abstract suspend fun fetchCredentials(): PowerSyncCredentials?
 
+    override suspend fun resolveCredentials(): String {
+        val credentials = fetchCredentials() ?: error("User is not logged in")
+        return credentials.token
+    }
+
     /**
      * Upload local changes to the app backend.
      *
@@ -142,7 +169,7 @@ public abstract class PowerSyncBackendConnector {
  * this requires PowerSync service version 1.24.0 or later.
  */
 @ExperimentalCheckpointRequestsApi
-public abstract class CustomCheckpointRequestConnector : PowerSyncBackendConnector() {
+public interface CustomCheckpointRequestConnector : MutationUploader {
     /**
      * Posts a client-generated checkpoint request to the backend and returns the effective
      * checkpoint request state.
@@ -150,7 +177,7 @@ public abstract class CustomCheckpointRequestConnector : PowerSyncBackendConnect
      * @param clientId The PowerSync client ID for the current device.
      * @param requestId The client-generated checkpoint request ID.
      */
-    public abstract suspend fun postCheckpointRequest(
+    public suspend fun postCheckpointRequest(
         clientId: String,
         requestId: Long,
     ): Long

--- a/common/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
+++ b/common/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
@@ -181,13 +181,6 @@ internal class PowerSyncDatabaseImpl(
             disconnectInternal()
 
             connectInternal {
-                @OptIn(ExperimentalCheckpointRequestsApi::class)
-                if (connector is CustomCheckpointRequestConnector && options.checkpointMode == CheckpointMode.Legacy) {
-                    logger.w {
-                        "A CustomCheckpointRequestConnector was used with legacy checkpoints, postCheckpointRequest will not get called"
-                    }
-                }
-
                 StreamingSyncClient(
                     status = currentStatus,
                     database = this,
@@ -203,11 +196,33 @@ internal class PowerSyncDatabaseImpl(
     }
 
     override suspend fun connect(
+        endpoint: String,
         authenticator: Authenticator?,
         uploader: MutationUploader?,
-        options: SyncOptions
+        options: SyncOptions,
     ) {
-        TODO("Not yet implemented")
+        check(authenticator != null || uploader != null) {
+            "Calling connect() and specifying neither an authenticator or uploader doesn't do anything"
+        }
+
+        waitReady()
+        mutex.withLock {
+            disconnectInternal()
+
+            connectInternal {
+                StreamingSyncClient(
+                    status = currentStatus,
+                    database = this,
+                    authenticator,
+                    uploader,
+                    powerSyncUrl = endpoint,
+                    logger,
+                    options,
+                    schema = schema,
+                    activeSubscriptions = streams.currentlyReferencedStreams,
+                )
+            }
+        }
     }
 
     private fun connectInternal(createStream: () -> StreamingSyncClient) {

--- a/common/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
+++ b/common/src/commonMain/kotlin/com/powersync/db/PowerSyncDatabaseImpl.kt
@@ -8,7 +8,9 @@ import com.powersync.PowerSyncException
 import com.powersync.bucket.BucketStorage
 import com.powersync.bucket.StreamPriority
 import com.powersync.bucket.targetCheckpointRequestId
+import com.powersync.connectors.Authenticator
 import com.powersync.connectors.CustomCheckpointRequestConnector
+import com.powersync.connectors.MutationUploader
 import com.powersync.connectors.PowerSyncBackendConnector
 import com.powersync.db.crud.CrudBatch
 import com.powersync.db.crud.CrudEntry
@@ -189,7 +191,8 @@ internal class PowerSyncDatabaseImpl(
                 StreamingSyncClient(
                     status = currentStatus,
                     database = this,
-                    connector = connector,
+                    authenticator = connector,
+                    uploader = connector,
                     logger = logger,
                     options = options,
                     schema = schema,
@@ -197,6 +200,14 @@ internal class PowerSyncDatabaseImpl(
                 )
             }
         }
+    }
+
+    override suspend fun connect(
+        authenticator: Authenticator?,
+        uploader: MutationUploader?,
+        options: SyncOptions
+    ) {
+        TODO("Not yet implemented")
     }
 
     private fun connectInternal(createStream: () -> StreamingSyncClient) {

--- a/common/src/commonMain/kotlin/com/powersync/sync/StreamingSyncClient.kt
+++ b/common/src/commonMain/kotlin/com/powersync/sync/StreamingSyncClient.kt
@@ -152,7 +152,16 @@ internal class StreamingSyncClient(
                     launch { repostUnacknowledgedCheckpointRequests() }
                 }
 
-                uploader?.let { crudUploadLoop(it) }
+                uploader.let { uploader ->
+                    if (uploader != null) {
+                        launch { crudUploadLoop(uploader) }
+                    } else if (authenticator != null) {
+                        // We can't upload mutations, but we can request a checkpoint for mutations
+                        // that have already been uploaded from a potential prior upload-only
+                        // connection.
+                        launch { updateLocalTarget() }
+                    }
+                }
             }
         } finally {
             checkpointSignals.disconnected()
@@ -251,11 +260,8 @@ internal class StreamingSyncClient(
                     uploader.uploadMutations(database)
                 } else {
                     // Uploading is completed
-                    bucketStorage.updateLocalTarget {
-                        when (options.checkpointMode) {
-                            CheckpointMode.Legacy -> getLegacyWriteCheckpoint()
-                            is CheckpointMode.Requests -> requestNextCheckpointFromService()
-                        }
+                    if (authenticator != null) {
+                        updateLocalTarget()
                     }
                     status.update { copy(uploading = false, uploadError = null) }
                     break
@@ -273,6 +279,15 @@ internal class StreamingSyncClient(
             }
         }
         status.update { copy(uploading = false) }
+    }
+
+    suspend fun updateLocalTarget() {
+        bucketStorage.updateLocalTarget {
+            when (options.checkpointMode) {
+                CheckpointMode.Legacy -> getLegacyWriteCheckpoint()
+                is CheckpointMode.Requests -> requestNextCheckpointFromService()
+            }
+        }
     }
 
     private suspend fun requestNextCheckpointFromService(): Long {

--- a/common/src/commonMain/kotlin/com/powersync/sync/StreamingSyncClient.kt
+++ b/common/src/commonMain/kotlin/com/powersync/sync/StreamingSyncClient.kt
@@ -10,8 +10,11 @@ import com.powersync.bucket.CheckpointRequestPayload
 import com.powersync.bucket.CheckpointRequestResponse
 import com.powersync.bucket.PowerSyncControlArguments
 import com.powersync.bucket.WriteCheckpointResponse
+import com.powersync.connectors.Authenticator
 import com.powersync.connectors.CustomCheckpointRequestConnector
+import com.powersync.connectors.MutationUploader
 import com.powersync.connectors.PowerSyncBackendConnector
+import com.powersync.connectors.PowerSyncCredentials
 import com.powersync.db.PowerSyncDatabaseImpl
 import com.powersync.db.SubscriptionGroup
 import com.powersync.db.crud.CrudEntry
@@ -65,16 +68,15 @@ import kotlinx.io.EOFException
 import kotlinx.io.readByteArray
 import kotlinx.io.readIntLe
 import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonObject
 import kotlin.coroutines.cancellation.CancellationException
-import kotlin.time.Duration
-import kotlin.time.Duration.Companion.seconds
 
 @OptIn(ExperimentalPowerSyncAPI::class, ExperimentalCheckpointRequestsApi::class)
 internal class StreamingSyncClient(
     private val status: SyncStatus,
     private val database: PowerSyncDatabaseImpl,
-    private val connector: PowerSyncBackendConnector,
+    private val authenticator: Authenticator,
+    private var uploader: MutationUploader,
+    private val powerSyncUrl: String? = null,
     private val logger: Logger,
     val options: SyncOptions,
     private val schema: Schema,
@@ -88,6 +90,12 @@ internal class StreamingSyncClient(
     private val checkpointSignals = CheckpointStateSignals()
 
     private var clientId: String? = null
+
+    init {
+        if (powerSyncUrl == null && authenticator !is PowerSyncBackendConnector) {
+            error("When connecting aith an Authenticator, a PowerSync URL needs to be set")
+        }
+    }
 
     private val httpClient: HttpClient =
         when (val config = options.clientConfiguration) {
@@ -104,7 +112,7 @@ internal class StreamingSyncClient(
         }
 
     fun invalidateCredentials() {
-        connector.invalidateCredentials()
+        authenticator.invalidateCredentials()
     }
 
     private suspend fun loadClientId(): String {
@@ -157,7 +165,7 @@ internal class StreamingSyncClient(
                 if (invalidCredentials) {
                     // This may error. In that case it will be retried again on the next
                     // iteration.
-                    connector.invalidateCredentials()
+                    authenticator.invalidateCredentials()
                     invalidCredentials = false
                 }
                 result = ActiveIteration().syncIteration()
@@ -167,7 +175,7 @@ internal class StreamingSyncClient(
                 if (e.indicatesInvalidCredentials()) {
                     // The server rejected the RSocket SETUP frame, most likely due to an invalid
                     // token. Invalidate credentials so a fresh token is fetched on the next attempt.
-                    connector.invalidateCredentials()
+                    authenticator.invalidateCredentials()
                 }
                 logger.e("Error in streamingSync: ${e.message}")
                 status.update { copy(downloadError = e) }
@@ -179,7 +187,7 @@ internal class StreamingSyncClient(
                 if (e is RSocketCredentialsExpiredException) {
                     // Auth error (PSYNC_S21xx) delivered via the RSocket transport-layer failure
                     // path. Invalidate credentials so a fresh token is fetched on the next attempt.
-                    connector.invalidateCredentials()
+                    authenticator.invalidateCredentials()
                 }
 
                 logger.e("Error in streamingSync: ${e.message}")
@@ -235,7 +243,7 @@ internal class StreamingSyncClient(
 
                     checkedCrudItem = nextCrudItem
                     status.update { copy(uploading = true) }
-                    connector.uploadData(database)
+                    uploader.uploadMutations(database)
                 } else {
                     // Uploading is completed
                     bucketStorage.updateLocalTarget {
@@ -274,13 +282,34 @@ internal class StreamingSyncClient(
         )
     }
 
+    private suspend fun prefetchCredentials() {
+        if (authenticator is PowerSyncBackendConnector) {
+            authenticator.updateCredentials()
+        } else {
+            authenticator.invalidateCredentials()
+            authenticator.resolveCredentials()
+        }
+    }
+
+    private suspend fun resolveCredentials(): PowerSyncCredentials {
+        return if (authenticator is PowerSyncBackendConnector) {
+            requireNotNull(authenticator.getCredentialsCached()) {
+                "Not logged in"
+            }
+        } else {
+            PowerSyncCredentials(
+                endpoint = powerSyncUrl!!,
+                token = authenticator.resolveCredentials(),
+            )
+        }
+    }
+
     private suspend fun authenticatedRequest(
         path: String,
         method: HttpMethod = HttpMethod.Get,
         configure: HttpRequestBuilder.() -> Unit = {},
     ): HttpResponse {
-        val credentials = connector.getCredentialsCached()
-        require(credentials != null) { "Not logged in" }
+        val credentials = resolveCredentials()
         val uri = credentials.endpointUri(path)
 
         val response =
@@ -294,7 +323,7 @@ internal class StreamingSyncClient(
             }
 
         if (response.status.value == 401) {
-            connector.invalidateCredentials()
+            authenticator.invalidateCredentials()
         }
 
         return response
@@ -302,7 +331,7 @@ internal class StreamingSyncClient(
 
     private suspend fun requestCheckpointFromService(payload: CheckpointRequestPayload): Long {
         // First, check if we can use a custom checkpoint request implementation.
-        (connector as? CustomCheckpointRequestConnector)?.let {
+        (uploader as? CustomCheckpointRequestConnector)?.let {
             return it.postCheckpointRequest(payload.clientId, payload.checkpointRequestId)
         }
 
@@ -340,9 +369,7 @@ internal class StreamingSyncClient(
     ): Flow<T> {
         val originalFlow =
             channelFlow<T> {
-                val credentials = connector.getCredentialsCached()
-                require(credentials != null) { "Not logged in" }
-
+                val credentials = resolveCredentials()
                 val uri = credentials.endpointUri("sync/stream")
 
                 val bodyJson = JsonUtil.json.encodeToString(req)
@@ -367,7 +394,7 @@ internal class StreamingSyncClient(
                     val isBson = httpResponse.contentType() == bsonStream
 
                     if (httpResponse.status.value == 401) {
-                        connector.invalidateCredentials()
+                        authenticator.invalidateCredentials()
                     }
 
                     if (httpResponse.status != HttpStatusCode.OK) {
@@ -407,8 +434,7 @@ internal class StreamingSyncClient(
         } else {
             // Use RSocket as a fallback to ensure we have backpressure on platforms that don't support it natively.
             flow {
-                val credentials =
-                    requireNotNull(connector.getCredentialsCached()) { "Not logged in" }
+                val credentials = resolveCredentials()
 
                 emitAll(
                     httpClient.rSocketSyncStream(
@@ -640,7 +666,7 @@ internal class StreamingSyncClient(
                 launch(CoroutineName("Prefetch credentials")) {
                     needsCredentialsRefresh.consumeEach {
                         try {
-                            connector.updateCredentials()
+                            prefetchCredentials()
 
                             logger.v { "Stopping because new credentials are available" }
                             // Token has been refreshed, start another iteration
@@ -697,7 +723,7 @@ internal class StreamingSyncClient(
 
                 is Instruction.FetchCredentials -> {
                     if (instruction.didExpire) {
-                        connector.invalidateCredentials()
+                        authenticator.invalidateCredentials()
                     } else {
                         // Token expires soon - refresh it in the background
                         needsCredentialsRefresh.send(Unit)

--- a/common/src/commonMain/kotlin/com/powersync/sync/StreamingSyncClient.kt
+++ b/common/src/commonMain/kotlin/com/powersync/sync/StreamingSyncClient.kt
@@ -74,8 +74,8 @@ import kotlin.coroutines.cancellation.CancellationException
 internal class StreamingSyncClient(
     private val status: SyncStatus,
     private val database: PowerSyncDatabaseImpl,
-    private val authenticator: Authenticator,
-    private var uploader: MutationUploader,
+    private val authenticator: Authenticator?,
+    private var uploader: MutationUploader?,
     private val powerSyncUrl: String? = null,
     private val logger: Logger,
     val options: SyncOptions,
@@ -92,8 +92,10 @@ internal class StreamingSyncClient(
     private var clientId: String? = null
 
     init {
-        if (powerSyncUrl == null && authenticator !is PowerSyncBackendConnector) {
-            error("When connecting aith an Authenticator, a PowerSync URL needs to be set")
+        if (uploader is CustomCheckpointRequestConnector && options.checkpointMode == CheckpointMode.Legacy) {
+            logger.w {
+                "A CustomCheckpointRequestConnector was used with legacy checkpoints, postCheckpointRequest will not get called"
+            }
         }
     }
 
@@ -112,7 +114,7 @@ internal class StreamingSyncClient(
         }
 
     fun invalidateCredentials() {
-        authenticator.invalidateCredentials()
+        authenticator?.invalidateCredentials()
     }
 
     private suspend fun loadClientId(): String {
@@ -145,16 +147,19 @@ internal class StreamingSyncClient(
     suspend fun streamingSync() {
         try {
             coroutineScope {
-                launch { downloadLoop() }
-                launch { crudUploadLoop() }
-                launch { repostUnacknowledgedCheckpointRequests() }
+                authenticator?.let {
+                    launch { downloadLoop(it) }
+                    launch { repostUnacknowledgedCheckpointRequests() }
+                }
+
+                uploader?.let { crudUploadLoop(it) }
             }
         } finally {
             checkpointSignals.disconnected()
         }
     }
 
-    private suspend fun downloadLoop() {
+    private suspend fun downloadLoop(authenticator: Authenticator) {
         var invalidCredentials = false
         loadClientId()
 
@@ -168,7 +173,7 @@ internal class StreamingSyncClient(
                     authenticator.invalidateCredentials()
                     invalidCredentials = false
                 }
-                result = ActiveIteration().syncIteration()
+                result = ActiveIteration(authenticator).syncIteration()
             } catch (e: PowerSyncRSocketError) {
                 // RSocketError extends Throwable directly (not Exception), so it needs its own
                 // catch block to avoid accidentally catching JVM Errors (OutOfMemoryError, etc.).
@@ -204,14 +209,14 @@ internal class StreamingSyncClient(
         }
     }
 
-    private suspend fun crudUploadLoop() {
+    private suspend fun crudUploadLoop(uploader: MutationUploader) {
         while (true) {
             coroutineScope {
                 // To throttle, ensure we spend at least this much time in the iteration.
                 launch { delay(options.crudThrottle) }
 
                 try {
-                    uploadAllCrud()
+                    uploadAllCrud(uploader)
                 } finally {
                     logger.v { "crud upload: notify completion" }
                     completedCrudUploads.send(Unit)
@@ -222,7 +227,7 @@ internal class StreamingSyncClient(
         }
     }
 
-    private suspend fun uploadAllCrud() {
+    private suspend fun uploadAllCrud(uploader: MutationUploader) {
         var checkedCrudItem: CrudEntry? = null
 
         while (true) {
@@ -282,7 +287,7 @@ internal class StreamingSyncClient(
         )
     }
 
-    private suspend fun prefetchCredentials() {
+    private suspend fun prefetchCredentials(authenticator: Authenticator) {
         if (authenticator is PowerSyncBackendConnector) {
             authenticator.updateCredentials()
         } else {
@@ -292,13 +297,21 @@ internal class StreamingSyncClient(
     }
 
     private suspend fun resolveCredentials(): PowerSyncCredentials {
+        val authenticator =
+            requireNotNull(authenticator) {
+                "Authenticator is required for credentials"
+            }
+
         return if (authenticator is PowerSyncBackendConnector) {
             requireNotNull(authenticator.getCredentialsCached()) {
                 "Not logged in"
             }
         } else {
             PowerSyncCredentials(
-                endpoint = powerSyncUrl!!,
+                endpoint =
+                    requireNotNull(powerSyncUrl) {
+                        "When connecting with an Authenticator, a PowerSync URL needs to be set"
+                    },
                 token = authenticator.resolveCredentials(),
             )
         }
@@ -323,7 +336,7 @@ internal class StreamingSyncClient(
             }
 
         if (response.status.value == 401) {
-            authenticator.invalidateCredentials()
+            invalidateCredentials()
         }
 
         return response
@@ -394,7 +407,7 @@ internal class StreamingSyncClient(
                     val isBson = httpResponse.contentType() == bsonStream
 
                     if (httpResponse.status.value == 401) {
-                        authenticator.invalidateCredentials()
+                        invalidateCredentials()
                     }
 
                     if (httpResponse.status != HttpStatusCode.OK) {
@@ -506,7 +519,9 @@ internal class StreamingSyncClient(
      * This avoids us having to decode sync lines in Kotlin, unlocking the RSocket protocol and
      * improving performance.
      */
-    private inner class ActiveIteration {
+    private inner class ActiveIteration(
+        private val authenticator: Authenticator,
+    ) {
         private val needsCredentialsRefresh = Channel<Unit>(CONFLATED)
 
         suspend fun syncIteration(): SyncIterationResult {
@@ -666,7 +681,7 @@ internal class StreamingSyncClient(
                 launch(CoroutineName("Prefetch credentials")) {
                     needsCredentialsRefresh.consumeEach {
                         try {
-                            prefetchCredentials()
+                            prefetchCredentials(authenticator)
 
                             logger.v { "Stopping because new credentials are available" }
                             // Token has been refreshed, start another iteration

--- a/common/src/commonMain/kotlin/com/powersync/sync/SyncOptions.kt
+++ b/common/src/commonMain/kotlin/com/powersync/sync/SyncOptions.kt
@@ -1,13 +1,10 @@
 package com.powersync.sync
 
 import com.powersync.ExperimentalCheckpointRequestsApi
-import com.powersync.ExperimentalPowerSyncAPI
 import com.powersync.PowerSyncDatabase
 import com.powersync.utils.JsonParam
 import io.ktor.client.HttpClient
 import io.ktor.client.HttpClientConfig
-import kotlinx.serialization.json.JsonObject
-import kotlin.native.HiddenFromObjC
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds


### PR DESCRIPTION
This implements a possible approach for the backend connector split (https://github.com/orgs/powersync-ja/discussions/787).

## API changes

(These should not be considered final)

This splits `PowerSyncBackendConnector` into two new interfaces:

1. `Authenticator` (used for downloads), exposing the `resolveCredentials()` and `invalidateCredentials()` methods. The name of `resolveCredentials` reflects that users won't necessarily fetch credentials everytime the method is called. In many cases, users manage the JWT as part of their app state and would simply return that. `invalidateCredentials()` is a hint from the SDK that the JWT has been rejected by the service.
2. `MutationUploader` (used for uploads) exposes `uploadMutations`, called by SDKs to upload `ps_crud` records. This interface can also be implemented as a closure.

A new `connect()` overload takes independent authenticator and uploader instances, which allows implementing these independently and connecting in download or upload-only mode.

The streaming sync implementation skips the download or upload loop if the authenticator or uploader is not set.